### PR TITLE
Add no learn parameter to pipeline transformations

### DIFF
--- a/river/compose/pipeline.py
+++ b/river/compose/pipeline.py
@@ -324,7 +324,7 @@ class Pipeline(base.Estimator):
 
         return self
 
-    def _transform_one(self, x: dict, no_learn: bool=False):
+    def _transform_one(self, x: dict, no_learn: bool = False):
         """This methods takes care of applying the first n - 1 steps of the pipeline, which are
         supposedly transformers. It also returns the final step so that other functions can do
         something with it.
@@ -351,7 +351,7 @@ class Pipeline(base.Estimator):
 
         return x, next(steps)
 
-    def transform_one(self, x: dict, no_learn: bool=False):
+    def transform_one(self, x: dict, no_learn: bool = False):
         """Apply each transformer in the pipeline to some features.
 
         The final step in the pipeline will be applied if it is a transformer. If not, then it will
@@ -364,15 +364,15 @@ class Pipeline(base.Estimator):
             return final_step.transform_one(x=x)
         return x
 
-    def predict_one(self, x: dict, no_learn: bool=False):
+    def predict_one(self, x: dict, no_learn: bool = False):
         x, final_step = self._transform_one(x=x, no_learn=no_learn)
         return final_step.predict_one(x=x)
 
-    def predict_proba_one(self, x: dict, no_learn: bool=False):
+    def predict_proba_one(self, x: dict, no_learn: bool = False):
         x, final_step = self._transform_one(x=x, no_learn=no_learn)
         return final_step.predict_proba_one(x=x)
 
-    def score_one(self, x: dict, no_learn: bool=False):
+    def score_one(self, x: dict, no_learn: bool = False):
         x, final_step = self._transform_one(x=x, no_learn=no_learn)
         return final_step.score_one(x=x)
 
@@ -525,7 +525,7 @@ class Pipeline(base.Estimator):
 
         return self
 
-    def _transform_many(self, X: pd.DataFrame, no_learn: bool=False):
+    def _transform_many(self, X: pd.DataFrame, no_learn: bool = False):
         """This methods takes care of applying the first n - 1 steps of the pipeline, which are
         supposedly transformers. It also returns the final step so that other functions can do
         something with it.
@@ -565,11 +565,11 @@ class Pipeline(base.Estimator):
             return final_step.transform_many(X=X)
         return X
 
-    def predict_many(self, X: pd.DataFrame, no_learn: bool=False):
+    def predict_many(self, X: pd.DataFrame, no_learn: bool = False):
         X, final_step = self._transform_many(X=X, no_learn=no_learn)
         return final_step.predict_many(X=X)
 
-    def predict_proba_many(self, X: pd.DataFrame, no_learn: bool=False):
+    def predict_proba_many(self, X: pd.DataFrame, no_learn: bool = False):
         X, final_step = self._transform_many(X=X, no_learn=no_learn)
         return final_step.predict_proba_many(X=X)
 

--- a/river/compose/pipeline.py
+++ b/river/compose/pipeline.py
@@ -324,7 +324,7 @@ class Pipeline(base.Estimator):
 
         return self
 
-    def _transform_one(self, x: dict, no_learn: bool = False):
+    def _transform_one(self, x: dict, learn_unsupervised: bool = True):
         """This methods takes care of applying the first n - 1 steps of the pipeline, which are
         supposedly transformers. It also returns the final step so that other functions can do
         something with it.
@@ -341,17 +341,17 @@ class Pipeline(base.Estimator):
             # specific to online machine learning.
             if isinstance(t, union.TransformerUnion):
                 for sub_t in t.transformers.values():
-                    if not sub_t._supervised and not no_learn:
+                    if not sub_t._supervised and learn_unsupervised:
                         sub_t.learn_one(x=x)
 
-            elif not t._supervised and not no_learn:
+            elif not t._supervised and learn_unsupervised:
                 t.learn_one(x=x)
 
             x = t.transform_one(x=x)
 
         return x, next(steps)
 
