### PR TITLE
Add methods to clone and reset estimators

### DIFF
--- a/river/base/__init__.py
+++ b/river/base/__init__.py
@@ -20,6 +20,7 @@ from .clusterer import Clusterer
 from .drift_detector import DriftDetector
 from .ensemble import EnsembleMixin
 from .estimator import Estimator
+from .estimator import clone
 from .multi_output import MultiOutputMixin
 from .regressor import Regressor
 from .regressor import MiniBatchRegressor
@@ -32,6 +33,7 @@ __all__ = [
     'AnomalyDetector',
     'Classifier',
     'Clusterer',
+    'clone',
     'DriftDetector',
     'EnsembleMixin',
     'Estimator',

--- a/river/ensemble/adaptive_random_forest.py
+++ b/river/ensemble/adaptive_random_forest.py
@@ -156,7 +156,12 @@ class BaseTreeClassifier(HoeffdingTreeClassifier):
                  attr_obs_params: dict = None,
                  max_features: int = 2,
                  seed=None,
-                 **kwargs):
+                 binary_split: bool = False,
+                 max_size: int = 100,
+                 memory_estimate_period: int = 1000000,
+                 stop_mem_management: bool = False,
+                 remove_poor_attrs: bool = False,
+                 merit_preprune: bool = True):
         super().__init__(grace_period=grace_period,
                          max_depth=max_depth,
                          split_criterion=split_criterion,
@@ -167,7 +172,12 @@ class BaseTreeClassifier(HoeffdingTreeClassifier):
                          nominal_attributes=nominal_attributes,
                          attr_obs=attr_obs,
                          attr_obs_params=attr_obs_params,
-                         **kwargs)
+                         binary_split=binary_split,
+                         max_size=max_size,
+                         memory_estimate_period=memory_estimate_period,
+                         stop_mem_management=stop_mem_management,
+                         remove_poor_attrs=remove_poor_attrs,
+                         merit_preprune=merit_preprune)
 
         self.max_features = max_features
         self.seed = seed
@@ -246,7 +256,12 @@ class BaseTreeRegressor(HoeffdingTreeRegressor):
                  min_samples_split: int = 5,
                  max_features: int = 2,
                  seed=None,
-                 **kwargs):
+                 binary_split: bool = False,
+                 max_size: int = 100,
+                 memory_estimate_period: int = 1000000,
+                 stop_mem_management: bool = False,
+                 remove_poor_attrs: bool = False,
+                 merit_preprune: bool = True):
         super().__init__(grace_period=grace_period,
                          max_depth=max_depth,
                          split_confidence=split_confidence,
@@ -258,7 +273,12 @@ class BaseTreeRegressor(HoeffdingTreeRegressor):
                          attr_obs=attr_obs,
                          attr_obs_params=attr_obs_params,
                          min_samples_split=min_samples_split,
-                         **kwargs)
+                         binary_split=binary_split,
+                         max_size=max_size,
+                         memory_estimate_period=memory_estimate_period,
+                         stop_mem_management=stop_mem_management,
+                         remove_poor_attrs=remove_poor_attrs,
+                         merit_preprune=merit_preprune)
 
         self.max_features = max_features
         self.seed = seed
@@ -417,6 +437,19 @@ class AdaptiveRandomForestClassifier(BaseForest, base.Classifier):
     max_depth
         [*Tree parameter*] The maximum depth a tree can reach. If `None`, the
         tree will grow indefinitely.
+    binary_split
+        [*Tree parameter*] If True, only allow binary splits.
+    max_size
+        [*Tree parameter*] The max size of the tree, in Megabytes (MB).
+    memory_estimate_period
+        [*Tree parameter*] Interval (number of processed instances) between memory consumption
+        checks.
+    stop_mem_management
+        [*Tree parameter*] If True, stop growing as soon as memory limit is hit.
+    remove_poor_attrs
+        [*Tree parameter*] If True, disable poor attributes to reduce memory usage.
+    merit_preprune
+        [*Tree parameter*] If True, enable merit-based tree pre-pruning.
     seed
         If `int`, `seed` is used to seed the random number generator;
         If `RandomState`, `seed` is the random number generator;
@@ -691,6 +724,19 @@ class AdaptiveRandomForestRegressor(BaseForest, base.Regressor):
     max_depth
         [*Tree parameter*] The maximum depth a tree can reach. If `None`, the
         tree will grow indefinitely.
