### PR TITLE
Fix broken link to API docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Here are some benefits of using River (and online machine learning in general):
 - Feature extraction and selection
 - Online statistics and metrics
 - Built-in datasets
-- And [much more](https://online-ml.github.io/content/api.html)
+- And [much more](https://riverml.xyz/latest/api/overview/)
 
 ## 🔗 Useful links
 


### PR DESCRIPTION
The link to `online-ml.github.io` is broken, this PR updates it to redirect to the River API docs.