### PR TITLE
Recover the reset method in ADWIN that was lost during the refactoring.

### DIFF
--- a/river/drift/adwin.py
+++ b/river/drift/adwin.py
@@ -116,3 +116,7 @@ class ADWIN(DriftDetector):
         """
         self._in_concept_change = self._helper.update(value)
         return self._in_concept_change, self._in_warning_zone
+
+    def reset(self):
+        """Reset the change detector."""
+        self._helper = AdaptiveWindowing(delta=self.delta)


### PR DESCRIPTION
<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->

Fixes #574