+    binary_split
+        [*Tree parameter*] If True, only allow binary splits.
+    max_size
+        [*Tree parameter*] The max size of the tree, in Megabytes (MB).
+    memory_estimate_period
+        [*Tree parameter*] Interval (number of processed instances) between memory consumption
+        checks.
+    stop_mem_management
+        [*Tree parameter*] If True, stop growing as soon as memory limit is hit.
+    remove_poor_attrs
+        [*Tree parameter*] If True, disable poor attributes to reduce memory usage.
+    merit_preprune
+        [*Tree parameter*] If True, enable merit-based tree pre-pruning.
     seed
         If `int`, `seed` is used to seed the random number generator;
         If `RandomState`, `seed` is the random number generator;

--- a/river/ensemble/streaming_random_patches.py
+++ b/river/ensemble/streaming_random_patches.py
@@ -273,11 +273,11 @@ class SRPClassifier(base.WrapperMixin, base.EnsembleMixin, base.Classifier):
             subspace = self._subspaces[subspace_indexes[i]]
             self.models.append(self._base_learner_class(
                 idx_original=i,
-                base_model=self.model,    # TODO replace with clone
-                metric=copy.deepcopy(self.metric),
+                model=self.model,
+                metric=self.metric,
                 created_on=self._n_samples_seen,
-                base_drift_detector=self.drift_detector,
-                base_warning_detector=self.warning_detector,
+                drift_detector=self.drift_detector,
+                warning_detector=self.warning_detector,
                 is_background_learner=False,
                 features=subspace,
                 nominal_attributes=self.nominal_attributes,
@@ -295,20 +295,19 @@ class StreamingRandomPatchesBaseLearner:
     """
     def __init__(self,
                  idx_original: int,
-                 base_model: base.Classifier,
+                 model: base.Classifier,
                  metric: MultiClassMetric,
                  created_on: int,
-                 base_drift_detector: base.DriftDetector,
-                 base_warning_detector: base.DriftDetector,
+                 drift_detector: base.DriftDetector,
+                 warning_detector: base.DriftDetector,
                  is_background_learner,
                  features=None,
                  nominal_attributes=None,
                  rng=None):
         self.idx_original = idx_original
         self.created_on = created_on
-        self.base_model = base_model    # Model prototype
-        self.model = copy.deepcopy(base_model)  # Actual model used
-        self.metric = metric
+        self.model = base.clone(model)
+        self.metric = copy.deepcopy(metric)
         # Make sure that the metric is not initialized, e.g. when creating background learners.
         self.metric.cm.reset()
 
@@ -316,21 +315,19 @@ class StreamingRandomPatchesBaseLearner:
         self.features = features
 
         # Drift and warning detection
-        self.base_drift_detector = base_drift_detector  # Drift detector prototype
-        self.base_warning_detector = base_warning_detector  # Warning detector prototype
 
-        if base_drift_detector is not None:
+        if drift_detector is not None:
             self.disable_drift_detector = False
             # TODO Replace with clone
-            self.drift_detector = copy.deepcopy(base_drift_detector)  # Actual detector used
+            self.drift_detector = base.clone(drift_detector)  # Actual detector used
         else:
             self.disable_drift_detector = True
             self.drift_detector = None
 
-        if base_warning_detector is not None:
+        if warning_detector is not None:
             self.disable_background_learner = False
             # TODO Replace with clone
-            self.warning_detector = copy.deepcopy(base_warning_detector)  # Actual detector used
+            self.warning_detector = base.clone(warning_detector)  # Actual detector used
         else:
             self.disable_background_learner = True
             self.warning_detector = None
@@ -417,18 +414,18 @@ class StreamingRandomPatchesBaseLearner:
         # Initialize the background learner
         self._background_learner = self._background_learner_class(
             idx_original=self.idx_original,
-            base_model=self.base_model,
-            metric=copy.deepcopy(self.metric),
+            model=self.model,
+            metric=self.metric,
             created_on=n_samples_seen,
-            base_drift_detector=self.base_drift_detector,
-            base_warning_detector=self.base_warning_detector,
+            drift_detector=self.drift_detector,
+            warning_detector=self.warning_detector,
             is_background_learner=True,
             features=subspace,
             nominal_attributes=self.nominal_attributes,
             rng=self._rng
         )
         # Hard-reset the warning method
-        self.warning_detector = copy.deepcopy(self.base_warning_detector)
+        self.warning_detector = base.clone(self.warning_detector)
 
     def reset(self, all_features: list, n_samples_seen: int, rng: np.random.RandomState):
         # Randomly generate a new subspace from all the original features
@@ -448,10 +445,10 @@ class StreamingRandomPatchesBaseLearner:
             self._background_learner = None
         else:
             # Reset model
-            self.model = copy.deepcopy(self.base_model)
+            self.model = base.clone(self.model)
             self.metric.cm.reset()
             self.created_on = n_samples_seen
-            self.drift_detector = copy.deepcopy(self.base_drift_detector)
+            self.drift_detector = base.clone(self.drift_detector)
             self.features = subspace
             self._set_nominal_attributes = self._can_set_nominal_attributes()
 

--- a/river/neighbors/base_neighbors.py
+++ b/river/neighbors/base_neighbors.py
@@ -183,11 +183,12 @@ class KNeighborsBuffer:
 class BaseNeighbors:
     """Base class for neighbors-based estimators. """
     def __init__(self, n_neighbors: int = 5, window_size: int = 1000, leaf_size: int = 30,
-                 p: float = 2, **kwargs):
+                 p: float = 2, compact_nodes=True, balanced_tree=True):
         self.n_neighbors = n_neighbors
         self.window_size = window_size
         self.leaf_size = leaf_size
-        self._kwargs = kwargs
+        self.compact_nodes = compact_nodes
+        self.balanced_tree = balanced_tree
 
         if p < 1:
             raise ValueError('Invalid Minkowski p-norm value: {}.\n'
@@ -197,7 +198,8 @@ class BaseNeighbors:
 
     def _get_neighbors(self, x):
         X = self.data_window.features_buffer
-        tree = cKDTree(X, leafsize=self.leaf_size, **self._kwargs)
+        tree = cKDTree(X, leafsize=self.leaf_size, compact_nodes=self.compact_nodes,
+                       balanced_tree=self.balanced_tree)
         dist, idx = tree.query(x.reshape(1, -1), k=self.n_neighbors, p=self.p)
         return dist, idx
 

--- a/river/neighbors/knn_adwin.py
+++ b/river/neighbors/knn_adwin.py
@@ -26,6 +26,15 @@ class KNNADWINClassifier(KNNClassifier):
         p-norm value for the Minkowski metric. When `p=1`, this corresponds to the
         Manhattan distance, while `p=2` corresponds to the Euclidean distance. Valid
         values are in the interval $[1, +\\infty)$
+    compact_nodes
+        scipy.spatial.cKDTree parameter. If True, the kd-tree is built to shrink the
+        hyperrectangles to the actual data range. This usually gives a more compact tree
+        that is robust against degenerated input data and gives faster queries at the
+        expense of longer build time.
+    balanced_tree
+        scipy.spatial.cKDTree parameter. If True, the median is used to split the
+        hyperrectangles instead of the midpoint. This usually gives a more compact tree
+        and faster queries at the expense of longer build time. Default: True.
 
     Notes
     -----

--- a/river/neighbors/knn_classifier.py
+++ b/river/neighbors/knn_classifier.py
@@ -36,8 +36,15 @@ class KNNClassifier(BaseNeighbors, base.Classifier):
     weighted
         Whether to weight the contribution of each neighbor by it's inverse
         distance or not.
-    kwargs
-        Other parameters passed to `scipy.spatial.cKDTree`.
+    compact_nodes
+        scipy.spatial.cKDTree parameter. If True, the kd-tree is built to shrink the
+        hyperrectangles to the actual data range. This usually gives a more compact tree
+        that is robust against degenerated input data and gives faster queries at the
+        expense of longer build time.
+    balanced_tree
+        scipy.spatial.cKDTree parameter. If True, the median is used to split the
+        hyperrectangles instead of the midpoint. This usually gives a more compact tree
+        and faster queries at the expense of longer build time. Default: True.
 
     Notes
     -----
@@ -68,9 +75,9 @@ class KNNClassifier(BaseNeighbors, base.Classifier):
     """
 
     def __init__(self, n_neighbors: int = 5, window_size: int = 1000, leaf_size: int = 30,
-                 p: float = 2, weighted: bool = True, **kwargs):
+                 p: float = 2, weighted: bool = True, compact_nodes=True, balanced_tree=True):
         super().__init__(n_neighbors=n_neighbors, window_size=window_size, leaf_size=leaf_size,
-                         p=p, **kwargs)
+                         p=p, compact_nodes=compact_nodes, balanced_tree=balanced_tree)
         self.weighted = weighted
         self.classes_: typing.Set = set()
 

