### PR TITLE
implement neat repr for TimeRolling

### DIFF
--- a/river/metrics/rolling.py
+++ b/river/metrics/rolling.py
@@ -34,11 +34,10 @@ class Rolling(base.WrapperMetric, utils.Window):
 
     >>> for yt, yp in zip(y_true, y_pred):
     ...     print(metric.update(yt, yp))
-    Rolling of size 2 MSE: 0.25
-    Rolling of size 2 MSE: 0.25
-    Rolling of size 2 MSE: 0.125
-    Rolling of size 2 MSE: 0.5
-
+    MSE: 0.25   Metric rolling window size: 2
+    MSE: 0.25   Metric rolling window size: 2
+    MSE: 0.125  Metric rolling window size: 2
+    MSE: 0.5    Metric rolling window size: 2
     """
 
     def __init__(self, metric: base.Metric, window_size: int):
@@ -69,4 +68,4 @@ class Rolling(base.WrapperMetric, utils.Window):
     def __repr__(self):
         if isinstance(self.metric, report.ClassificationReport):
             return self.metric.__repr__()
-        return f"Rolling of size {self.window_size} {str(self.metric)}"
+        return f"{str(self.metric)}\tMetric rolling window size: {self.window_size}"

--- a/river/metrics/rolling.py
+++ b/river/metrics/rolling.py
@@ -34,10 +34,10 @@ class Rolling(base.WrapperMetric, utils.Window):
 
     >>> for yt, yp in zip(y_true, y_pred):
     ...     print(metric.update(yt, yp))
-    MSE: 0.25   Metric rolling window size: 2
-    MSE: 0.25   Metric rolling window size: 2
-    MSE: 0.125  Metric rolling window size: 2
-    MSE: 0.5    Metric rolling window size: 2
+    MSE: 0.25   (rolling 2)
+    MSE: 0.25   (rolling 2)
+    MSE: 0.125  (rolling 2)
+    MSE: 0.5    (rolling 2)
     """
 
     def __init__(self, metric: base.Metric, window_size: int):
@@ -68,4 +68,4 @@ class Rolling(base.WrapperMetric, utils.Window):
     def __repr__(self):
         if isinstance(self.metric, report.ClassificationReport):
             return self.metric.__repr__()
-        return f"{str(self.metric)}\tMetric rolling window size: {self.window_size}"
+        return f"{str(self.metric)}\t(rolling {self.window_size})"

--- a/river/metrics/time_rolling.py
+++ b/river/metrics/time_rolling.py
@@ -32,10 +32,10 @@ class TimeRolling(base.WrapperMetric):
     >>> for yt, yp, day in zip(y_true, y_pred, days):
     ...     t = dt.datetime(2019, 1, day)
     ...     print(metric.update(yt, yp, t))
-    MAE: 0.5    Metric rolling window period: 2 days, 0:00:00
-    MAE: 0.5    Metric rolling window period: 2 days, 0:00:00
-    MAE: 0.25   Metric rolling window period: 2 days, 0:00:00
-    MAE: 1. Metric rolling window period: 2 days, 0:00:00
+    MAE: 0.5    (rolling 2 days, 0:00:00)
+    MAE: 0.5    (rolling 2 days, 0:00:00)
+    MAE: 0.25   (rolling 2 days, 0:00:00)
+    MAE: 1. (rolling 2 days, 0:00:00)
 
     """
 
@@ -79,4 +79,4 @@ class TimeRolling(base.WrapperMetric):
     def __repr__(self):
         if isinstance(self.metric, report.ClassificationReport):
             return self.metric.__repr__()
-        return f"{str(self.metric)}\tMetric rolling window period: {self.period}"
+        return f"{str(self.metric)}\t(rolling {self.period})"

--- a/river/metrics/time_rolling.py
+++ b/river/metrics/time_rolling.py
@@ -2,7 +2,7 @@ import bisect
 import datetime as dt
 import typing
 
-from . import base
+from . import base, report
 
 __all__ = ["TimeRolling"]
 
@@ -32,10 +32,10 @@ class TimeRolling(base.WrapperMetric):
     >>> for yt, yp, day in zip(y_true, y_pred, days):
     ...     t = dt.datetime(2019, 1, day)
     ...     print(metric.update(yt, yp, t))
-    MAE: 0.5
-    MAE: 0.5
-    MAE: 0.25
-    MAE: 1.
+    MAE: 0.5    Metric rolling window period: 2 days, 0:00:00
+    MAE: 0.5    Metric rolling window period: 2 days, 0:00:00
+    MAE: 0.25   Metric rolling window period: 2 days, 0:00:00
+    MAE: 1. Metric rolling window period: 2 days, 0:00:00
 
     """
 
@@ -75,3 +75,8 @@ class TimeRolling(base.WrapperMetric):
 
     def revert(self, y_true, y_pred):
         raise NotImplementedError
+
+    def __repr__(self):
+        if isinstance(self.metric, report.ClassificationReport):
+            return self.metric.__repr__()
+        return f"{str(self.metric)}\tMetric rolling window period: {self.period}"

--- a/river/time_series/snarimax.py
+++ b/river/time_series/snarimax.py
@@ -261,7 +261,7 @@ class SNARIMAX(base.Forecaster):
     ...     metric = metric.update(y, y_pred[0])
 
     >>> metric
-    MAE: 11.636563  Metric rolling window size: 12
+    MAE: 11.636563  (rolling 12)
 
     >>> horizon = 12
     >>> future = [

--- a/river/time_series/snarimax.py
+++ b/river/time_series/snarimax.py
@@ -261,7 +261,7 @@ class SNARIMAX(base.Forecaster):
     ...     metric = metric.update(y, y_pred[0])
 
     >>> metric
-    Rolling of size 12 MAE: 11.636563
+    MAE: 11.636563  Metric rolling window size: 12
 
     >>> horizon = 12
     >>> future = [


### PR DESCRIPTION
<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->

Add a neat \_\_repr\_\_ for TimeRolling metric wrapper (see doctest)

Have been using it in my work for a while. 
I found it more readable than the current \_\_repr\_\_ for Rolling. If you like, I can align Rolling \_\_repr\_\_ for consistency.