### PR TITLE
[Fix] nominal features being split more than once in tree regressors

### DIFF
--- a/river/tree/splitter/nominal_splitter_reg.py
+++ b/river/tree/splitter/nominal_splitter_reg.py
@@ -60,7 +60,7 @@ class NominalSplitterReg(Splitter):
     ):
         current_best = BranchFactory()
         ordered_feature_values = sorted(list(self._statistics.keys()))
-        if not binary_only:
+        if not binary_only and len(self._statistics) > 2:
             post_split_dist = [self._statistics[k] for k in ordered_feature_values]
 
             merit = criterion.merit_of_split(pre_split_dist, post_split_dist)


### PR DESCRIPTION
<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->