--- a/river/neighbors/knn_regressor.py
+++ b/river/neighbors/knn_regressor.py
@@ -34,8 +34,15 @@ class KNNRegressor(BaseNeighbors, base.Regressor):
             | 'mean'
             | 'median'
             | 'weighted_mean'
-    kwargs
-        Other parameters passed to scipy.spatial.cKDTree.
+    compact_nodes
+        scipy.spatial.cKDTree parameter. If True, the kd-tree is built to shrink the
+        hyperrectangles to the actual data range. This usually gives a more compact tree
+        that is robust against degenerated input data and gives faster queries at the
+        expense of longer build time.
+    balanced_tree
+        scipy.spatial.cKDTree parameter. If True, the median is used to split the
+        hyperrectangles instead of the midpoint. This usually gives a more compact tree
+        and faster queries at the expense of longer build time. Default: True.
 
     Notes
     -----
@@ -70,10 +77,11 @@ class KNNRegressor(BaseNeighbors, base.Regressor):
     _WEIGHTED_MEAN = 'weighted_mean'
 
     def __init__(self, n_neighbors: int = 5, window_size: int = 1000, leaf_size: int = 30,
-                 p: float = 2, aggregation_method: str = 'mean', **kwargs):
+                 p: float = 2, aggregation_method: str = 'mean', compact_nodes=True,
+                 balanced_tree=True):
 
         super().__init__(n_neighbors=n_neighbors, window_size=window_size, leaf_size=leaf_size,
-                         p=p, **kwargs)
+                         p=p, compact_nodes=compact_nodes, balanced_tree=balanced_tree)
         if aggregation_method not in {self._MEAN, self._MEDIAN, self._WEIGHTED_MEAN}:
             raise ValueError('Invalid aggregation_method: {}.\n'
                              'Valid options are: {}'.format(aggregation_method,

--- a/river/tree/extremely_fast_decision_tree.py
+++ b/river/tree/extremely_fast_decision_tree.py
@@ -56,8 +56,18 @@ class ExtremelyFastDecisionTreeClassifier(HoeffdingTreeClassifier):
         See 'Notes' for more information about the AOs.
     attr_obs_params
         Parameters passed to the numeric AOs. See `attr_obs` for more information.
-    kwargs
-        Other parameters passed to `river.tree.BaseHoeffdingTree`.
+    binary_split
+        If True, only allow binary splits.
+    max_size
+        The max size of the tree, in Megabytes (MB).
+    memory_estimate_period
+        Interval (number of processed instances) between memory consumption checks.
+    stop_mem_management
+        If True, stop growing as soon as memory limit is hit.
+    remove_poor_attrs
+        If True, disable poor attributes to reduce memory usage.
+    merit_preprune
+        If True, enable merit-based tree pre-pruning.
 
     Notes
     -----
@@ -135,7 +145,13 @@ class ExtremelyFastDecisionTreeClassifier(HoeffdingTreeClassifier):
                  nominal_attributes: list = None,
                  attr_obs: str = 'gaussian',
                  attr_obs_params: dict = None,
-                 **kwargs):
+                 binary_split: bool = False,
+                 max_size: int = 100,
+                 memory_estimate_period: int = 1000000,
+                 stop_mem_management: bool = False,
+                 remove_poor_attrs: bool = False,
+                 merit_preprune: bool = True
+                 ):
 
         super().__init__(grace_period=grace_period,
                          max_depth=max_depth,
@@ -147,7 +163,12 @@ class ExtremelyFastDecisionTreeClassifier(HoeffdingTreeClassifier):
                          nominal_attributes=nominal_attributes,
                          attr_obs=attr_obs,
                          attr_obs_params=attr_obs_params,
-                         **kwargs)
+                         binary_split=binary_split,
+                         max_size=max_size,
+                         memory_estimate_period=memory_estimate_period,
+                         stop_mem_management=stop_mem_management,
+                         remove_poor_attrs=remove_poor_attrs,
+                         merit_preprune=merit_preprune)
 
         self.min_samples_reevaluate = min_samples_reevaluate
 

