### PR TITLE
Enforce SRP reproducibility for different Numpy versions

### DIFF
--- a/river/ensemble/streaming_random_patches.py
+++ b/river/ensemble/streaming_random_patches.py
@@ -133,7 +133,7 @@ class SRPClassifier(base.WrapperMixin, base.EnsembleMixin, base.Classifier):
         if warning_detector is None:
             warning_detector = ADWIN(delta=1e-4)
 
-        if disable_detector == 'off':
+        if disable_detector == "off":
             pass
         elif disable_detector == "drift":
             drift_detector = None
@@ -141,8 +141,10 @@ class SRPClassifier(base.WrapperMixin, base.EnsembleMixin, base.Classifier):
         elif disable_detector == "warning":
             warning_detector = None
         else:
-            raise AttributeError(f"{disable_detector} is not a valid value for disable_detector.\n"
-                                 f"Valid options are: 'off', 'drift', 'warning'")
+            raise AttributeError(
+                f"{disable_detector} is not a valid value for disable_detector.\n"
+                f"Valid options are: 'off', 'drift', 'warning'"
+            )
         self.disable_detector = disable_detector
 
         if metric is None:
@@ -231,7 +233,9 @@ class SRPClassifier(base.WrapperMixin, base.EnsembleMixin, base.Classifier):
             y_proba_temp = model.predict_proba_one(x)
             metric_value = model.metric.get()
             if not self.disable_weighted_vote and metric_value > 0.0:
-                y_proba_temp = {k: val * metric_value for k, val in y_proba_temp.items()}
+                y_proba_temp = {
+                    k: val * metric_value for k, val in y_proba_temp.items()
+                }
             y_pred.update(y_proba_temp)
 
         total = sum(y_pred.values())
@@ -312,7 +316,9 @@ class SRPClassifier(base.WrapperMixin, base.EnsembleMixin, base.Classifier):
     def _init_ensemble(self, features: list):
         self._generate_subspaces(features=features)
 
-        subspace_indexes = np.arange(self.n_models)  # For matching subspaces with ensemble members
+        subspace_indexes = np.arange(
+            self.n_models
+        )  # For matching subspaces with ensemble members
         if (
             self.training_method == self._TRAIN_RANDOM_PATCHES
             or self.training_method == self._TRAIN_RANDOM_SUBSPACES
@@ -396,7 +402,9 @@ class StreamingRandomPatchesBaseLearner:
         self.n_warnings_detected = 0
 
         # Background learner
-        self._background_learner = None  # type: typing.Optional[StreamingRandomPatchesBaseLearner]
+        self._background_learner = (
+            None
+        )  # type: typing.Optional[StreamingRandomPatchesBaseLearner]
         self._background_learner_class = StreamingRandomPatchesBaseLearner
 
         # Nominal attributes
@@ -420,7 +428,9 @@ class StreamingRandomPatchesBaseLearner:
         if self.features is not None:
             # Select the subset of features to use
             x_subset = {k: x[k] for k in self.features}
-            if self._set_nominal_attributes and hasattr(self.model, "nominal_attributes"):
+            if self._set_nominal_attributes and hasattr(
+                self.model, "nominal_attributes"
+            ):
                 self.model.nominal_attributes = list(
                     set(self.features).intersection(set(self.nominal_attributes))
                 )
@@ -467,7 +477,9 @@ class StreamingRandomPatchesBaseLearner:
             if self.drift_detector.change_detected:
                 self.n_drifts_detected += 1
                 # There was a change, reset the model
-                self.reset(all_features=all_features, n_samples_seen=n_samples_seen, rng=rng)
+                self.reset(
+                    all_features=all_features, n_samples_seen=n_samples_seen, rng=rng
+                )
 
     def predict_proba_one(self, x):
         # Select the features to use
@@ -475,12 +487,16 @@ class StreamingRandomPatchesBaseLearner:
 
         return self.model.predict_proba_one(x_subset)
 
-    def _trigger_warning(self, all_features, n_samples_seen: int, rng: np.random.Generator):
+    def _trigger_warning(
+        self, all_features, n_samples_seen: int, rng: np.random.Generator
+    ):
         # Randomly generate a new subspace from all the original features
         subspace = (
             None
             if self.features is None
-            else random_subspace(all_features=all_features, k=len(self.features), rng=rng)
+            else random_subspace(
+                all_features=all_features, k=len(self.features), rng=rng
+            )
         )
 
         # Initialize the background learner
@@ -516,7 +532,9 @@ class StreamingRandomPatchesBaseLearner:
             subspace = (
                 None
                 if self.features is None
-                else random_subspace(all_features=all_features, k=len(self.features), rng=rng)
+                else random_subspace(
+                    all_features=all_features, k=len(self.features), rng=rng
+                )
             )
             # Reset model
             self.model = self.model.clone()

--- a/river/ensemble/streaming_random_patches.py
+++ b/river/ensemble/streaming_random_patches.py
@@ -423,7 +423,6 @@ class StreamingRandomPatchesBaseLearner:
         n_samples_seen: int,
         rng: np.random.Generator,
     ):