-    def transform_one(self, x: dict, no_learn: bool = False):
+    def transform_one(self, x: dict, learn_unsupervised: bool = True):
         """Apply each transformer in the pipeline to some features.
 
         The final step in the pipeline will be applied if it is a transformer. If not, then it will
@@ -359,21 +359,21 @@ class Pipeline(base.Estimator):
         that precede the final step are assumed to all be transformers.
 
         """
-        x, final_step = self._transform_one(x=x, no_learn=no_learn)
+        x, final_step = self._transform_one(x=x, learn_unsupervised=learn_unsupervised)
         if isinstance(final_step, base.Transformer):
             return final_step.transform_one(x=x)
         return x
 
-    def predict_one(self, x: dict, no_learn: bool = False):
-        x, final_step = self._transform_one(x=x, no_learn=no_learn)
+    def predict_one(self, x: dict, learn_unsupervised: bool = True):
+        x, final_step = self._transform_one(x=x, learn_unsupervised=learn_unsupervised)
         return final_step.predict_one(x=x)
 
-    def predict_proba_one(self, x: dict, no_learn: bool = False):
-        x, final_step = self._transform_one(x=x, no_learn=no_learn)
+    def predict_proba_one(self, x: dict, learn_unsupervised: bool = True):
+        x, final_step = self._transform_one(x=x, learn_unsupervised=learn_unsupervised)
         return final_step.predict_proba_one(x=x)
 
-    def score_one(self, x: dict, no_learn: bool = False):
-        x, final_step = self._transform_one(x=x, no_learn=no_learn)
+    def score_one(self, x: dict, learn_unsupervised: bool = True):
+        x, final_step = self._transform_one(x=x, learn_unsupervised=learn_unsupervised)
         return final_step.score_one(x=x)
 
     def forecast(self, horizon: int, xs: typing.List[dict] = None):
@@ -525,7 +525,7 @@ class Pipeline(base.Estimator):
 
         return self
 
-    def _transform_many(self, X: pd.DataFrame, no_learn: bool = False):
+    def _transform_many(self, X: pd.DataFrame, learn_unsupervised: bool = True):
         """This methods takes care of applying the first n - 1 steps of the pipeline, which are
         supposedly transformers. It also returns the final step so that other functions can do
         something with it.
@@ -542,10 +542,10 @@ class Pipeline(base.Estimator):
             # specific to online machine learning.
             if isinstance(t, union.TransformerUnion):
                 for sub_t in t.transformers.values():
-                    if not sub_t._supervised and not no_learn:
+                    if not sub_t._supervised and learn_unsupervised:
                         sub_t.learn_many(X=X)
 
-            elif not t._supervised and not no_learn:
+            elif not t._supervised and learn_unsupervised:
                 t.learn_many(X=X)
 
             X = t.transform_many(X=X)
@@ -565,12 +565,12 @@ class Pipeline(base.Estimator):
             return final_step.transform_many(X=X)
         return X
 
-    def predict_many(self, X: pd.DataFrame, no_learn: bool = False):
-        X, final_step = self._transform_many(X=X, no_learn=no_learn)
+    def predict_many(self, X: pd.DataFrame, learn_unsupervised: bool = True):
+        X, final_step = self._transform_many(X=X, learn_unsupervised=learn_unsupervised)
         return final_step.predict_many(X=X)
 
-    def predict_proba_many(self, X: pd.DataFrame, no_learn: bool = False):
-        X, final_step = self._transform_many(X=X, no_learn=no_learn)
+    def predict_proba_many(self, X: pd.DataFrame, learn_unsupervised: bool = True):
+        X, final_step = self._transform_many(X=X, learn_unsupervised=learn_unsupervised)
         return final_step.predict_proba_many(X=X)
 
     def draw(self):

--- a/river/compose/pipeline.py
+++ b/river/compose/pipeline.py
@@ -324,7 +324,7 @@ class Pipeline(base.Estimator):
 
         return self
 
-    def _transform_one(self, x: dict):
+    def _transform_one(self, x: dict, no_learn: bool=False):
         """This methods takes care of applying the first n - 1 steps of the pipeline, which are
         supposedly transformers. It also returns the final step so that other functions can do
         something with it.
