### PR TITLE
Add ML-KNN

### DIFF
--- a/river/ensemble/adaptive_random_forest.py
+++ b/river/ensemble/adaptive_random_forest.py
@@ -264,7 +264,7 @@ class BaseTreeRegressor(HoeffdingTreeRegressor):
         leaf_model: base.Regressor = None,
         model_selector_decay: float = 0.95,
         nominal_attributes: list = None,
-        attr_obs: str = "gaussian",
+        attr_obs: str = "e-bst",
         attr_obs_params: dict = None,
         min_samples_split: int = 5,
         seed=None,
@@ -753,7 +753,7 @@ class AdaptiveRandomForestRegressor(BaseForest, base.Regressor):
     >>> metric = metrics.MAE()
 
     >>> evaluate.progressive_val_score(dataset, model, metric)
-    MAE: 23.320694
+    MAE: 1.870913
 
     """
 
@@ -769,7 +769,7 @@ class AdaptiveRandomForestRegressor(BaseForest, base.Regressor):
         aggregation_method: str = "median",
         lambda_value: int = 6,
         metric: RegressionMetric = MSE(),
-        disable_weighted_vote=False,
+        disable_weighted_vote=True,
         drift_detector: base.DriftDetector = ADWIN(0.001),
         warning_detector: base.DriftDetector = ADWIN(0.01),
         # Tree parameters
@@ -842,7 +842,7 @@ class AdaptiveRandomForestRegressor(BaseForest, base.Regressor):
 
         y_pred = np.zeros(self.n_models)
 
-        if not self.disable_weighted_vote:
+        if not self.disable_weighted_vote and self.aggregation_method != self._MEDIAN:
             weights = np.zeros(self.n_models)
             sum_weights = 0.0
             for idx, model in enumerate(self.models):
@@ -1101,7 +1101,7 @@ class ForestMemberRegressor(BaseForestMember, base.Regressor):
         if self._var.mean.n == 1:
             return 0.5  # The expected error is the normalized mean error
 
-        sd = math.sqrt(self._var.sigma)
+        sd = math.sqrt(self._var.get())
 
         # We assume the error follows a normal distribution -> (empirical rule)
         # 99.73% of the values lie  between [mean - 3*sd, mean + 3*sd]. We

--- a/river/multioutput/__init__.py
+++ b/river/multioutput/__init__.py
@@ -10,5 +10,5 @@ __all__ = [
     "MonteCarloClassifierChain",
     "ProbabilisticClassifierChain",
     "RegressorChain",
-    "MLKNN"
+    "MLKNN",
 ]

--- a/river/multioutput/__init__.py
+++ b/river/multioutput/__init__.py
@@ -3,11 +3,12 @@ from .chain import ClassifierChain
 from .chain import MonteCarloClassifierChain
 from .chain import ProbabilisticClassifierChain
 from .chain import RegressorChain
-
+from .mlknn import MLKNN
 
 __all__ = [
     "ClassifierChain",
     "MonteCarloClassifierChain",
     "ProbabilisticClassifierChain",
     "RegressorChain",
+    "MLKNN"
 ]

--- a/river/multioutput/mlknn.py
+++ b/river/multioutput/mlknn.py
@@ -1,0 +1,231 @@
+from river import base
+from river.utils import dict2numpy
+from collections import Counter, deque
+from collections.abc import Hashable
+import numpy as np
+
+__all__ = [
+    "MLKNN",
+]
+
+def jensen_shannon(p, q, base=None):
+    p = p / norm(p, ord=1)
+    q = q / norm(q, ord=1)
+    m = (p+q) / 2
+    rel_entr_p_m = np.log(p/m).sum(axis=0)
+    rel_entr_q_m = np.log(q/m).sum(axis=0)
+    js = (rel_entr_p_m + rel_entr_q_m) / 2
+    if base is not None:
+        js /= np.log(base)
+    return js
+
+class MLKNN(base.Classifier, base.MultiOutputMixin):
+    __metrics = {
+        'l2': lambda u, v: norm(u-v),
+        'cos': lambda u, v: u.dot(v) / np.linalg.norm(u) / np.linalg.norm(v),
+        'js': jensen_shannon
+    }
+
+    def __init__(self, dim=None, distance_metric='l2', smoothing=1.0, n_neighbors=10, window_size=1000):
+        self.n_neighbors = n_neighbors
+        if not callable(distance_metric):
+            space = distance_metric.lower()
+            if space not in self.__metrics:
+                error = ('''
+                         unrecognized metric for induced vector space:
+                         please provide one of Callable[[dict, dict], float],
+                         'cos', 'l2', or 'js'
+                         ''')
+                raise ValueError(' '.join(error.split()))
+            distance_metric = self.__metrics[space]
+        self.distance_metric = distance_metric
+        self.smoothing = smoothing
+        self.window_size = window_size
+        self.X = deque(maxlen=window_size)
+        self.Y = deque(maxlen=window_size)
+        self.positive_frequencies = Counter()
+        self.negative_frequencies = Counter()
+        self.dim = None
+
+        self._priors = None
+        self._posteriors = None
+        self._deltas = None
+
+    def labels(self):
+        positives = self.positive_frequencies
+        negatives = self.negative_frequencies
+        labels = set(positives.keys()) | set(negatives.keys())
+        return labels
+
+    def _compute_priors(self):
+        positives = self.positive_frequencies
+        negatives = self.negative_frequencies
+        labels = self.labels()
+        positive_priors = dict()
+        negative_priors = dict()
+        s = self.smoothing
+        n = len(self.Y)
+        for l in labels:
+            k = positives[l]
+            p = (s+k) / (s*2+n)
+            positive_priors[l] = p
+            negative_priors[l] = 1-p
+        return positive_priors, negative_priors
+
+    def _knn_query(self, x, k=None):
+        if k is None:
+            k = self.n_neighbors
+        distance = self.distance_metric
+        distances = np.array([distance(x, v) for v in self.X])
+        idx_asc_distance = np.argsort(distances)
+        neighbor_ids = idx_asc_distance[:k]
+        return neighbor_ids, distances[idx_asc_distance][:k]
+
+    def _compute_membership_counts(self, x):
+        x = dict2numpy(x)
+        Y = self.Y
+        yis, yds = self._knn_query(x)
+        deltas = dict()
+        for l in self.labels():
+            delta = 0
+            for yi in yis:
+                y = Y[yi]
+                y_has_label = l in y and y[l]
+                if y_has_label:
+                    delta += 1
+            deltas[l] = delta
+        return deltas
+
+    def _compute_posteriors(self, x, deltas=None):
+        if deltas is None:
+            deltas = self._compute_membership_counts(x)
+        x = dict2numpy(x)
+        x.resize((self.dim,))
+        Y = self.Y
+        s = self.smoothing
+        k = self.n_neighbors
+        negative_posteriors = dict()
+        positive_posteriors = dict()
+        neighbor_ids, neighbor_distances = self._knn_query(x)
+        neighbor_distances += neighbor_distances.min()
+        neighbor_distances /= np.linalg.norm(neighbor_distances)
+        for l, ci in deltas.items():
+            c0 = np.zeros(k+1)
+            c1 = np.zeros(k+1)
+            for yi, yd in zip(neighbor_ids, neighbor_distances):
+                y = Y[yi]
+                c = c1 if l in y and y[l] else c0
+                # This line deviates from the paper, where the count vector is
+                # always incremented by one. instead of being a true "count,"
+                # this implementation adds 2 for very similar entries, and
+                # adds 1/2 for less similar entries.
+                c[ci] += 2 * (1-yd)
+            n0 = s*k + np.sum(c0)
+            n1 = s*k + np.sum(c1)
+            p0 = (s+c0) / n0
+            p1 = (s+c1) / n1
+            positive_posteriors[l] = p1
+            negative_posteriors[l] = p0
+        return positive_posteriors, negative_posteriors
+
+    def learn_one(self, x, y):
+        if isinstance(y, Hashable):
+            y = {y: True}
+        if self.dim is None:
+            self.dim = len(x)
+        x = dict2numpy(x)
+        x.resize((self.dim,))
+        assert x is not None
+        positives = self.positive_frequencies
+        negatives = self.negative_frequencies
+        for t, p in y.items():
+            counter = positives if p else negatives
+            counter[t] += 1
+        self.X.append(x)
+        self.Y.append(y)
+
+        self._priors = None
+        self._posteriors = None
+        self._deltas = None
+
+    def predict_proba_one(self, x):
+        # memoize and retrieve deltas, priors, and posteriors if no training
+        # has occurred since last prediction
+        if self._deltas is None:
+            deltas = self._compute_membership_counts(x)
+            self._deltas = deltas
+        else:
+            deltas = self._deltas
+
+        if self._posteriors is None:
+            pe1s, pe0s = self._compute_posteriors(x, deltas)
+            self._posteriors = pe1s, pe0s
+        else:
+            pe1s, pe0s = self._posteriors
+ 
+        if self._priors is None:
+            ph1s, ph0s = self._compute_priors()
+            self._priors = ph1s, ph0s
+        else:
+            ph1s, ph0s = self._priors
+
+        conclusions = dict()
+        for l, ci in deltas.items():
+            pe1 = pe1s[l][ci]
+            pe0 = pe0s[l][ci]
+            ph1 = ph1s[l]
+            ph0 = ph0s[l]
+            p0 = pe0 * ph0
+            p1 = pe1 * ph1
+            conclusions[l] = {True: p1, False: p0}
+        return conclusions
+
+    def predict_one(self, x):
+        posteriors = self.predict_proba_one(x)
+        return {l: p[True] > p[False] for l, p in posteriors.items()}
+
+    def reset(self):
+        self.__init__(
+            distance_metric=self.distance_metric,
+            smoothing=self.smoothing,
+            n_neighbors=self.n_neighbors,
+            window_size=self.window_size
+        )
+
+def crossvalidate():
+    from sklearn import datasets
+    from tqdm import tqdm
+    from river.multioutput import ClassifierChain
+    from river.linear_model import LogisticRegression
+    from river.stream import iter_sklearn_dataset
+    from river.metrics import HammingLoss
+
+    print('retrieve dataset...')
+    samples = datasets.fetch_openml('yeast', version=4)
+    print('initialize candidates...')
+    logreg = LogisticRegression()
+    baseline = ClassifierChain(model=logreg, order=list(range(14)))
+    mlknn = MLKNN(distance_metric='cos', window_size=len(samples))
+    dataset = iter_sklearn_dataset(dataset=samples, shuffle=True, seed=42)
+    mlknn_performance = HammingLoss()
+    baseline_performance = HammingLoss()
+    print('evaluate ML-KNN vs baseline...')
+    for x, y in tqdm(dataset, total=len(samples.data)):
+        y = {i: p == 'TRUE' for i, (t, p) in enumerate(y.items())}
+        baseline.learn_one(x, y)
+        # evaluate/train baseline
+        y_hat_baseline = baseline.predict_one(x)
+        baseline_performance.update(y, y_hat_baseline)
+        # evaluate/train ML-KNN
+        mlknn.learn_one(x, y)
+        y_hat_mlknn = mlknn.predict_one(x)
+        y_hat_mlknn.update({t: False for t in y.keys() if t not in y_hat_mlknn})
+        mlknn_performance.update(y, y_hat_mlknn)
+
+    print(f'ClassifierChain: {baseline_performance}')
+    print(f'MLKNN: {mlknn_performance}')
+
+if __name__ == '__main__':
+    crossvalidate()
+
+

--- a/river/multioutput/mlknn.py
+++ b/river/multioutput/mlknn.py
@@ -9,8 +9,8 @@ __all__ = [
 ]
 
 def jensen_shannon(p, q, base=None):
-    p = p / norm(p, ord=1)
-    q = q / norm(q, ord=1)
+    p = p / np.linalg.norm(p, ord=1)
+    q = q / np.linalg.norm(q, ord=1)
     m = (p+q) / 2
     rel_entr_p_m = np.log(p/m).sum(axis=0)
     rel_entr_q_m = np.log(q/m).sum(axis=0)
@@ -48,7 +48,7 @@ class MLKNN(base.Classifier, base.MultiOutputMixin):
     """
 
     __metrics = {
-        'l2': lambda u, v: norm(u-v),
+        'l2': lambda u, v: np.linalg.norm(u-v),
         'cos': lambda u, v: u.dot(v) / np.linalg.norm(u) / np.linalg.norm(v),
         'js': jensen_shannon
     }