-        # print(sample_weight)
         all_features = [feature for feature in x.keys()]
         if self.features is not None:
             # Select the subset of features to use

--- a/river/ensemble/streaming_random_patches.py
+++ b/river/ensemble/streaming_random_patches.py
@@ -233,9 +233,7 @@ class SRPClassifier(base.WrapperMixin, base.EnsembleMixin, base.Classifier):
             y_proba_temp = model.predict_proba_one(x)
             metric_value = model.metric.get()
             if not self.disable_weighted_vote and metric_value > 0.0:
-                y_proba_temp = {
-                    k: val * metric_value for k, val in y_proba_temp.items()
-                }
+                y_proba_temp = {k: val * metric_value for k, val in y_proba_temp.items()}
             y_pred.update(y_proba_temp)
 
         total = sum(y_pred.values())
@@ -316,9 +314,7 @@ class SRPClassifier(base.WrapperMixin, base.EnsembleMixin, base.Classifier):
     def _init_ensemble(self, features: list):
         self._generate_subspaces(features=features)
 
-        subspace_indexes = np.arange(
-            self.n_models
-        )  # For matching subspaces with ensemble members
+        subspace_indexes = np.arange(self.n_models)  # For matching subspaces with ensemble members
         if (
             self.training_method == self._TRAIN_RANDOM_PATCHES
             or self.training_method == self._TRAIN_RANDOM_SUBSPACES
@@ -402,9 +398,7 @@ class StreamingRandomPatchesBaseLearner:
         self.n_warnings_detected = 0
 
         # Background learner
-        self._background_learner = (
-            None
-        )  # type: typing.Optional[StreamingRandomPatchesBaseLearner]
+        self._background_learner = None  # type: typing.Optional[StreamingRandomPatchesBaseLearner]
         self._background_learner_class = StreamingRandomPatchesBaseLearner
 
         # Nominal attributes
@@ -427,9 +421,7 @@ class StreamingRandomPatchesBaseLearner:
         if self.features is not None:
             # Select the subset of features to use
             x_subset = {k: x[k] for k in self.features}
-            if self._set_nominal_attributes and hasattr(
-                self.model, "nominal_attributes"
-            ):
+            if self._set_nominal_attributes and hasattr(self.model, "nominal_attributes"):
                 self.model.nominal_attributes = list(
                     set(self.features).intersection(set(self.nominal_attributes))
                 )
@@ -476,9 +468,7 @@ class StreamingRandomPatchesBaseLearner:
             if self.drift_detector.change_detected:
                 self.n_drifts_detected += 1
                 # There was a change, reset the model
-                self.reset(
-                    all_features=all_features, n_samples_seen=n_samples_seen, rng=rng
-                )
+                self.reset(all_features=all_features, n_samples_seen=n_samples_seen, rng=rng)
 
     def predict_proba_one(self, x):
         # Select the features to use
@@ -486,16 +476,12 @@ class StreamingRandomPatchesBaseLearner:
 
         return self.model.predict_proba_one(x_subset)
 
-    def _trigger_warning(
-        self, all_features, n_samples_seen: int, rng: np.random.Generator
-    ):
+    def _trigger_warning(self, all_features, n_samples_seen: int, rng: np.random.Generator):
         # Randomly generate a new subspace from all the original features
         subspace = (
             None
             if self.features is None
-            else random_subspace(
-                all_features=all_features, k=len(self.features), rng=rng
-            )
+            else random_subspace(all_features=all_features, k=len(self.features), rng=rng)
         )
 
         # Initialize the background learner
@@ -531,9 +517,7 @@ class StreamingRandomPatchesBaseLearner:
             subspace = (
                 None
                 if self.features is None
-                else random_subspace(
-                    all_features=all_features, k=len(self.features), rng=rng
-                )
+                else random_subspace(all_features=all_features, k=len(self.features), rng=rng)
             )
             # Reset model
             self.model = self.model.clone()


### PR DESCRIPTION
This PR fixes a bug where the Streaming Random Patches classifier resulted in different behavior for different `numpy` versions. In newer numpy versions the `poisson` method provides different values (sampling) which resulted in internal models. 

For context, `numpy` made changes in the random number generation. From Numpy's [documentation](https://numpy.org/doc/stable/reference/random/index.html#quick-start):

> Call default_rng to get a new instance of a Generator, then call its methods to obtain samples from different distributions. By default, Generator uses bits provided by PCG64 which has better statistical properties than the legacy MT19937 used in RandomState.

For more information: [Legacy Random Generation](https://numpy.org/doc/stable/reference/random/legacy.html)

This seems to be the root cause of the unexpected behavior described in #443.

This PR covers:

- Replacement in SRP of `RandomState` by `Generator` for sampling via `poisson`.
- Recover the option to disable drift/warning detection which was lost in previous changes.
- Minor improvements (non-functional changes).
- Re-factor the SRP example to account for nominal attributes from the `Agrawal` generator.
- Fixes #443 