--- a/river/tree/hoeffding_adaptive_tree_classifier.py
+++ b/river/tree/hoeffding_adaptive_tree_classifier.py
@@ -63,8 +63,18 @@ class HoeffdingAdaptiveTreeClassifier(HoeffdingTreeClassifier):
        If None, the random number generator is the RandomState instance used
        by `np.random`. Only used when `bootstrap_sampling=True` to direct the
        bootstrap sampling.</br>
-    kwargs
-        Other parameters passed to `river.tree.BaseHoeffdingTree`.
+    binary_split
+        If True, only allow binary splits.
+    max_size
+        The max size of the tree, in Megabytes (MB).
+    memory_estimate_period
+        Interval (number of processed instances) between memory consumption checks.
+    stop_mem_management
+        If True, stop growing as soon as memory limit is hit.
+    remove_poor_attrs
+        If True, disable poor attributes to reduce memory usage.
+    merit_preprune
+        If True, enable merit-based tree pre-pruning.
 
     Notes
     -----
@@ -156,7 +166,12 @@ class HoeffdingAdaptiveTreeClassifier(HoeffdingTreeClassifier):
                  drift_window_threshold: int = 300,
                  adwin_confidence: float = 0.002,
                  seed=None,
-                 **kwargs):
+                 binary_split: bool = False,
+                 max_size: int = 100,
+                 memory_estimate_period: int = 1000000,
+                 stop_mem_management: bool = False,
+                 remove_poor_attrs: bool = False,
+                 merit_preprune: bool = True):
 
         super().__init__(grace_period=grace_period,
                          max_depth=max_depth,
@@ -168,7 +183,12 @@ class HoeffdingAdaptiveTreeClassifier(HoeffdingTreeClassifier):
                          nominal_attributes=nominal_attributes,
                          attr_obs=attr_obs,
                          attr_obs_params=attr_obs_params,
-                         **kwargs)
+                         binary_split=binary_split,
+                         max_size=max_size,
+                         memory_estimate_period=memory_estimate_period,
+                         stop_mem_management=stop_mem_management,
+                         remove_poor_attrs=remove_poor_attrs,
+                         merit_preprune=merit_preprune)
 
         self._n_alternate_trees = 0
         self._n_pruned_alternate_trees = 0

