### PR TITLE
Make stats.RollingQuantile comply with np.quantile(interpolation="linear")

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -15,6 +15,9 @@
 
 - Added `rules.AMRules`
 
+## stats
+- Make `stats.RollingQuantile` match the default behavior of Numpy's `quantile` function.
+
 ## tree
 
 - Unifed base class structure applied to all tree models.

--- a/river/stats/iqr.py
+++ b/river/stats/iqr.py
@@ -77,24 +77,24 @@ class RollingIQR(base.RollingUnivariate, utils.SortedWindow):
     >>> rolling_iqr = stats.RollingIQR(
     ...     q_inf=0.25,
     ...     q_sup=0.75,
-    ...     window_size=100
+    ...     window_size=101
     ... )
 
     >>> for i in range(0, 1001):
     ...     rolling_iqr = rolling_iqr.update(i)
     ...     if i % 100 == 0:
     ...         print(rolling_iqr.get())
-    0
-    50
-    50
-    50
-    50
-    50
-    50
-    50
-    50
-    50
-    50
+    0.0
+    50.0
+    50.0
+    50.0
+    50.0
+    50.0
+    50.0
+    50.0
+    50.0
+    50.0
+    50.0
 
     """
 

--- a/river/stats/quantile.py
+++ b/river/stats/quantile.py
@@ -181,24 +181,24 @@ class RollingQuantile(base.RollingUnivariate, utils.SortedWindow):
 
     >>> rolling_quantile = stats.RollingQuantile(
     ...     q=.5,
-    ...     window_size=100,
+    ...     window_size=101,
     ... )
 
-    >>> for i in range(0, 1001):
+    >>> for i in range(1001):
     ...     rolling_quantile = rolling_quantile.update(i)
     ...     if i % 100 == 0:
     ...         print(rolling_quantile.get())
-    0
-    50
-    150
-    250
-    350
-    450
-    550
-    650
-    750
-    850
-    950
+    0.0
+    50.0
+    150.0
+    250.0
+    350.0
+    450.0
+    550.0
+    650.0
+    750.0
+    850.0
+    950.0
 
     References
     ----------
@@ -209,7 +209,25 @@ class RollingQuantile(base.RollingUnivariate, utils.SortedWindow):
     def __init__(self, q, window_size):
         super().__init__(size=window_size)
         self.q = q
-        self.idx = int(round(self.q * self.size + 0.5)) - 1
+        idx = self.q * (self.size - 1)
+
+        self._lower = int(math.floor(idx))
+        self._higher = self._lower + 1
+        if self._higher > self.size - 1:
+            self._higher = self.size - 1
+        self._frac = idx - self._lower
+
+    def _prepare(self):
+        if len(self) < self.size:
+            idx = self.q * (len(self) - 1)
+            lower = int(math.floor(idx))
+            higher = lower + 1
+            if higher > len(self) - 1:
+                higher = len(self) - 1
+            frac = idx - lower
+            return lower, higher, frac
+
+        return self._lower, self._higher, self._frac
 
     @property
     def window_size(self):
@@ -220,7 +238,5 @@ class RollingQuantile(base.RollingUnivariate, utils.SortedWindow):
         return self
 
     def get(self):
-        if len(self) < self.size:
-            idx = int(round(self.q * len(self) + 0.5)) - 1
-            return self[idx]
-        return self[self.idx]
+        lower, higher, frac = self._prepare()
+        return self[lower] + (self[higher] - self[lower]) * frac

--- a/river/stats/test_.py
+++ b/river/stats/test_.py
@@ -80,6 +80,26 @@ def test_univariate(stat, func):
         (stats.RollingMean(10), statistics.mean),
         (stats.RollingVar(3, ddof=0), np.var),
         (stats.RollingVar(10, ddof=0), np.var),
+        (
+            stats.RollingQuantile(0.0, 10),
+            functools.partial(np.quantile, q=0.0, interpolation="linear"),
+        ),
+        (
+            stats.RollingQuantile(0.25, 10),
+            functools.partial(np.quantile, q=0.25, interpolation="linear"),
+        ),
+        (
+            stats.RollingQuantile(0.5, 10),
+            functools.partial(np.quantile, q=0.5, interpolation="linear"),
+        ),
+        (
+            stats.RollingQuantile(0.75, 10),
+            functools.partial(np.quantile, q=0.75, interpolation="linear"),
+        ),
+        (
+            stats.RollingQuantile(1, 10),
+            functools.partial(np.quantile, q=1, interpolation="linear"),
+        ),
     ],
 )
 def test_rolling_univariate(stat, func):


### PR DESCRIPTION
<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->

The title pretty much describes the purpose of this PR. It is related to #610.

Numpy provides multiple interpolation strategies. None of them match the previous version of `stats.RollingQuantile`.

This PR makes `stats.RollingQuantile` match the linear interpolation strategy (the default option). In the future, we might want to bring other options and add an `interpolation` parameter, as done in the most recent Numpy versions.

Here's a simple test using Numpy and River:

```python
import random
import numpy as np

from river import stats


rng = random.Random(42)

data = [rng.random() for _ in range(100)]

qs = [0., 0.01, 0.05, 0.1, 0.25, 0.5, 0.6, 0.75, 0.99, 1.]
np_percs = np.quantile(data, q=qs)

perc = {}

for q in qs:
    perc[q] = stats.RollingQuantile(q=q, window_size=len(data))


for p in data:
    for q in qs:
        perc[q].update(p)

for i, q in enumerate(qs):
    print(f"Percentile {q:.2f}: {np_percs[i]:.2f} (Numpy)", end="\t")
    print(f"{perc[q].get():.2f} (River)", end="\t")
    print(f"{np_percs[i] - perc[q].get():.2f} (Diff)")
```

The output:

```python
Percentile 0.00: 0.01 (Numpy)   0.01 (River)    0.00 (Diff)
Percentile 0.01: 0.02 (Numpy)   0.02 (River)    0.00 (Diff)
Percentile 0.05: 0.05 (Numpy)   0.05 (River)    0.00 (Diff)
Percentile 0.10: 0.09 (Numpy)   0.09 (River)    0.00 (Diff)
Percentile 0.25: 0.23 (Numpy)   0.23 (River)    0.00 (Diff)
Percentile 0.50: 0.48 (Numpy)   0.48 (River)    0.00 (Diff)
Percentile 0.60: 0.59 (Numpy)   0.59 (River)    0.00 (Diff)
Percentile 0.75: 0.71 (Numpy)   0.71 (River)    0.00 (Diff)
Percentile 0.99: 1.00 (Numpy)   1.00 (River)    0.00 (Diff)
Percentile 1.00: 1.00 (Numpy)   1.00 (River)    0.00 (Diff)
```

The previous version failed to provide responses when `q=0` and `q=1`. As a bonus, this new version supports both cases.