### PR TITLE
Regression generators

### DIFF
--- a/river/datasets/synth/__init__.py
+++ b/river/datasets/synth/__init__.py
@@ -9,6 +9,7 @@ from .agrawal import Agrawal
 from .anomaly_sine import AnomalySine
 from .concept_drift_stream import ConceptDriftStream
 from .friedman import Friedman
+from .friedman import FriedmanDrift
 from .hyper_plane import Hyperplane
 from .led import LED
 from .led import LEDDrift
@@ -28,6 +29,7 @@ __all__ = [
     'AnomalySine',
     'ConceptDriftStream',
     'Friedman',
+    'FriedmanDrift',
     'Hyperplane',
     'LED',
     'LEDDrift',

--- a/river/datasets/synth/__init__.py
+++ b/river/datasets/synth/__init__.py
@@ -15,6 +15,7 @@ from .led import LED
 from .led import LEDDrift
 from .logical import Logical
 from .mixed import Mixed
+from .planes_2d import Planes2D
 from .random_rbf import RandomRBF
 from .random_rbf import RandomRBFDrift
 from .random_tree import RandomTree
@@ -35,6 +36,7 @@ __all__ = [
     'LEDDrift',
     'Logical',
     'Mixed',
+    'Planes2D',
     'RandomRBF',
     'RandomRBFDrift',
     'RandomTree',

--- a/river/datasets/synth/__init__.py
+++ b/river/datasets/synth/__init__.py
@@ -15,6 +15,7 @@ from .led import LED
 from .led import LEDDrift
 from .logical import Logical
 from .mixed import Mixed
+from .mv import Mv
 from .planes_2d import Planes2D
 from .random_rbf import RandomRBF
 from .random_rbf import RandomRBFDrift
@@ -36,6 +37,7 @@ __all__ = [
     'LEDDrift',
     'Logical',
     'Mixed',
+    'Mv',
     'Planes2D',
     'RandomRBF',
     'RandomRBFDrift',

--- a/river/datasets/synth/friedman.py
+++ b/river/datasets/synth/friedman.py
@@ -10,7 +10,7 @@ class Friedman(base.SyntheticDataset):
     Each observation is composed of 10 features. Each feature value is sampled uniformly in [0, 1].
     The target is defined by the following function:
 
-    $$y = 10 sin(\\pi x_0 x_1) + 20 (x_2 - .5)^2 + 10 x_3 + 5 x_4 + \\epsilon$$
+    $$y = 10 sin(\\pi x_0 x_1) + 20 (x_2 - 0.5)^2 + 10 x_3 + 5 x_4 + \\epsilon$$
 
     In the last expression, $\\epsilon \\sim \\mathcal{N}(0, 1)$, is the noise. Therefore,
     only the first 5 features are relevant.
@@ -71,14 +71,14 @@ class FriedmanDrift(base.SyntheticDataset):
     ----------
     drift_type
         The variant of concept drift.</br>
-        - 'lea': Local Expanding Abrupt drift. The concept drift appears in two distinct
+        - `'lea'`: Local Expanding Abrupt drift. The concept drift appears in two distinct
         regions of the instance space, while the remaining regions are left unaltered.
         There are three points of abrupt change in the training dataset.
         At every consecutive change the regions of drift are expanded.</br>
-        - 'gra': Global Recurring Abrupt drift. The concept drift appears over the whole
+        - `'gra'`: Global Recurring Abrupt drift. The concept drift appears over the whole
         instance space. There are two points of concept drift. At the second point of drift
         the old concept reoccurs.</br>
-        - 'gsg': Global and Slow Gradual drift. The concept drift affects all the instance
+        - `'gsg'`: Global and Slow Gradual drift. The concept drift affects all the instance
         space. However, the change is gradual and not abrupt. After each one of the two change
         points covered by this variant, and during a window of length `transition_window`,
         examples from both old and the new concepts are generated with equal probability.

--- a/river/datasets/synth/friedman.py
+++ b/river/datasets/synth/friedman.py
@@ -204,7 +204,7 @@ class FriedmanDrift(base.SyntheticDataset):
     def __lea_in_r1(self, x, index):
         if index < self.change_point1:
             return False
-        if self.change_point1 <= index < self.change_point2:
+        elif self.change_point1 <= index < self.change_point2:
             return x[1] < 0.3 and x[2] < 0.3 and x[3] > 0.7 and x[4] < 0.3
         elif self.change_point2 <= index < self.change_point3:
             return x[1] < 0.3 and x[2] < 0.3 and x[3] > 0.7
@@ -214,7 +214,7 @@ class FriedmanDrift(base.SyntheticDataset):
     def __lea_in_r2(self, x, index):
         if index < self.change_point1:
             return False
-        if self.change_point1 <= index < self.change_point2:
+        elif self.change_point1 <= index < self.change_point2:
             return x[1] > 0.7 and x[2] > 0.7 and x[3] < 0.3 and x[4] > 0.7
         elif self.change_point2 <= index < self.change_point3:
             return x[1] > 0.7 and x[2] > 0.7 and x[3] < 0.3

--- a/river/datasets/synth/friedman.py
+++ b/river/datasets/synth/friedman.py
@@ -10,9 +10,10 @@ class Friedman(base.SyntheticDataset):
     Each observation is composed of 10 features. Each feature value is sampled uniformly in [0, 1].
     The target is defined by the following function:
 
-    $$y = 10 sin(\\pi x_0 x_1) + 20 (x_2 - .5)^2 + 10 x_3 + 5 x_4$$
+    $$y = 10 sin(\\pi x_0 x_1) + 20 (x_2 - .5)^2 + 10 x_3 + 5 x_4 + \\epsilon$$
 
-    Therefore, only the first 5 features are relevant.
+    In the last expression, $\\epsilon \\sim \\mathcal{N}(0, 1)$, is the noise. Therefore,
+    only the first 5 features are relevant.
 
     Parameters
     ----------
@@ -28,11 +29,11 @@ class Friedman(base.SyntheticDataset):
 
     >>> for x, y in dataset.take(5):
     ...     print(list(x.values()), y)
-    [0.63, 0.02, 0.27, 0.22, 0.73, 0.67, 0.89, 0.08, 0.42, 0.02] 7.42
-    [0.21, 0.50, 0.02, 0.19, 0.64, 0.54, 0.22, 0.58, 0.80, 0.00] 13.12
-    [0.80, 0.69, 0.34, 0.15, 0.95, 0.33, 0.09, 0.09, 0.84, 0.60] 16.65
-    [0.80, 0.72, 0.53, 0.97, 0.37, 0.55, 0.82, 0.61, 0.86, 0.57] 21.26
-    [0.70, 0.04, 0.22, 0.28, 0.07, 0.23, 0.10, 0.27, 0.63, 0.36] 5.78
+    [0.63, 0.02, 0.27, 0.22, 0.73, 0.67, 0.89, 0.08, 0.42, 0.02] 7.66
+    [0.02, 0.19, 0.64, 0.54, 0.22, 0.58, 0.80, 0.00, 0.80, 0.69] 8.33
+    [0.34, 0.15, 0.95, 0.33, 0.09, 0.09, 0.84, 0.60, 0.80, 0.72] 7.04
+    [0.37, 0.55, 0.82, 0.61, 0.86, 0.57, 0.70, 0.04, 0.22, 0.28] 18.16
+    [0.07, 0.23, 0.10, 0.27, 0.63, 0.36, 0.37, 0.20, 0.26, 0.93] 8.90
 
     References
     ----------
@@ -51,6 +52,230 @@ class Friedman(base.SyntheticDataset):
         while True:
 
             x = {i: rng.uniform(a=0, b=1) for i in range(10)}
-            y = 10 * math.sin(math.pi * x[0] * x[1]) + 20 * (x[2] - .5) ** 2 + 10 * x[3] + 5 * x[4]
+            y = 10 * math.sin(math.pi * x[0] * x[1]) + 20 * (x[2] - .5) ** 2 + 10 * x[3] \
+                + 5 * x[4] + rng.gauss(mu=0, sigma=1)
 
             yield x, y
+
+
+class FriedmanDrift(base.SyntheticDataset):
+    """Friedman synthetic dataset with concept drifts.
+
+    Each observation is composed of 10 features. Each feature value is sampled uniformly in [0, 1].
+    Only the first 5 features are relevant. The target is defined by different functions depending
+    on the type of the drift.
+
+    The three available modes of operation of the data generator are described in [^1].
+
+    Parameters
+    ----------
+    drift_type
+        The variant of concept drift.</br>
+        - 'lea': Local Expanding Abrupt drift. The concept drift appears in two distinct
+        regions of the instance space, while the remaining regions are left unaltered.
+        There are three points of abrupt change in the training dataset.
+        At every consecutive change the regions of drift are expanded.</br>
+        - 'gra': Global Recurring Abrupt drift. The concept drift appears over the whole
+        instance space. There are two points of concept drift. At the second point of drift
+        the old concept reoccurs.</br>
+        - 'gsg': Global and Slow Gradual drift. The concept drift affects all the instance
+        space. However, the change is gradual and not abrupt. After each one of the two change
+        points covered by this variant, and during a window of length `transition_window`,
+        examples from both old and the new concepts are generated with equal probability.
+        After the transition period, only the examples from the new concept are generated.
+    change_point1
+        The amount of monitored instances after which the first drift occurs.
+    change_point2
+        The amount of monitored instances after which the second drift occurs.
+    change_point3
+        The amount of monitored instances after which the third drift occurs. Only used when
+        `drift_type='lea'`.
+    transition_window
+        The length of the transition window between two concepts. Only applicable when
+         `drift_type='gsg'`. If set to zero, the drifts will be abrupt. Anytime
+         `transition_window > 0`, it defines a window in which instances of the new
+         concept are gradually introduced among the examples from the old concept.
+         During this transition phase, both old and new concepts appear with equal probability.
+    seed
+        Random seed number used for reproducibility.
+
+    Examples
+    --------
+    >>> from river import synth
+
+    >>> dataset = synth.FriedmanDrift(
+    ...     drift_type='lea',
+    ...     change_point1=1,
+    ...     change_point2=2,
+    ...     change_point3=3,
+    ...     seed=42
+    ... )
+
+    >>> for x, y in dataset.take(5):
+    ...     print(list(x.values()), y)
+    [0.63, 0.02, 0.27, 0.22, 0.73, 0.67, 0.89, 0.08, 0.42, 0.02] 7.66
+    [0.02, 0.19, 0.64, 0.54, 0.22, 0.58, 0.80, 0.00, 0.80, 0.69] 8.33
+    [0.34, 0.15, 0.95, 0.33, 0.09, 0.09, 0.84, 0.60, 0.80, 0.72] 7.04
+    [0.37, 0.55, 0.82, 0.61, 0.86, 0.57, 0.70, 0.04, 0.22, 0.28] 18.16
+    [0.07, 0.23, 0.10, 0.27, 0.63, 0.36, 0.37, 0.20, 0.26, 0.93] -2.65
+
+    >>> dataset = synth.FriedmanDrift(
+    ...     drift_type='gra',
+    ...     change_point1=2,
+    ...     change_point2=3,
+    ...     seed=42
+    ... )
+
+    >>> for x, y in dataset.take(5):
+    ...     print(list(x.values()), y)
+    [0.63, 0.02, 0.27, 0.22, 0.73, 0.67, 0.89, 0.08, 0.42, 0.02] 7.66
+    [0.02, 0.19, 0.64, 0.54, 0.22, 0.58, 0.80, 0.00, 0.80, 0.69] 8.33
+    [0.34, 0.15, 0.95, 0.33, 0.09, 0.09, 0.84, 0.60, 0.80, 0.72] 8.96
+    [0.37, 0.55, 0.82, 0.61, 0.86, 0.57, 0.70, 0.04, 0.22, 0.28] 18.16
+    [0.07, 0.23, 0.10, 0.27, 0.63, 0.36, 0.37, 0.20, 0.26, 0.93] 8.90
+
+    >>> dataset = synth.FriedmanDrift(
+    ...     drift_type='gsg',
+    ...     change_point1=1,
+    ...     change_point2=4,
+    ...     transition_window=2,
+    ...     seed=42
+    ... )
+
+    >>> for x, y in dataset.take(5):
+    ...     print(list(x.values()), y)
+    [0.63, 0.02, 0.27, 0.22, 0.73, 0.67, 0.89, 0.08, 0.42, 0.02] 7.66
+    [0.02, 0.19, 0.64, 0.54, 0.22, 0.58, 0.80, 0.00, 0.80, 0.69] 8.33
+    [0.34, 0.15, 0.95, 0.33, 0.09, 0.09, 0.84, 0.60, 0.80, 0.72] 8.92
+    [0.37, 0.55, 0.82, 0.61, 0.86, 0.57, 0.70, 0.04, 0.22, 0.28] 17.32
+    [0.07, 0.23, 0.10, 0.27, 0.63, 0.36, 0.37, 0.20, 0.26, 0.93] 6.05
+
+    References
+    ----------
+    [^1]: Ikonomovska, E., Gama, J. and Džeroski, S., 2011. Learning model trees from evolving
+    data streams. Data mining and knowledge discovery, 23(1), pp.128-168.
+
+    """
+    _LOCAL_EXPANDING_ABRUPT = 'lea'
+    _GLOBAL_RECURRING_ABRUPT = 'gra'
+    _GLOBAL_AND_SLOW_GRADUAL = 'gsg'
+
+    _VALID_DRIFT_TYPES = [
+        _LOCAL_EXPANDING_ABRUPT,
+        _GLOBAL_RECURRING_ABRUPT,
+        _GLOBAL_AND_SLOW_GRADUAL
+    ]
+
+    def __init__(self, drift_type: str = 'lea', change_point1: int = 50_000,
+                 change_point2: int = 100_000, change_point3: int = 150_000,
+                 transition_window: int = 10_000, seed: int = None):
+        super().__init__(task=base.REG, n_features=10)
+
+        if drift_type not in self._VALID_DRIFT_TYPES:
+            raise ValueError(f'Invalid "drift_type: {drift_type}"\n'
+                             f'Valid options are: {self._VALID_DRIFT_TYPES}')
+
+        self.drift_type = drift_type
+
+        if not change_point1 < change_point2 < change_point3:
+            raise ValueError(f'"change_point3" must be greater than "change_point2", and'
+                             f'"change_point2 must be greater than "change_point1."')
+
+        if (transition_window > change_point2 - change_point1 or transition_window
+                > change_point3 - change_point2) \
+                and self.drift_type == self._GLOBAL_AND_SLOW_GRADUAL:
+            raise ValueError(
+                f'The chosen "transition_window" value is too big: {transition_window}')
+
+        self.change_point1 = change_point1
+        self.change_point2 = change_point2
+        self.change_point3 = change_point3
+        self.transition_window = transition_window
+
+        self.seed = seed
+
+        if self.drift_type == self._LOCAL_EXPANDING_ABRUPT:
+            self._y_maker = self._local_expanding_abrupt_gen
+        elif self.drift_type == self._GLOBAL_RECURRING_ABRUPT:
+            self._y_maker = self._global_recurring_abrupt_gen
+        else:  # Global and slow gradual drifts
+            self._y_maker = self._global_and_slow_gradual_gen
+
+    def __lea_in_r1(self, x, index):
+        if index < self.change_point1:
+            return False
+        if self.change_point1 <= index < self.change_point2:
+            return x[1] < 0.3 and x[2] < 0.3 and x[3] > 0.7 and x[4] < 0.3
+        elif self.change_point2 <= index < self.change_point3:
+            return x[1] < 0.3 and x[2] < 0.3 and x[3] > 0.7
+        else:
+            return x[1] < 0.3 and x[2] < 0.3
+
+    def __lea_in_r2(self, x, index):
+        if index < self.change_point1:
+            return False
+        if self.change_point1 <= index < self.change_point2:
+            return x[1] > 0.7 and x[2] > 0.7 and x[3] < 0.3 and x[4] > 0.7
+        elif self.change_point2 <= index < self.change_point3:
+            return x[1] > 0.7 and x[2] > 0.7 and x[3] < 0.3
+        else:
+            return x[1] > 0.7 and x[2] > 0.7
+
+    def _local_expanding_abrupt_gen(self, x, index: int, rc: random.Random = None):  # noqa
+        if self.__lea_in_r1(x, index):
+            return 10 * x[0] * x[1] + 20 * (x[2] - .5) + 10 * x[3] + 5 * x[4]
+
+        if self.__lea_in_r2(x, index):
+            return 10 * math.cos(x[0] * x[1]) + 20 * (x[2] - .5) + math.exp(x[3]) + 5 * x[4] ** 2
+
+        # default case
+        return 10 * math.sin(math.pi * x[0] * x[1]) + 20 * (x[2] - .5) ** 2 + 10 * x[3] + 5 * x[4]
+
+    def _global_recurring_abrupt_gen(self, x, index: int, rc: random.Random = None):  # noqa
+        if index < self.change_point1 or index >= self.change_point2:
+            # The initial concept is recurring
+            return 10 * math.sin(math.pi * x[0] * x[1]) + 20 * (x[2] - .5) ** 2 + 10 * x[3] \
+                   + 5 * x[4]
+        else:
+            # Drift: the positions of the features are swapped
+            return 10 * math.sin(math.pi * x[3] * x[5]) + 20 * (x[1] - .5) ** 2 + 10 * x[0] \
+                   + 5 * x[2]
+
+    def _global_and_slow_gradual_gen(self, x, index: int, rc: random.Random):
+        if index < self.change_point1:
+            # default function
+            return 10 * math.sin(math.pi * x[0] * x[1]) + 20 * (x[2] - .5) ** 2 + 10 * x[3] \
+                   + 5 * x[4]
+        elif self.change_point1 <= index < self.change_point2:
+            if index < self.change_point1 + self.transition_window and bool(rc.getrandbits(1)):
+                # default function
+                return 10 * math.sin(math.pi * x[0] * x[1]) + 20 * (x[2] - .5) ** 2 + 10 * x[3] \
+                       + 5 * x[4]
+            else:  # First new function
+                return 10 * math.sin(math.pi * x[3] * x[4]) + 20 * (x[1] - .5) ** 2 + 10 * x[0] \
+                       + 5 * x[2]
+        elif index >= self.change_point2:
+            if index < self.change_point2 + self.transition_window and bool(rc.getrandbits(1)):
+                # First new function
+                return 10 * math.sin(math.pi * x[3] * x[4]) + 20 * (x[1] - .5) ** 2 + 10 * x[0] \
+                       + 5 * x[2]
+            else:  # Second new function
+                return 10 * math.sin(math.pi * x[1] * x[4]) + 20 * (x[3] - .5) ** 2 + 10 * x[2] \
+                       + 5 * x[0]
+
+    def __iter__(self):
+        rng = random.Random(self.seed)
+
+        # To produce True or False with equal probability. Only used in gradual drifts
+        if self.drift_type == self._GLOBAL_AND_SLOW_GRADUAL:
+            rc = random.Random(self.seed)
+        else:
+            rc = None
+
+        i = 0
+        while True:
+            x = {i: rng.uniform(a=0, b=1) for i in range(10)}
+            y = self._y_maker(x, i, rc) + rng.gauss(mu=0, sigma=1)
+
+            yield x, y
+            i += 1

--- a/river/datasets/synth/mv.py
+++ b/river/datasets/synth/mv.py
@@ -24,7 +24,7 @@ class Mv(base.SyntheticDataset):
 
     - $x_4$:
 
-        * if $x_3 = $ `'green'`, $x_4 \\leftarrow x_1 + 2x_2$
+        * if $x_3 = $ `'green'`, $x_4 \\leftarrow x_1 + 2 x_2$
 
         * else $x_4 = \\frac{x_1}{2}$ with probability $0.3$ and $x_4 = \\frac{x_2}{2}$
         with probability $0.7$.
@@ -36,7 +36,7 @@ class Mv(base.SyntheticDataset):
 
     - $x_7$: `'yes'` with probability $0.3$, and `'no'` with probability $0.7$.
 
-    - $x_8$: `normal` if $x_5 < 0.5$ else `'large'`.
+    - $x_8$: `'normal'` if $x_5 < 0.5$ else `'large'`.
 
     - $x_9$: uniformly distributed over `[100, 500]`.
 
@@ -59,6 +59,21 @@ class Mv(base.SyntheticDataset):
     seed
         Random seed number used for reproducibility.
 
+    Examples
+    --------
+    >>> from river import synth
+
+    >>> dataset = synth.Mv(seed=42)
+
+    >>> for x, y in dataset.take(5):
+    ...     print(list(x.values()), y)
+    [1.39, -14.87, 'green', -28.35, -0.44, -31.64, 'no', 'normal', 370.67, 1178.43] -30.25
+    [-4.13, -12.89, 'red', -2.06, 0.01, -0.27, 'yes', 'normal', 359.95, 1108.98] 1.00
+    [-2.79, -12.05, 'brown', -1.39, 0.61, -4.87, 'no', 'large', 162.19, 1191.44] 15.59
+    [-1.63, -14.53, 'red', -7.26, 0.20, -29.33, 'no', 'normal', 314.49, 1194.62] -30.96
+    [-1.21, -12.23, 'brown', -6.11, 0.72, -17.66, 'no', 'large', 118.32, 1045.57] -0.60
+
+
     References
     ----------
     [^1]: [Mv in Luís Torgo regression datasets](https://www.dcc.fc.up.pt/~ltorgo/Regression/mv.html)
@@ -74,4 +89,48 @@ class Mv(base.SyntheticDataset):
         rng = random.Random(self.seed)
 
         while True:
-            pass
+            x = {
+                1: rng.uniform(-5, 5),
+                2: rng.uniform(-15, -10)
+            }
+
+            if x[1] > 0:
+                x[3] = 'green'
+            else:
+                x[3] = rng.choices(population=['red', 'brown'], weights=[0.4, 0.6])[0]
+
+            if x[3] == 'green':
+                x[4] = x[1] + 2 * x[2]
+            else:
+                choice = rng.choices(population=[True, False], weights=[0.3, 0.7])[0]
+
+                if choice:
+                    x[4] = x[1] / 2
+                else:
+                    x[4] = x[2] / 2
+
+            x[5] = rng.uniform(-1, 1)
+
+            epsilon = rng.uniform(0, 5)
+            x[6] = x[4] * epsilon
+
+            x[7] = rng.choices(population=['yes', 'no'], weights=[0.3, 0.7])[0]
+
+            x[8] = 'normal' if x[5] < 0.5 else 'large'
+
+            x[9] = rng.uniform(100, 500)
+
+            x[10] = rng.uniform(1000, 1200)
+
+            if x[2] > 2:
+                y = 35 - 0.5 * x[4]
+            elif -2 <= x[4] <= 2:
+                y = 10 - 2 * x[1]
+            elif x[7] == 'yes':
+                y = 3 - (x[1] / x[4] if x[4] != 0 else 0)
+            elif x[8] == 'normal':
+                y = x[6] + x[1]
+            else:
+                y = x[1] / 2
+
+            yield x, y

--- a/river/datasets/synth/mv.py
+++ b/river/datasets/synth/mv.py
@@ -1,0 +1,77 @@
+import random
+
+from .. import base
+
+
+class Mv(base.SyntheticDataset):
+    """Mv artificial dataset.
+
+    Artificial dataset composed of both nominal and numeric features, whose features
+    present co-dependencies. Originally described in [^1].
+
+    The features are generated using the following expressions:
+
+    - $x_1$: uniformly distributed over `[-5, 5]`.
+
+    - $x_2$: uniformly distributed over `[-15, -10]`.
+
+    - $x_3$:
+
+        * if $x_1 > 0$, $x_3 \\leftarrow$ `'green'`
+
+        * else $x_3 \\leftarrow$ `'red'` with probability $0.4$ and $x_3 \\leftarrow$ `'brown'`
+        with probability $0.6$.
+
+    - $x_4$:
+
+        * if $x_3 = $ `'green'`, $x_4 \\leftarrow x_1 + 2x_2$
+
+        * else $x_4 = \\frac{x_1}{2}$ with probability $0.3$ and $x_4 = \\frac{x_2}{2}$
+        with probability $0.7$.
+
+    - $x_5$: uniformly distributed over `[-1, 1]`.
+
+    - $x_6$: $x_6 \\leftarrow x_4 \\times \\epsilon$, where $\\epsilon$ is uniformly distributed
+    over `[0, 5]`.
+
+    - $x_7$: `'yes'` with probability $0.3$, and `'no'` with probability $0.7$.
+
+    - $x_8$: `normal` if $x_5 < 0.5$ else `'large'`.
+
+    - $x_9$: uniformly distributed over `[100, 500]`.
+
+    - $x_{10}$: uniformly distributed integer over the interval `[1000, 1200]`.
+
+    The target value is generated using the following rules:
+
+    - if $x_2 > 2$, $y \\leftarrow 35 - 0.5 x_4$
+
+    - else if $-2 \\le x_4 \\le 2$, $y \\leftarrow 10 - 2 x_1$
+
+    - else if $x_7 =$ `'yes'`, $y \\leftarrow 3 - \frac{x_1}{x_4}$
+
+    - else if $x_8 =$ `'normal'`, $y \\leftarrow x_6 + x_1$
+
+    - else $y \\leftarrow \\frac{x_1}{2}$.
+
+    Parameters
+    ----------
+    seed
+        Random seed number used for reproducibility.
+
+    References
+    ----------
+    [^1]: [Mv in Luís Torgo regression datasets](https://www.dcc.fc.up.pt/~ltorgo/Regression/mv.html)
+
+    """
+
+    def __init__(self, seed: int = None):
+        super().__init__(task=base.REG, n_features=10)
+        self.seed = seed
+
+    def __iter__(self):
+
+        rng = random.Random(self.seed)
+
+        while True:
+            pass

--- a/river/datasets/synth/mv.py
+++ b/river/datasets/synth/mv.py
@@ -24,14 +24,14 @@ class Mv(base.SyntheticDataset):
 
     - $x_4$:
 
-        * if $x_3 = $ `'green'`, $x_4 \\leftarrow x_1 + 2 x_2$
+        * if $x_3 =$ `'green'`, $x_4 \\leftarrow x_1 + 2 x_2$
 
         * else $x_4 = \\frac{x_1}{2}$ with probability $0.3$ and $x_4 = \\frac{x_2}{2}$
         with probability $0.7$.
 
     - $x_5$: uniformly distributed over `[-1, 1]`.
 
-    - $x_6$: $x_6 \\leftarrow x_4 \\times \\epsilon$, where $\\epsilon$ is uniformly distributed
+    - $x_6 \\leftarrow x_4 \\times \\epsilon$, where $\\epsilon$ is uniformly distributed
     over `[0, 5]`.
 
     - $x_7$: `'yes'` with probability $0.3$, and `'no'` with probability $0.7$.
@@ -48,7 +48,7 @@ class Mv(base.SyntheticDataset):
 
     - else if $-2 \\le x_4 \\le 2$, $y \\leftarrow 10 - 2 x_1$
 
-    - else if $x_7 =$ `'yes'`, $y \\leftarrow 3 - \frac{x_1}{x_4}$
+    - else if $x_7 =$ `'yes'`, $y \\leftarrow 3 - \\frac{x_1}{x_4}$
 
     - else if $x_8 =$ `'normal'`, $y \\leftarrow x_6 + x_1$
 

--- a/river/datasets/synth/planes_2d.py
+++ b/river/datasets/synth/planes_2d.py
@@ -1,4 +1,3 @@
-import math
 import random
 
 from .. import base
@@ -41,7 +40,9 @@ class Planes2D(base.SyntheticDataset):
     [^1]: [2DPlanes in Luís Torgo regression datasets](https://www.dcc.fc.up.pt/~ltorgo/Regression/2dplanes.html)
     [^2]: Breiman, L., Friedman, J., Stone, C.J. and Olshen, R.A., 1984. Classification and
     regression trees. CRC press.
+
     """
+
     def __init__(self, seed: int = None):
         super().__init__(task=base.REG, n_features=10)
         self.seed = seed

--- a/river/datasets/synth/planes_2d.py
+++ b/river/datasets/synth/planes_2d.py
@@ -1,0 +1,67 @@
+import math
+import random
+
+from .. import base
+
+
+class Planes2D(base.SyntheticDataset):
+    """2D Planes synthetic dataset.
+
+    This dataset is described in [^1] and was adapted from [^2]. The features are generated
+    using the following probabilities:
+
+    $$P(x_1 = -1) = P(x_1 = 1) = \\frac{1}{2}$$
+
+    $$P(x_m = -1) = P(x_m = 0) = P(x_m = 1) = \\frac{1}{3}, m=2,\\ldots, 10$$
+
+    The target value is defined by using rule:
+
+    $$\\text{if} x_1 = 1, y \\leftarrow 3 + 3x_2 + 2x_3 + x_4 + \\epsilon$$
+
+    $$\\text{if} x_1 = -1, y \\leftarrow -3 + 3x_5 + 2x_6 + x_7 + \\epsilon$$
+
+    In the expressions, $\\epsilon \\sim \\mathcal{N}(0, 1)$ is the noise.
+
+    Examples
+    --------
+    >>> from river import synth
+
+    >>> dataset = synth.Planes2D(seed=42)
+
+    >>> for x, y in dataset.take(5):
+    ...     print(list(x.values()), y)
+    [-1, -1, 1, 0, -1, -1, -1, 1, -1, 1] -9.07
+    [1, -1, -1, -1, -1, -1, 1, 1, -1, 1] -4.25
+    [-1, 1, 1, 1, 1, 0, -1, 0, 1, 0] -0.95
+    [-1, 1, 0, 0, 0, -1, -1, 0, -1, -1] -6.10
+    [1, -1, 0, 0, 1, 0, -1, 1, 0, 1] 1.60
+
+    References
+    ----------
+    [^1]: [2DPlanes in Luís Torgo regression datasets](https://www.dcc.fc.up.pt/~ltorgo/Regression/2dplanes.html)
+    [^2]: Breiman, L., Friedman, J., Stone, C.J. and Olshen, R.A., 1984. Classification and
+    regression trees. CRC press.
+    """
+    def __init__(self, seed: int = None):
+        super().__init__(task=base.REG, n_features=10)
+        self.seed = seed
+
+    def __iter__(self):
+
+        rng = random.Random(self.seed)
+
+        while True:
+            x = {1: rng.choice([-1, 1])}
+
+            for m in range(2, 11):
+                x[m] = rng.randint(-1, 1)
+
+            if x[1] == 1:
+                y = 3 + 3 * x[2] + 2 * x[3] + x[4]
+            else:
+                y = -3 + 3 * x[5] + 2 * x[6] + x[7]
+
+            # Add noise
+            y += rng.gauss(mu=0, sigma=1)
+
+            yield x, y

--- a/river/datasets/synth/planes_2d.py
+++ b/river/datasets/synth/planes_2d.py
@@ -21,6 +21,11 @@ class Planes2D(base.SyntheticDataset):
 
     In the expressions, $\\epsilon \\sim \\mathcal{N}(0, 1)$ is the noise.
 
+    Parameters
+    ----------
+    seed
+        Random seed number used for reproducibility.
+
     Examples
     --------
     >>> from river import synth

--- a/river/datasets/synth/planes_2d.py
+++ b/river/datasets/synth/planes_2d.py
@@ -13,7 +13,7 @@ class Planes2D(base.SyntheticDataset):
 
     $$P(x_m = -1) = P(x_m = 0) = P(x_m = 1) = \\frac{1}{3}, m=2,\\ldots, 10$$
 
-    The target value is defined by using rule:
+    The target value is defined by the following rule:
 
     $$\\text{if}~x_1 = 1, y \\leftarrow 3 + 3x_2 + 2x_3 + x_4 + \\epsilon$$
 

--- a/river/datasets/synth/planes_2d.py
+++ b/river/datasets/synth/planes_2d.py
@@ -15,11 +15,11 @@ class Planes2D(base.SyntheticDataset):
 
     The target value is defined by using rule:
 
-    $$\\text{if} x_1 = 1, y \\leftarrow 3 + 3x_2 + 2x_3 + x_4 + \\epsilon$$
+    $$\\text{if}~x_1 = 1, y \\leftarrow 3 + 3x_2 + 2x_3 + x_4 + \\epsilon$$
 
-    $$\\text{if} x_1 = -1, y \\leftarrow -3 + 3x_5 + 2x_6 + x_7 + \\epsilon$$
+    $$\\text{if}~x_1 = -1, y \\leftarrow -3 + 3x_5 + 2x_6 + x_7 + \\epsilon$$
 
-    In the expressions, $\\epsilon \\sim \\mathcal{N}(0, 1)$ is the noise.
+    In the expressions, $\\epsilon \\sim \\mathcal{N}(0, 1)$, is the noise.
 
     Parameters
     ----------


### PR DESCRIPTION
Adds the following new regression synthetic data generators:

- FriedmanDrift, as described in this [paper](https://link.springer.com/article/10.1007/s10618-010-0201-y) (the one that introduces the well-known FIMT-DD tree regressor). It implements three variants of concept drift
- Planes2D (originally 2DPlanes)
- Mv

The last two generators are described in the [Luís Torgo](https://www.dcc.fc.up.pt/~ltorgo/Regression/DataSets.html) repository of regression datasets and were used in multiple research papers in the last years.

Moreover, this PR also modifies `river.synth.Friedman` by adding a gaussian noise to the label, as originally proposed in the [original paper](https://www.jstor.org/stable/2241837?seq=1).