### PR TITLE
Protect trees against missing feature values and missing labels

### DIFF
--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -34,10 +34,10 @@ The algorithms from `sklearn` that support incremental learning are mostly meant
 **How do I save and load models?**
 
 ```python
->>> from river import tree
+>>> from river import ensemble
 >>> import pickle
 
->>> model = tree.RandomForestClassifier()
+>>> model = ensemble.AdaptiveRandomForestClassifier()
 
 # save
 >>> with open('model.pkl', 'wb') as f:

--- a/river/tree/_attribute_observer/numeric_attribute_class_observer_binary_tree.py
+++ b/river/tree/_attribute_observer/numeric_attribute_class_observer_binary_tree.py
@@ -67,6 +67,8 @@ class NumericAttributeClassObserverBinaryTree(AttributeObserver):
         return 0.0
 
     def best_evaluated_split_suggestion(self, criterion, pre_split_dist, att_idx, binary_only):
+        if self._root is None:
+            return AttributeSplitSuggestion(None, [{}], -float('inf'))
 
         return self._search_for_best_split_option(
             current_node=self._root,

--- a/river/tree/_attribute_observer/numeric_attribute_class_observer_binary_tree.py
+++ b/river/tree/_attribute_observer/numeric_attribute_class_observer_binary_tree.py
@@ -67,12 +67,11 @@ class NumericAttributeClassObserverBinaryTree(AttributeObserver):
         return 0.0
 
     def best_evaluated_split_suggestion(self, criterion, pre_split_dist, att_idx, binary_only):
-        if self._root is None:
-            return AttributeSplitSuggestion(None, [{}], -float('inf'))
+        current_best_option = AttributeSplitSuggestion(None, [{}], -float('inf'))
 
         return self._search_for_best_split_option(
             current_node=self._root,
-            current_best_option=None,
+            current_best_option=current_best_option,
             actual_parent_left=None,
             parent_left=None,
             parent_right=None,

--- a/river/tree/_attribute_observer/numeric_attribute_regression_observer.py
+++ b/river/tree/_attribute_observer/numeric_attribute_regression_observer.py
@@ -110,6 +110,9 @@ class NumericAttributeRegressionObserver(AttributeObserver):
 
         candidate = AttributeSplitSuggestion(None, [{}], -float('inf'))
 
+        if self._root is None:
+            return candidate
+
         best_split = self._find_best_split(self._root, candidate)
 
         # Delete auxiliary variables

--- a/river/tree/_attribute_observer/numeric_attribute_regression_observer.py
+++ b/river/tree/_attribute_observer/numeric_attribute_regression_observer.py
@@ -193,6 +193,9 @@ class NumericAttributeRegressionObserver(AttributeObserver):
         data streams. Data mining and knowledge discovery, 23(1), 128-168.
         """
 
+        if self._root is None:
+            return
+
         # Auxiliary variables
         self._criterion = criterion
         self._pre_split_dist = pre_split_dist

--- a/river/tree/_attribute_observer/numeric_attribute_regression_observer.py
+++ b/river/tree/_attribute_observer/numeric_attribute_regression_observer.py
@@ -98,6 +98,11 @@ class NumericAttributeRegressionObserver(AttributeObserver):
 
     def best_evaluated_split_suggestion(self, criterion, pre_split_dist, att_idx,
                                         binary_only=True):
+        candidate = AttributeSplitSuggestion(None, [{}], -float('inf'))
+
+        if self._root is None:
+            return candidate
+
         self._criterion = criterion
         self._pre_split_dist = pre_split_dist
         self._att_idx = att_idx
@@ -107,11 +112,6 @@ class NumericAttributeRegressionObserver(AttributeObserver):
             self._aux_estimator = VectorDict(default_factory=functools.partial(Var))
         else:
             self._aux_estimator = Var()
-
-        candidate = AttributeSplitSuggestion(None, [{}], -float('inf'))
-
-        if self._root is None:
-            return candidate
 
         best_split = self._find_best_split(self._root, candidate)
 

--- a/river/tree/_base_tree.py
+++ b/river/tree/_base_tree.py
@@ -68,6 +68,16 @@ class BaseHoeffdingTree(ABC):
         If True, disable poor attributes to reduce memory usage.
     merit_preprune
         If True, enable merit-based tree pre-pruning.
+
+    Notes
+    -----
+    Hoeffding trees might face situations where an input feature previously used to make
+    a split decision is now absent in an incoming sample. In this case, the trees follow the
+    conventions:
+
+    - *Learning:* choose the subtree branch most traversed so far to pass the instance on.</br>
+    - * Predicting:* Use the last "reachable" decision node to provide responses.
+
     """
     def __init__(self, max_depth: int = None, binary_split: bool = False, max_size: int = 100,
                  memory_estimate_period: int = 1000000, stop_mem_management: bool = False,

--- a/river/tree/_base_tree.py
+++ b/river/tree/_base_tree.py
@@ -72,7 +72,7 @@ class BaseHoeffdingTree(ABC):
     Notes
     -----
     Hoeffding trees might face situations where an input feature previously used to make
-    a split decision is now absent in an incoming sample. In this case, the trees follow the
+    a split decision is missing in an incoming sample. In this case, the trees follow the
     conventions:
 
     - *Learning:* choose the subtree branch most traversed so far to pass the instance on.</br>

--- a/river/tree/_nodes/base.py
+++ b/river/tree/_nodes/base.py
@@ -100,6 +100,17 @@ class Node(metaclass=ABCMeta):
         if depth >= 0:
             self._depth = depth
 
+    @property
+    @abstractmethod
+    def total_weight(self) -> float:
+        """Calculate the total weight seen by the node.
+
+        Returns
+        -------
+        Total weight seen.
+        """
+        pass
+
     def subtree_depth(self) -> int:
         """Calculate the depth of the subtree from this node.
 
@@ -186,6 +197,23 @@ class SplitNode(Node):
         """
 
         return self._split_test
+
+    @property
+    def total_weight(self) -> float:
+        """Calculate the total weight seen by the node.
+
+        Returns
+        -------
+        Total weight seen.
+        """
+        w = 0.
+
+        for child in self._children.values():
+            if child is None:
+                continue
+            w += child.total_weight
+
+        return w
 
     def set_child(self, index: int, node: Node):
         """Set node as child.
@@ -359,17 +387,6 @@ class LearningNode(Node, metaclass=ABCMeta):
 
     def deactivate(self):
         self._attribute_observers = None
-
-    @property
-    @abstractmethod
-    def total_weight(self) -> float:
-        """Calculate the total weight seen by the node.
-
-        Returns
-        -------
-        Total weight seen.
-        """
-        pass
 
     @property
     def last_split_attempt_at(self) -> float:

--- a/river/tree/_nodes/base.py
+++ b/river/tree/_nodes/base.py
@@ -206,14 +206,7 @@ class SplitNode(Node):
         -------
         Total weight seen.
         """
-        w = 0.
-
-        for child in self._children.values():
-            if child is None:
-                continue
-            w += child.total_weight
-
-        return w
+        return sum(ch.total_weight for ch in filter(None, self._children.values()))
 
     def set_child(self, index: int, node: Node):
         """Set node as child.

--- a/river/tree/_nodes/hatc_nodes.py
+++ b/river/tree/_nodes/hatc_nodes.py
@@ -342,8 +342,8 @@ class AdaSplitNodeClassifier(SplitNode, AdaNode):
             else:
                 found_nodes.append(FoundNode(None, self, child_index))
         else:
-            # Emerging value in a categorical feature appears or a numerical feature is
-            # being evaluated but it is absent from the instance: use parent node in both cases
+            # Emerging value in a categorical feature appears or the split feature is missing from
+            # the instance: use parent node in both cases
             found_nodes.append(FoundNode(None, self, child_index))
 
         if self._alternate_tree is not None:

--- a/river/tree/_nodes/hatc_nodes.py
+++ b/river/tree/_nodes/hatc_nodes.py
@@ -277,17 +277,19 @@ class AdaSplitNodeClassifier(SplitNode, AdaNode):
         if child is not None:
             child.learn_one(x, y, sample_weight=sample_weight, tree=tree, parent=self,
                             parent_branch=child_branch)
-        # Instance contains a categorical value previously unseen by the split node
         elif self.split_test.branch_for_instance(x) < 0:
-            # Creates a new learning node to encompass the new observed feature
-            # value
-            leaf_node = tree._new_learning_node(parent=self)
-            branch_id = self.split_test.add_new_branch(
-                x[self.split_test.attrs_test_depends_on()[0]])
-            self.set_child(branch_id, leaf_node)
-            tree._n_active_leaves += 1
-            leaf_node.learn_one(x, y, sample_weight=sample_weight, tree=tree, parent=self,
-                                parent_branch=child_branch)
+            split_feat = self.split_test.attrs_test_depends_on()[0]
+            # Instance contains a categorical value previously unseen by the split node
+            if self.split_test.max_branches() == -1 and split_feat in x:
+                # Creates a new learning node to encompass the new observed feature value
+                leaf_node = tree._new_learning_node(parent=self)
+                branch_id = self.split_test.add_new_branch(x[split_feat])
+                self.set_child(branch_id, leaf_node)
+                tree._n_active_leaves += 1
+                leaf_node.learn_one(x, y, sample_weight=sample_weight, tree=tree, parent=self,
+                                    parent_branch=branch_id)
+            # else: If the feature is numerical but its value is not present in the instance,
+            # there is not much we can do
 
     def leaf_prediction(self, x, *, tree=None):
         # In case split nodes end up being used (if emerging categorical feature appears,
@@ -325,5 +327,10 @@ class AdaSplitNodeClassifier(SplitNode, AdaNode):
                 child.filter_instance_to_leaves(x, parent, parent_branch, found_nodes)
             else:
                 found_nodes.append(FoundNode(None, self, child_index))
+        else:
+            # Emerging value in a categorical feature appears or a numerical feature is
+            # being evaluated but it is absent from the instance: use parent node in both cases
+            found_nodes.append(FoundNode(None, self, child_index))
+
         if self._alternate_tree is not None:
             self._alternate_tree.filter_instance_to_leaves(x, self, -999, found_nodes)

--- a/river/tree/_nodes/hatc_nodes.py
+++ b/river/tree/_nodes/hatc_nodes.py
@@ -288,7 +288,7 @@ class AdaSplitNodeClassifier(SplitNode, AdaNode):
                 tree._n_active_leaves += 1
                 leaf_node.learn_one(x, y, sample_weight=sample_weight, tree=tree, parent=self,
                                     parent_branch=branch_id)
-            # The split feature is not present in the instance. Hence, we pass the new example
+            # The split feature is missing in the instance. Hence, we pass the new example
             # to the most traversed path in the current subtree
             else:
                 path = max(

--- a/river/tree/_nodes/hatr_nodes.py
+++ b/river/tree/_nodes/hatr_nodes.py
@@ -250,7 +250,7 @@ class AdaSplitNodeRegressor(SplitNode, AdaNode):
                 tree._n_active_leaves += 1
                 leaf_node.learn_one(x, y, sample_weight=sample_weight, tree=tree, parent=self,
                                     parent_branch=branch_id)
-            # The split feature is not present in the instance. Hence, we pass the new example
+            # The split feature is missing in the instance. Hence, we pass the new example
             # to the most traversed path in the current subtree
             else:
                 path = max(

--- a/river/tree/_nodes/hatr_nodes.py
+++ b/river/tree/_nodes/hatr_nodes.py
@@ -304,8 +304,8 @@ class AdaSplitNodeRegressor(SplitNode, AdaNode):
             else:
                 found_nodes.append(FoundNode(None, self, child_index))
         else:
-            # Emerging value in a categorical feature appears or a numerical feature is
-            # being evaluated but it is absent from the instance: use parent node in both cases
+            # Emerging value in a categorical feature appears or the split feature is missing from
+            # the instance: use parent node in both cases
             found_nodes.append(FoundNode(None, self, child_index))
 
         if self._alternate_tree is not None:

--- a/river/tree/_nodes/hatr_nodes.py
+++ b/river/tree/_nodes/hatr_nodes.py
@@ -239,7 +239,7 @@ class AdaSplitNodeRegressor(SplitNode, AdaNode):
         if child is not None:
             child.learn_one(x, y, sample_weight=sample_weight, tree=tree, parent=self,
                             parent_branch=child_branch)
-        elif self.split_test.branch_for_instance(x) < 0:
+        elif self.split_test.branch_for_instance(x) == -1:
             split_feat = self.split_test.attrs_test_depends_on()[0]
             # Instance contains a categorical value previously unseen by the split node
             if self.split_test.max_branches() == -1 and split_feat in x:
@@ -250,8 +250,22 @@ class AdaSplitNodeRegressor(SplitNode, AdaNode):
                 tree._n_active_leaves += 1
                 leaf_node.learn_one(x, y, sample_weight=sample_weight, tree=tree, parent=self,
                                     parent_branch=branch_id)
-            # else: If the feature is numerical but its value is not present in the instance,
-            # there is not much we can do
+            # The split feature is not present in the instance. Hence, we pass the new example
+            # to the most traversed path in the current subtree
+            else:
+                path = max(
+                    self._children,
+                    key=lambda c: self._children[c].total_weight if self._children[c] else 0.
+                )
+                leaf_node = self.get_child(path)
+                # Pass instance to the most traversed path
+                if leaf_node is None:
+                    leaf_node = tree._new_learning_node(parent=self)
+                    self.set_child(path, leaf_node)
+                    tree._n_active_leaves += 1
+
+                leaf_node.learn_one(x, y, sample_weight=sample_weight, tree=tree, parent=self,
+                                    parent_branch=path)
 
     def leaf_prediction(self, x, *, tree=None):
         # Called in case an emerging categorical feature has no path down the split node to be

--- a/river/tree/_nodes/hatr_nodes.py
+++ b/river/tree/_nodes/hatr_nodes.py
@@ -239,17 +239,19 @@ class AdaSplitNodeRegressor(SplitNode, AdaNode):
         if child is not None:
             child.learn_one(x, y, sample_weight=sample_weight, tree=tree, parent=self,
                             parent_branch=child_branch)
-        # Instance contains a categorical value previously unseen by the split node
         elif self.split_test.branch_for_instance(x) < 0:
-            # Creates a new learning node to encompass the new observed feature
-            # value
-            leaf_node = tree._new_learning_node(parent=self)
-            branch_id = self.split_test.add_new_branch(
-                x[self.split_test.attrs_test_depends_on()[0]])
-            self.set_child(branch_id, leaf_node)
-            tree._n_active_leaves += 1
-            leaf_node.learn_one(x, y, sample_weight=sample_weight, tree=tree, parent=parent,
-                                parent_branch=parent_branch)
+            split_feat = self.split_test.attrs_test_depends_on()[0]
+            # Instance contains a categorical value previously unseen by the split node
+            if self.split_test.max_branches() == -1 and split_feat in x:
+                # Creates a new learning node to encompass the new observed feature value
+                leaf_node = tree._new_learning_node(parent=self)
+                branch_id = self.split_test.add_new_branch(x[split_feat])
+                self.set_child(branch_id, leaf_node)
+                tree._n_active_leaves += 1
+                leaf_node.learn_one(x, y, sample_weight=sample_weight, tree=tree, parent=self,
+                                    parent_branch=branch_id)
+            # else: If the feature is numerical but its value is not present in the instance,
+            # there is not much we can do
 
     def leaf_prediction(self, x, *, tree=None):
         # Called in case an emerging categorical feature has no path down the split node to be
@@ -287,6 +289,11 @@ class AdaSplitNodeRegressor(SplitNode, AdaNode):
                 child.filter_instance_to_leaves(x, parent, parent_branch, found_nodes)
             else:
                 found_nodes.append(FoundNode(None, self, child_index))
+        else:
+            # Emerging value in a categorical feature appears or a numerical feature is
+            # being evaluated but it is absent from the instance: use parent node in both cases
+            found_nodes.append(FoundNode(None, self, child_index))
+
         if self._alternate_tree is not None:
             self._alternate_tree.filter_instance_to_leaves(x, self, -999, found_nodes)
 

--- a/river/tree/hoeffding_tree_classifier.py
+++ b/river/tree/hoeffding_tree_classifier.py
@@ -363,7 +363,7 @@ class HoeffdingTreeClassifier(BaseHoeffdingTree, base.Classifier):
                 current.set_child(branch_id, leaf_node)
                 self._n_active_leaves += 1
                 leaf_node.learn_one(x, y, sample_weight=sample_weight, tree=self)
-            # The split feature is not present in the instance. Hence, we pass the new example
+            # The split feature is missing in the instance. Hence, we pass the new example
             # to the most traversed path in the current subtree
             else:
                 nd = leaf_node

--- a/river/tree/hoeffding_tree_classifier.py
+++ b/river/tree/hoeffding_tree_classifier.py
@@ -351,17 +351,20 @@ class HoeffdingTreeClassifier(BaseHoeffdingTree, base.Classifier):
                         self._attempt_to_split(leaf_node, found_node.parent,
                                                found_node.parent_branch)
                         leaf_node.last_split_attempt_at = weight_seen
-        # Split node encountered a previously unseen categorical value (in a multi-way test),
-        # so there is no branch to sort the instance to
-        elif not leaf_node.is_leaf() and leaf_node.split_test.max_branches() == -1:
-            # Creates a new branch to the new categorical value
+        else:
             current = leaf_node
-            leaf_node = self._new_learning_node(parent=current)
-            branch_id = current.split_test.add_new_branch(
-                x[current.split_test.attrs_test_depends_on()[0]])
-            current.set_child(branch_id, leaf_node)
-            self._n_active_leaves += 1
-            leaf_node.learn_one(x, y, sample_weight=sample_weight, tree=self)
+            split_feat = current.split_test.attrs_test_depends_on()[0]
+            # Split node encountered a previously unseen categorical value (in a multi-way test),
+            # so there is no branch to sort the instance to
+            if current.split_test.max_branches() == -1 and split_feat in x:
+                # Creates a new branch to the new categorical value
+                leaf_node = self._new_learning_node(parent=current)
+                branch_id = current.split_test.add_new_branch(x[split_feat])
+                current.set_child(branch_id, leaf_node)
+                self._n_active_leaves += 1
+                leaf_node.learn_one(x, y, sample_weight=sample_weight, tree=self)
+            # else: If the feature is numerical but its value is not present in the instance,
+            # there is not much we can do
 
         if self._train_weight_seen_by_model % self.memory_estimate_period == 0:
             self._estimate_model_size()

--- a/river/tree/hoeffding_tree_classifier.py
+++ b/river/tree/hoeffding_tree_classifier.py
@@ -363,8 +363,34 @@ class HoeffdingTreeClassifier(BaseHoeffdingTree, base.Classifier):
                 current.set_child(branch_id, leaf_node)
                 self._n_active_leaves += 1
                 leaf_node.learn_one(x, y, sample_weight=sample_weight, tree=self)
-            # else: If the feature is numerical but its value is not present in the instance,
-            # there is not much we can do
+            # The split feature is not present in the instance. Hence, we pass the new example
+            # to the most traversed path in the current subtree
+            else:
+                nd = leaf_node
+                # Keep traversing down the tree until a leaf is found
+                while not nd.is_leaf():
+                    path = max(
+                        nd._children,
+                        key=lambda c: nd._children[c].total_weight if nd._children[c] else 0.
+                    )
+                    most_traversed = nd.get_child(path)
+                    # Pass instance to the most traversed path
+                    if most_traversed is not None:
+                        found_node = most_traversed.filter_instance_to_leaf(x, nd, path)
+                        nd = found_node.node
+
+                        if nd is None:
+                            nd = self._new_learning_node(parent=found_node.parent)
+                            found_node.parent.set_child(found_node.parent_branch, nd)
+                            self._n_active_leaves += 1
+                    else:
+                        leaf = self._new_learning_node(parent=nd)
+                        nd.set_child(path, leaf)
+                        nd = leaf
+                        self._n_active_leaves += 1
+
+                # Learn from the sample
+                nd.learn_one(x, y, sample_weight=sample_weight, tree=self)
 
         if self._train_weight_seen_by_model % self.memory_estimate_period == 0:
             self._estimate_model_size()

--- a/river/tree/hoeffding_tree_regressor.py
+++ b/river/tree/hoeffding_tree_regressor.py
@@ -256,7 +256,7 @@ class HoeffdingTreeRegressor(BaseHoeffdingTree, base.Regressor):
                 current.set_child(branch_id, leaf_node)
                 self._n_active_leaves += 1
                 leaf_node.learn_one(x, y, sample_weight=sample_weight, tree=self)
-            # The split feature is not present in the instance. Hence, we pass the new example
+            # The split feature is missing in the instance. Hence, we pass the new example
             # to the most traversed path in the current subtree
             else:
                 nd = leaf_node


### PR DESCRIPTION
Fix #393.

---
### TL;DR

- Protects Binary Search Tree-based attribute observers against the case where `None` is passed to trees' `learn_one`method and splits are attempted.
- It also makes the trees deal with the situation where a split feature's value is not found during the learning process.

---

Currently, the trees manipulate their branches by identifying them with integers. Why so? Well, this gives us a standardized way of dealing with numerical and categorical features. For instance, suppose a categorical feature carries a mixture of strings and numbers. If we identify the tree branches by their actual values, they will become a mess. Right?

Instead, we use increasing integer values starting from `0` till `n_branches - 1`. We also reserve negative values for special cases:
- `-1`: a branch was not found while sorting an instance down the tree
- `-999`: the current branch corresponds to an alternate tree of the Hoeffding Adaptive Tree (HAT) classifier/regressor. This code is the same one used in the original MOA implementation of HATC.

That said, this PR concerns the specific case where `-1` is returned while sorting an instance in the trees. If, while traversing the tree, we get `-1` as the branch identifier for the next node, that could mean two things:

1. The current split feature is nominal, and the category in the new incoming instance `x` was never seen before this point. Hence, the tree does not know what to do with the instance from this point onward.
2. The node's split feature value in `x` is missing.

The solution for (1) was already in place since the original code of `skmultiflow`:

- if a new category arises while learning, we create a new leaf to accommodate it :)
- if a new category arises while predicting, we use the last accessible node to make the predictions. In other words, that poor decision node whose branches do not encompass the new emerging value.

Okie Doki. But what about (2)? Well, since the original Hoeffding Tree framework does not tells us what to do, and the current implementation might break depending on the situation:

**Changed (keeping the following paragraph for discussion history tracking purposes):**
- ~if the missing value arises while updating the tree, do nothing. That's the point: we do not know which of the two branches representing the tests `<=` and `>` the instance should be passed on. Thus, this PR makes the learning process simply stopping there. This strategy impacts the trees at different levels: HAT* implementations and EFDT update all the nodes in the path (they leverage the information from the incomplete instance). The vanilla HTs do not, so they will ultimately ignore this example as it cannot reach a leaf. As discussed in #393, other strategies might be pursued in the future.~
- if the missing value happens at prediction time, we use the last accessible node to obtain the responses.