--- a/river/multioutput/mlknn.py
+++ b/river/multioutput/mlknn.py
@@ -76,8 +76,6 @@ class MLKNN(base.Classifier, base.MultiOutputMixin):
         self.dim = None
 
         self._priors = None
-        self._posteriors = None
-        self._deltas = None
 
     def labels(self):
         positives = self.positive_frequencies
@@ -173,30 +171,17 @@ class MLKNN(base.Classifier, base.MultiOutputMixin):
         self.Y.append(y)
 
         self._priors = None
-        self._posteriors = None
-        self._deltas = None
 
     def predict_proba_one(self, x):
         # memoize and retrieve deltas, priors, and posteriors if no training
         # has occurred since last prediction
-        if self._deltas is None:
-            deltas = self._compute_membership_counts(x)
-            self._deltas = deltas
-        else:
-            deltas = self._deltas
-
-        if self._posteriors is None:
-            pe1s, pe0s = self._compute_posteriors(x, deltas)
-            self._posteriors = pe1s, pe0s
-        else:
-            pe1s, pe0s = self._posteriors
- 
+        deltas = self._compute_membership_counts(x)
+        pe1s, pe0s = self._compute_posteriors(x, deltas)
         if self._priors is None:
             ph1s, ph0s = self._compute_priors()
             self._priors = ph1s, ph0s
         else:
             ph1s, ph0s = self._priors
