### PR TITLE
Changed iter_array returning y when y=None

### DIFF
--- a/river/stream/iter_array.py
+++ b/river/stream/iter_array.py
@@ -71,5 +71,5 @@ def iter_array(X: np.ndarray, y: np.ndarray = None,
 
     else:
 
-        for xi, yi in itertools.zip_longest(X, y if hasattr(y, '__iter__') else []):
-            yield dict(zip(feature_names, xi)), yi
+        for xi in X:
+            yield dict(zip(feature_names, xi))


### PR DESCRIPTION
For streaming from data, when y is None it is unnecessarily returned. If the function only gets X it is expected to return only X, not y.