### PR TITLE
Add check_init_params_are_not_mutable

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9]
+        python: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8]
+        python: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/river/ensemble/streaming_random_patches.py
+++ b/river/ensemble/streaming_random_patches.py
@@ -82,7 +82,7 @@ class SRPClassifier(base.WrapperMixin, base.EnsembleMixin, base.Classifier):
     >>> metric = metrics.Accuracy()
 
     >>> evaluate.progressive_val_score(dataset, model, metric)
-    Accuracy: 76.88%
+    Accuracy: 76.78%
 
     References
     ----------

--- a/river/utils/estimator_checks.py
+++ b/river/utils/estimator_checks.py
@@ -213,12 +213,12 @@ def check_set_params_idempotent(model):
     assert len(model.__dict__) == len(model._set_params().__dict__)
 
 
-def check_init_has_default_params(model):
+def check_init_has_default_params_for_tests(model):
     params = model._unit_test_params()
     assert isinstance(model.__class__(**params), model.__class__)
 
 
-def check_init_params_are_not_mutable(model):
+def check_init_default_params_are_not_mutable(model):
     """Mutable parameters in signatures are discouraged, as explained in
     https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments
 
@@ -310,8 +310,8 @@ def yield_checks(model):
     yield check_str
     yield check_tags
     yield check_set_params_idempotent
-    yield check_init_has_default_params
-    yield check_init_params_are_not_mutable
+    yield check_init_has_default_params_for_tests
+    yield check_init_default_params_are_not_mutable
     yield check_doc
     yield check_clone
 

--- a/river/utils/estimator_checks.py
+++ b/river/utils/estimator_checks.py
@@ -213,9 +213,23 @@ def check_set_params_idempotent(model):
     assert len(model.__dict__) == len(model._set_params().__dict__)
 
 
-def check_init(model):
+def check_init_has_default_params(model):
     params = model._unit_test_params()
     assert isinstance(model.__class__(**params), model.__class__)
+
+
+def check_init_params_are_not_mutable(model):
+    """Mutable parameters in signatures are discouraged, as explained in
+    https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments
+
+    We enforce immutable parameters by only allowing a certain list of basic types.
+
+    """
+
+    allowed = (type(None), float, int, tuple, str, bool, type)
+
+    for param in inspect.signature(model.__class__).parameters.values():
+        assert param.default is inspect._empty or isinstance(param.default, allowed)
 
 
 def check_doc(model):
@@ -296,7 +310,8 @@ def yield_checks(model):
     yield check_str
     yield check_tags
     yield check_set_params_idempotent
-    yield check_init
+    yield check_init_has_default_params
+    yield check_init_params_are_not_mutable
     yield check_doc
     yield check_clone
 


### PR DESCRIPTION
Following our discussion I decided to write a little test that checks that all of our class `__init__` signatures use immutable parameters.