--- a/river/tree/hoeffding_adaptive_tree_regressor.py
+++ b/river/tree/hoeffding_adaptive_tree_regressor.py
@@ -69,8 +69,18 @@ class HoeffdingAdaptiveTreeRegressor(HoeffdingTreeRegressor):
        If None, the random number generator is the RandomState instance used
        by `np.random`. Only used when `bootstrap_sampling=True` to direct the
        bootstrap sampling.</br>
-    kwargs
-        Other parameters passed to `river.tree.BaseHoeffdingTree`.
+    binary_split
+        If True, only allow binary splits.
+    max_size
+        The max size of the tree, in Megabytes (MB).
+    memory_estimate_period
+        Interval (number of processed instances) between memory consumption checks.
+    stop_mem_management
+        If True, stop growing as soon as memory limit is hit.
+    remove_poor_attrs
+        If True, disable poor attributes to reduce memory usage.
+    merit_preprune
+        If True, enable merit-based tree pre-pruning.
 
     Notes
     -----
@@ -150,7 +160,12 @@ class HoeffdingAdaptiveTreeRegressor(HoeffdingTreeRegressor):
                  drift_window_threshold: int = 300,
                  adwin_confidence: float = 0.002,
                  seed=None,
-                 **kwargs):
+                 binary_split: bool = False,
+                 max_size: int = 100,
+                 memory_estimate_period: int = 1000000,
+                 stop_mem_management: bool = False,
+                 remove_poor_attrs: bool = False,
+                 merit_preprune: bool = True):
 
         super().__init__(grace_period=grace_period,
                          max_depth=max_depth,
@@ -163,7 +178,12 @@ class HoeffdingAdaptiveTreeRegressor(HoeffdingTreeRegressor):
                          attr_obs=attr_obs,
                          attr_obs_params=attr_obs_params,
                          min_samples_split=min_samples_split,
-                         **kwargs)
+                         binary_split=binary_split,
+                         max_size=max_size,
+                         memory_estimate_period=memory_estimate_period,
+                         stop_mem_management=stop_mem_management,
+                         remove_poor_attrs=remove_poor_attrs,
+                         merit_preprune=merit_preprune)
 
         self._n_alternate_trees = 0
         self._n_pruned_alternate_trees = 0