@@ -341,17 +341,17 @@ class Pipeline(base.Estimator):
             # specific to online machine learning.
             if isinstance(t, union.TransformerUnion):
                 for sub_t in t.transformers.values():
-                    if not sub_t._supervised:
+                    if not sub_t._supervised and not no_learn:
                         sub_t.learn_one(x=x)
 
-            elif not t._supervised:
+            elif not t._supervised and not no_learn:
                 t.learn_one(x=x)
 
             x = t.transform_one(x=x)
 
         return x, next(steps)
 
-    def transform_one(self, x: dict):
+    def transform_one(self, x: dict, no_learn: bool=False):
         """Apply each transformer in the pipeline to some features.
 
         The final step in the pipeline will be applied if it is a transformer. If not, then it will
@@ -359,21 +359,21 @@ class Pipeline(base.Estimator):
         that precede the final step are assumed to all be transformers.
 
         """
-        x, final_step = self._transform_one(x=x)
+        x, final_step = self._transform_one(x=x, no_learn=no_learn)
         if isinstance(final_step, base.Transformer):
             return final_step.transform_one(x=x)
         return x
 
-    def predict_one(self, x: dict):
-        x, final_step = self._transform_one(x=x)
+    def predict_one(self, x: dict, no_learn: bool=False):
+        x, final_step = self._transform_one(x=x, no_learn=no_learn)
         return final_step.predict_one(x=x)
 
-    def predict_proba_one(self, x: dict):
-        x, final_step = self._transform_one(x=x)
+    def predict_proba_one(self, x: dict, no_learn: bool=False):
+        x, final_step = self._transform_one(x=x, no_learn=no_learn)
         return final_step.predict_proba_one(x=x)
 
-    def score_one(self, x: dict):
-        x, final_step = self._transform_one(x=x)
+    def score_one(self, x: dict, no_learn: bool=False):
+        x, final_step = self._transform_one(x=x, no_learn=no_learn)
         return final_step.score_one(x=x)
 
     def forecast(self, horizon: int, xs: typing.List[dict] = None):
@@ -525,7 +525,7 @@ class Pipeline(base.Estimator):
 
         return self
 
