### PR TITLE
Make HDDM drift detectors report downward changes

### DIFF
--- a/river/drift/hddm_a.py
+++ b/river/drift/hddm_a.py
@@ -132,13 +132,19 @@ class HDDM_A(DriftDetector):
             self._in_concept_change = False
             self._in_warning_zone = False
 
-        if self.two_sided_test and self._mean_decr(
-            self.c_max, self.n_max, self.total_c, self.total_n
-        ):
-            self.n_estimation = self.total_n - self.n_max
-            self.c_estimation = self.total_c - self.c_max
-            self.n_min = self.n_max = self.total_n = 0
-            self.c_min = self.c_max = self.total_c = 0
+        if self.two_sided_test:
+            if self._mean_decr(
+                self.c_max, self.n_max, self.total_c, self.total_n, self.drift_confidence
+            ):
+                self.n_estimation = self.total_n - self.n_max
+                self.c_estimation = self.total_c - self.c_max
+                self.n_min = self.n_max = self.total_n = 0
+                self.c_min = self.c_max = self.total_c = 0
+                self._in_concept_change = True
+            elif self._mean_decr(
+                self.c_max, self.n_max, self.total_c, self.total_n, self.warning_confidence
+            ):
+                self._in_warning_zone = True
 
         self._update_estimations()
 
@@ -153,12 +159,12 @@ class HDDM_A(DriftDetector):
         cota = sqrt(m / 2 * log(2.0 / confidence))
         return total_c / total_n - c_min / n_min >= cota
 
-    def _mean_decr(self, c_max, n_max, total_c, total_n):
+    def _mean_decr(self, c_max, n_max, total_c, total_n, confidence):
         if n_max == total_n:
             return False
 
         m = (total_n - n_max) / n_max * (1.0 / total_n)
-        cota = sqrt(m / 2 * log(2.0 / self.drift_confidence))
+        cota = sqrt(m / 2 * log(2.0 / confidence))
         return c_max / n_max - total_c / total_n >= cota
 
     def reset(self):

--- a/river/drift/hddm_w.py
+++ b/river/drift/hddm_w.py
@@ -137,6 +137,10 @@ class HDDM_W(DriftDetector):
         self._update_decr_statistics(value, self.drift_confidence)
         if self.two_sided_test and self._monitor_mean_decr(self.drift_confidence):
             self.reset()
+            self._in_concept_change = True
+        elif self._monitor_mean_decr(self.drift_confidence):
+            self._in_warning_zone = True
+        
         self.estimation = self.total.EWMA_estimator
 
         return self._in_concept_change, self._in_warning_zone

--- a/river/drift/hddm_w.py
+++ b/river/drift/hddm_w.py
@@ -139,7 +139,7 @@ class HDDM_W(DriftDetector):
             if self._monitor_mean_decr(self.drift_confidence):
                 self.reset()
                 self._in_concept_change = True
-            elif self._monitor_mean_decr(self.drift_confidence):
+            elif self._monitor_mean_decr(self.warning_confidence):
                 self._in_warning_zone = True
         
         self.estimation = self.total.EWMA_estimator

--- a/river/drift/hddm_w.py
+++ b/river/drift/hddm_w.py
@@ -135,11 +135,12 @@ class HDDM_W(DriftDetector):
             self._in_warning_zone = False
 
         self._update_decr_statistics(value, self.drift_confidence)
-        if self.two_sided_test and self._monitor_mean_decr(self.drift_confidence):
-            self.reset()
-            self._in_concept_change = True
-        elif self._monitor_mean_decr(self.drift_confidence):
-            self._in_warning_zone = True
+        if self.two_sided_test:
+            if self._monitor_mean_decr(self.drift_confidence):
+                self.reset()
+                self._in_concept_change = True
+            elif self._monitor_mean_decr(self.drift_confidence):
+                self._in_warning_zone = True
         
         self.estimation = self.total.EWMA_estimator
 


### PR DESCRIPTION
Currently, HDDM_W & HDDM_A drift detectors correctly detect a downward concept drift when two_side_option is set to True, however, the user is not notified of this detection.

For example, on this simple staircase-like pattern of probabilities (going up every 1k and then probability going down every 1k)
```python
l = []
for i in range(10):
    if i <= 5:
        l.append(np.random.choice([1, 0], p=[i/5, 1-i/5], size=1000))
    else:
        l.append(np.random.choice([1, 0], p=[(10-i)/5, 1-(10-i)/5], size=1000))
    print(np.mean(l[-1]))
x = np.concatenate(l)
```
Probability of getting one every 1k steps:
```bash
0.0
0.189
0.395
0.598
0.81
1.0
0.812
0.621
0.394
0.21
```


The code from example only reports the upward drifts, even thou `two_sided_test` is explicitly set to True
```python
hddm_a = HDDM_A(two_sided_test=True)

# Update drift detector and verify if change is detected
for i, val in enumerate(x):
     in_drift, in_warning = hddm_a.update(val)
     if in_drift:
         print(f"Change detected at index {i}, input value: {val}")
```
```bash
Change detected at index 1006, input value: 1.1463234650782699
Change detected at index 2024, input value: 2.1515355330643837
Change detected at index 3002, input value: 2.9529633774777175
Change detected at index 4006, input value: 4.190142295514493
```

After the change, HDDM correctly report both upward and downward concept drifts when `two_sided_test` is set to True
```bash
Change detected at index 1006, input value: 1.1463234650782699
Change detected at index 2024, input value: 2.1515355330643837
Change detected at index 3002, input value: 2.9529633774777175
Change detected at index 4006, input value: 4.190142295514493
Change detected at index 5001, input value: -0.22185322335601565
Change detected at index 6025, input value: -0.8520755260778327
Change detected at index 7003, input value: -1.9141891972478393
Change detected at index 8013, input value: -2.71994544016899
Change detected at index 9008, input value: -3.7395718500084483
```