--- a/river/tree/hoeffding_tree_classifier.py
+++ b/river/tree/hoeffding_tree_classifier.py
@@ -55,8 +55,18 @@ class HoeffdingTreeClassifier(BaseHoeffdingTree, base.Classifier):
         See 'Notes' for more information about the AOs.
     attr_obs_params
         Parameters passed to the numeric AOs. See `attr_obs` for more information.
-    kwargs
-        Other parameters passed to `river.tree.BaseHoeffdingTree`.
+    binary_split
+        If True, only allow binary splits.
+    max_size
+        The max size of the tree, in Megabytes (MB).
+    memory_estimate_period
+        Interval (number of processed instances) between memory consumption checks.
+    stop_mem_management
+        If True, stop growing as soon as memory limit is hit.
+    remove_poor_attrs
+        If True, disable poor attributes to reduce memory usage.
+    merit_preprune
+        If True, enable merit-based tree pre-pruning.
 
     Notes
     -----
@@ -153,9 +163,20 @@ class HoeffdingTreeClassifier(BaseHoeffdingTree, base.Classifier):
                  nominal_attributes: list = None,
                  attr_obs: str = 'gaussian',
                  attr_obs_params: dict = None,
-                 **kwargs):
+                 binary_split: bool = False,
+                 max_size: int = 100,
+                 memory_estimate_period: int = 1000000,
+                 stop_mem_management: bool = False,
+                 remove_poor_attrs: bool = False,
+                 merit_preprune: bool = True):
 
-        super().__init__(max_depth=max_depth, **kwargs)
+        super().__init__(max_depth=max_depth,
+                         binary_split=binary_split,
+                         max_size=max_size,
+                         memory_estimate_period=memory_estimate_period,
+                         stop_mem_management=stop_mem_management,
+                         remove_poor_attrs=remove_poor_attrs,
+                         merit_preprune=merit_preprune)
         self.grace_period = grace_period
         self.split_criterion = split_criterion
         self.split_confidence = split_confidence

--- a/river/tree/hoeffding_tree_regressor.py
+++ b/river/tree/hoeffding_tree_regressor.py
@@ -55,8 +55,18 @@ class HoeffdingTreeRegressor(BaseHoeffdingTree, base.Regressor):
     min_samples_split
         The minimum number of samples every branch resulting from a split candidate must have
         to be considered valid.
-    kwargs
-        Other parameters passed to `river.tree.BaseHoeffdingTree`.
+    binary_split
+        If True, only allow binary splits.
+    max_size
+        The max size of the tree, in Megabytes (MB).
+    memory_estimate_period
+        Interval (number of processed instances) between memory consumption checks.
+    stop_mem_management
+        If True, stop growing as soon as memory limit is hit.
+    remove_poor_attrs
+        If True, disable poor attributes to reduce memory usage.
+    merit_preprune
+        If True, enable merit-based tree pre-pruning.
 
     Notes
     -----
@@ -122,8 +132,19 @@ class HoeffdingTreeRegressor(BaseHoeffdingTree, base.Regressor):
                  attr_obs: str = 'e-bst',
                  attr_obs_params: dict = None,
                  min_samples_split: int = 5,
-                 **kwargs):
-        super().__init__(max_depth=max_depth, **kwargs)
+                 binary_split: bool = False,
+                 max_size: int = 100,
+                 memory_estimate_period: int = 1000000,
+                 stop_mem_management: bool = False,
+                 remove_poor_attrs: bool = False,
+                 merit_preprune: bool = True):
+        super().__init__(max_depth=max_depth,
+                         binary_split=binary_split,
+                         max_size=max_size,
+                         memory_estimate_period=memory_estimate_period,
+                         stop_mem_management=stop_mem_management,
+                         remove_poor_attrs=remove_poor_attrs,
+                         merit_preprune=merit_preprune)
 
         self._split_criterion: str = 'vr'
         self.grace_period = grace_period

--- a/river/tree/isoup_tree_regressor.py
+++ b/river/tree/isoup_tree_regressor.py
@@ -61,8 +61,18 @@ class iSOUPTreeRegressor(HoeffdingTreeRegressor, base.MultiOutputMixin):
     min_samples_split
         The minimum number of samples every branch resulting from a split candidate must have
         to be considered valid.