-    def _transform_many(self, X: pd.DataFrame):
+    def _transform_many(self, X: pd.DataFrame, no_learn: bool=False):
         """This methods takes care of applying the first n - 1 steps of the pipeline, which are
         supposedly transformers. It also returns the final step so that other functions can do
         something with it.
@@ -542,10 +542,10 @@ class Pipeline(base.Estimator):
             # specific to online machine learning.
             if isinstance(t, union.TransformerUnion):
                 for sub_t in t.transformers.values():
-                    if not sub_t._supervised:
+                    if not sub_t._supervised and not no_learn:
                         sub_t.learn_many(X=X)
 
-            elif not t._supervised:
+            elif not t._supervised and not no_learn:
                 t.learn_many(X=X)
 
             X = t.transform_many(X=X)
@@ -565,12 +565,12 @@ class Pipeline(base.Estimator):
             return final_step.transform_many(X=X)
         return X
 
-    def predict_many(self, X: pd.DataFrame):
-        X, final_step = self._transform_many(X=X)
+    def predict_many(self, X: pd.DataFrame, no_learn: bool=False):
+        X, final_step = self._transform_many(X=X, no_learn=no_learn)
         return final_step.predict_many(X=X)
 
-    def predict_proba_many(self, X: pd.DataFrame):
-        X, final_step = self._transform_many(X=X)
+    def predict_proba_many(self, X: pd.DataFrame, no_learn: bool=False):
+        X, final_step = self._transform_many(X=X, no_learn=no_learn)
         return final_step.predict_proba_many(X=X)
 
     def draw(self):

--- a/river/compose/test_.py
+++ b/river/compose/test_.py
@@ -1,3 +1,5 @@
+import pandas as pd
+
 from river import compose, linear_model, preprocessing
 
 
@@ -49,3 +51,43 @@ def test_union_funcs():
     for i, pipeline in enumerate(pipelines):
         print(i, str(pipeline))
         assert str(pipeline) == "a + b"
+
+
+def test_no_learn_predict_one():
+    pipeline = compose.Pipeline(
+        ("scale", preprocessing.StandardScaler()),
+        ("lin_reg", linear_model.LinearRegression()),
+    )
+
+    dataset = [(dict(a=x, b=x), x) for x in range(100)]
+
+    for x, y in dataset:
+        counts_pre = dict(pipeline.steps["scale"].counts)
+        pipeline.predict_one(x, no_learn=False)
+        counts_post = dict(pipeline.steps["scale"].counts)
+        pipeline.predict_one(x, no_learn=True)
+        counts_no_learn = dict(pipeline.steps["scale"].counts)
+
+        assert counts_pre != counts_post
+        assert counts_post == counts_no_learn
+
+
+def test_no_learn_predict_many():
+    pipeline = compose.Pipeline(
+        ("scale", preprocessing.StandardScaler()),
+        ("lin_reg", linear_model.LinearRegression()),
+    )
+
+    dataset = [(dict(a=x, b=x), x) for x in range(100)]
+
+    for i in range(0, len(dataset), 5):
+        X = pd.DataFrame([x for x, y in dataset][i : i + 5])
+
+        counts_pre = dict(pipeline.steps["scale"].counts)
+        pipeline.predict_many(X, no_learn=False)
+        counts_post = dict(pipeline.steps["scale"].counts)
+        pipeline.predict_many(X, no_learn=True)
+        counts_no_learn = dict(pipeline.steps["scale"].counts)
+
+        assert counts_pre != counts_post
+        assert counts_post == counts_no_learn

--- a/river/compose/test_.py
+++ b/river/compose/test_.py
@@ -53,7 +53,7 @@ def test_union_funcs():
         assert str(pipeline) == "a + b"
 
 
-def test_no_learn_predict_one():
+def test_no_learn_unsupervised_predict_one():
     pipeline = compose.Pipeline(
         ("scale", preprocessing.StandardScaler()),
         ("lin_reg", linear_model.LinearRegression()),
@@ -63,16 +63,16 @@ def test_no_learn_predict_one():
 
     for x, y in dataset:
         counts_pre = dict(pipeline.steps["scale"].counts)
-        pipeline.predict_one(x, no_learn=False)
+        pipeline.predict_one(x, learn_unsupervised=True)
         counts_post = dict(pipeline.steps["scale"].counts)
-        pipeline.predict_one(x, no_learn=True)
+        pipeline.predict_one(x, learn_unsupervised=False)
         counts_no_learn = dict(pipeline.steps["scale"].counts)
 
         assert counts_pre != counts_post
         assert counts_post == counts_no_learn
 
 
-def test_no_learn_predict_many():
+def test_no_learn_unsupervised_predict_many():
     pipeline = compose.Pipeline(
         ("scale", preprocessing.StandardScaler()),
         ("lin_reg", linear_model.LinearRegression()),
@@ -84,9 +84,9 @@ def test_no_learn_predict_many():
         X = pd.DataFrame([x for x, y in dataset][i : i + 5])
 
         counts_pre = dict(pipeline.steps["scale"].counts)
-        pipeline.predict_many(X, no_learn=False)
+        pipeline.predict_many(X, learn_unsupervised=True)
         counts_post = dict(pipeline.steps["scale"].counts)
-        pipeline.predict_many(X, no_learn=True)
+        pipeline.predict_many(X, learn_unsupervised=False)
         counts_no_learn = dict(pipeline.steps["scale"].counts)
 
         assert counts_pre != counts_post


### PR DESCRIPTION
As described in #499 it's not possible to predict without updating the scalers. This PR adds the `no_learn` parameter that avoids training the non-supervised parts.

I'm not sure this is the best solution so lets have a discussion on this.

Firstly without beeing a "clean code" zealot I still feel like adding binary arguments should generally be avoided in favour of separate methods with descriptive naming - is there no better name for the process of calculating a predictions while also updating weights than `predict_one`? Backwards compatibility notwithstanding. Or should we name the non-learning methods `predict_nolearn_one`, for example?

Secondly, if this is the proper solution - should it rather be named `learn` or `update_transformers` and default to true? As an added negation also adds some unnecessary complexity.