### PR TITLE
Index fix for CluStream and DBStream

### DIFF
--- a/river/cluster/clustream.py
+++ b/river/cluster/clustream.py
@@ -280,9 +280,10 @@ class CluStream(base.Clusterer):
         index, _ = self._get_closest_micro_cluster(
             x, self._get_micro_clustering_result()
         )
-        y = kmeans.predict_one(micro_cluster_centers[index])
-
-        return y
+        try:
+            return kmeans.predict_one(micro_cluster_centers[index])
+        except KeyError:
+            return 0
 
 
 class CluStreamMicroCluster(metaclass=ABCMeta):

--- a/river/cluster/dbstream.py
+++ b/river/cluster/dbstream.py
@@ -388,7 +388,11 @@ class DBSTREAM(base.Clusterer):
         self._recluster()
 
         min_distance = math.inf
-        closest_cluster_index = -1
+
+        # default result of all clustering results, regardless of whether there already
+        # exists macro-clusters
+        closest_cluster_index = 0
+
         for i, center_i in self.centers.items():
             distance = self._distance(center_i, x)
             if distance < min_distance:


### PR DESCRIPTION
This PR serves to handle `KeyError` cases at the beginning of each algorithm. 

Whenever the algorithm returns this error when `predict_one` is called, the index is automatically set to `0`, which comes from the assumption that all outlier points are kept in the same cluster.