-    kwargs
-        Other parameters passed to `river.tree.BaseHoeffdingTree`.
+    binary_split
+        If True, only allow binary splits.
+    max_size
+        The max size of the tree, in Megabytes (MB).
+    memory_estimate_period
+        Interval (number of processed instances) between memory consumption checks.
+    stop_mem_management
+        If True, stop growing as soon as memory limit is hit.
+    remove_poor_attrs
+        If True, disable poor attributes to reduce memory usage.
+    merit_preprune
+        If True, enable merit-based tree pre-pruning.
 
     Notes
     -----
@@ -127,7 +137,12 @@ class iSOUPTreeRegressor(HoeffdingTreeRegressor, base.MultiOutputMixin):
                  attr_obs: str = 'e-bst',
                  attr_obs_params: dict = None,
                  min_samples_split: int = 5,
-                 **kwargs):
+                 binary_split: bool = False,
+                 max_size: int = 100,
+                 memory_estimate_period: int = 1000000,
+                 stop_mem_management: bool = False,
+                 remove_poor_attrs: bool = False,
+                 merit_preprune: bool = True):
         super().__init__(grace_period=grace_period,
                          max_depth=max_depth,
                          split_confidence=split_confidence,
@@ -139,7 +154,12 @@ class iSOUPTreeRegressor(HoeffdingTreeRegressor, base.MultiOutputMixin):
                          attr_obs=attr_obs,
                          attr_obs_params=attr_obs_params,
                          min_samples_split=min_samples_split,
-                         **kwargs)
+                         binary_split=binary_split,
+                         max_size=max_size,
+                         memory_estimate_period=memory_estimate_period,
+                         stop_mem_management=stop_mem_management,
+                         remove_poor_attrs=remove_poor_attrs,
+                         merit_preprune=merit_preprune)
 
         self.split_criterion: str = 'icvr'   # intra cluster variance reduction
         self.targets: set = set()

--- a/river/tree/label_combination_hoeffding_tree.py
+++ b/river/tree/label_combination_hoeffding_tree.py
@@ -55,8 +55,18 @@ class LabelCombinationHoeffdingTreeClassifier(HoeffdingTreeClassifier, base.Mult
         See 'Notes' for more information about the AOs.
     attr_obs_params
         Parameters passed to the numeric AOs. See `attr_obs` for more information.
-    kwargs
-        Other parameters passed to `river.tree.BaseHoeffdingTree`.
+    binary_split
+        If True, only allow binary splits.
+    max_size
+        The max size of the tree, in Megabytes (MB).
+    memory_estimate_period
+        Interval (number of processed instances) between memory consumption checks.
+    stop_mem_management
+        If True, stop growing as soon as memory limit is hit.
+    remove_poor_attrs
+        If True, disable poor attributes to reduce memory usage.
+    merit_preprune
+        If True, enable merit-based tree pre-pruning.
 
     Notes
     -----
@@ -115,7 +125,12 @@ class LabelCombinationHoeffdingTreeClassifier(HoeffdingTreeClassifier, base.Mult
                  nominal_attributes: list = None,
                  attr_obs: str = 'gaussian',
                  attr_obs_params: dict = None,
-                 **kwargs):
+                 binary_split: bool = False,
+                 max_size: int = 100,
+                 memory_estimate_period: int = 1000000,
+                 stop_mem_management: bool = False,
+                 remove_poor_attrs: bool = False,
+                 merit_preprune: bool = True):
 
         super().__init__(grace_period=grace_period,
                          max_depth=max_depth,
@@ -127,7 +142,12 @@ class LabelCombinationHoeffdingTreeClassifier(HoeffdingTreeClassifier, base.Mult
                          nominal_attributes=nominal_attributes,
                          attr_obs=attr_obs,
                          attr_obs_params=attr_obs_params,
-                         **kwargs)
+                         binary_split=binary_split,
+                         max_size=max_size,
+                         memory_estimate_period=memory_estimate_period,
+                         stop_mem_management=stop_mem_management,
+                         remove_poor_attrs=remove_poor_attrs,
+                         merit_preprune=merit_preprune)
 
         self._next_label_code: int = 0
         self._label_map: typing.Dict[typing.Tuple, int] = {}


### PR DESCRIPTION
When dealing with estimators there are two cases to consider:

- **Reset** Sometimes it is necessary to get to the initial state of a model, in other words, the model is again empty. This is useful for example when dealing with concept drift. In some cases we want the model to "forget" the previous concept. This is the purpose of the `reset` method.
- **Clone** The `clone` method takes as input an estimator (possibly trained) and yields a new empty estimator that is empty. This is useful for example in ensembles.