-
         conclusions = dict()
         for l, ci in deltas.items():
             pe1 = pe1s[l][ci]

--- a/river/multioutput/mlknn.py
+++ b/river/multioutput/mlknn.py
@@ -44,7 +44,7 @@ class MLKNN(base.Classifier, base.MultiOutputMixin):
         If a value of None is given, the search space will grow arbitrarily
         large, but also be unbounded. Useful to prevent search in the induced
         vector space from becoming intractable and for prioritization of the
-        most recent instances encountered during training during prediction.
+        most recent instances encountered during prediction.
     """
 
     __metrics = {

--- a/river/multioutput/mlknn.py
+++ b/river/multioutput/mlknn.py
@@ -91,7 +91,6 @@ class MLKNN(base.Classifier, base.MultiOutputMixin):
 
     def _compute_priors(self):
         positives = self.positive_frequencies
-        negatives = self.negative_frequencies
         labels = self.labels()
         positive_priors = dict()
         negative_priors = dict()


### PR DESCRIPTION
hi all

I was working on a multilabel classification project, and I thought to myself, it'd be very nice if `online-ml/river` had an incremental version of `skmultilearn.adapt.MLkNN`. I missed it very much in `river` because I wanted a version that would learn incrementally, and I wanted to know how it worked anyway, so I made my own implementation which is more familiar to `river`'s interface. While I realize that `river.neighbors` already included a multi-output classification algorithm that operates on this premise, it didn't perform as well as the `skmultilearn` implementation for recalling multiple labels for my application; this one gets comparable results on the yeast dataset to the classifier chain already included in `river.multioutput`

I hope this is to your satisfaction, I wasn't really sure how to integrate things with the test suite so I included an evaluation script in my implementation of the module

I want to get back to work on my project, though, so I'll wait for feedback on how to proceed with a more idiomatic set of unit tests that play a bit nicer with what's being used upstream