### PR TITLE
Improvements to multi-class/multi-label metrics

### DIFF
--- a/river/metrics/__init__.py
+++ b/river/metrics/__init__.py
@@ -45,6 +45,8 @@ from .fbeta import (
     MultiFBeta,
     PerClassF1,
     PerClassFBeta,
+    PerLabelF1,
+    PerLabelFBeta,
     WeightedF1,
     WeightedFBeta,
 )
@@ -66,6 +68,7 @@ from .precision import (
     MacroPrecision,
     MicroPrecision,
     PerClassPrecision,
+    PerLabelPrecision,
     Precision,
     WeightedPrecision,
 )
@@ -79,6 +82,7 @@ from .recall import (
     MacroRecall,
     MicroRecall,
     PerClassRecall,
+    PerLabelRecall,
     Recall,
     WeightedRecall,
 )
@@ -146,6 +150,10 @@ __all__ = [
     "PerClassRecall",
     "PerClassFBeta",
     "PerClassF1",
+    "PerLabelPrecision",
+    "PerLabelRecall",
+    "PerLabelF1",
+    "PerLabelFBeta",
     "Precision",
     "Purity",
     "Q0",

--- a/river/metrics/__init__.py
+++ b/river/metrics/__init__.py
@@ -43,6 +43,8 @@ from .fbeta import (
     MicroF1,
     MicroFBeta,
     MultiFBeta,
+    PerClassF1,
+    PerClassFBeta,
     WeightedF1,
     WeightedFBeta,
 )
@@ -63,6 +65,7 @@ from .precision import (
     ExamplePrecision,
     MacroPrecision,
     MicroPrecision,
+    PerClassPrecision,
     Precision,
     WeightedPrecision,
 )
@@ -71,7 +74,14 @@ from .purity import Purity
 from .q0 import Q0, Q2
 from .r2 import R2
 from .rand import AdjustedRand, Rand
-from .recall import ExampleRecall, MacroRecall, MicroRecall, Recall, WeightedRecall
+from .recall import (
+    ExampleRecall,
+    MacroRecall,
+    MicroRecall,
+    PerClassRecall,
+    Recall,
+    WeightedRecall,
+)
 from .report import ClassificationReport
 from .roc_auc import ROCAUC
 from .rolling import Rolling
@@ -89,7 +99,6 @@ __all__ = [
     "Completeness",
     "ClassificationMetric",
     "ClassificationReport",
-    "ClusteringReport",
     "cluster",
     "CohenKappa",
     "ConfusionMatrix",
@@ -133,6 +142,10 @@ __all__ = [
     "MutualInfo",
     "NormalizedMutualInfo",
     "PairConfusionMatrix",
+    "PerClassPrecision",
+    "PerClassRecall",
+    "PerClassFBeta",
+    "PerClassF1",
     "Precision",
     "Purity",
     "Q0",
@@ -145,7 +158,6 @@ __all__ = [
     "RMSLE",
     "ROCAUC",
     "Rolling",
-    "RollingClusteringReport",
     "R2",
     "Precision",
     "PrevalenceThreshold",

--- a/river/metrics/confusion.pxd
+++ b/river/metrics/confusion.pxd
@@ -11,7 +11,7 @@ cdef class ConfusionMatrix:
     cdef readonly sum_col                       # Sum per column
     cdef readonly data                          # The actual data (dictionary)
     cdef readonly int n_samples                 # Number of samples seen
-    cdef readonly float total_weight            # Sum of sample_weights seen
+    cdef readonly float total_weight             # Sum of sample_weights seen
     cdef readonly last_y_true                   # Last y_true value seen
     cdef readonly last_y_pred                   # Last y_pred value seen
     cdef readonly sample_correction             # Used to apply corrections during revert
@@ -27,11 +27,7 @@ cdef class MultiLabelConfusionMatrix:
 
     # Internal variables
     cdef readonly set _init_labels              # Initial set of labels
-    cdef readonly set labels                    # Set of labels
-    cdef readonly int n_labels                  # Number of labels
     cdef readonly data                          # The actual data (3D np.ndarray)
-    cdef readonly dict _label_dict              # Dictionary to map labels and their label-index
-    cdef readonly int _label_idx_cnt            # Internal label-index counter
     cdef readonly last_y_true                   # Last y_true value seen
     cdef readonly last_y_pred                   # Last y_pred value seen
     cdef readonly int n_samples                 # Number of samples seen
@@ -40,8 +36,3 @@ cdef class MultiLabelConfusionMatrix:
     cdef readonly double precision_sum          # Precision sum
     cdef readonly double recall_sum             # Recall sum
     cdef readonly double jaccard_sum            # Jaccard-index sum
-
-    # Methods
-    cdef int _map_label(self, label, bint add_label)
-    cdef void _add_label(self, label)
-    cdef void _reshape(self)

--- a/river/metrics/hamming.py
+++ b/river/metrics/hamming.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from . import base
 
 __all__ = ["Hamming"]
@@ -53,14 +51,14 @@ class Hamming(base.MultiOutputClassificationMetric):
     def get(self):
 
         try:
-            return np.sum(self.cm.data[:, 1, 1]) / (
+            return sum([m[1][1] for m in self.cm.data.values()]) / (
                 self.cm.n_samples * self.cm.n_labels
             )
         except ZeroDivisionError:
             return 0.0
 
 
-class HammingLoss(base.MultiOutputClassificationMetric):
+class HammingLoss(Hamming):
     """Hamming loss score.
 
     The Hamming loss is the complement of the Hamming score.
@@ -97,19 +95,6 @@ class HammingLoss(base.MultiOutputClassificationMetric):
 
     """
 
-    @property
-    def bigger_is_better(self):
-        return True
-
-    @property
-    def requires_labels(self):
-        return True
-
     def get(self):
 
-        try:
-            return 1.0 - np.sum(self.cm.data[:, 1, 1]) / (
-                self.cm.n_samples * self.cm.n_labels
-            )
-        except ZeroDivisionError:
-            return 0.0
+        return 1.0 - super().get()

--- a/river/metrics/hamming.py
+++ b/river/metrics/hamming.py
@@ -1,6 +1,6 @@
 from . import base
 
-__all__ = ["Hamming"]
+__all__ = ["Hamming", "HammingLoss"]
 
 
 class Hamming(base.MultiOutputClassificationMetric):

--- a/river/metrics/precision.py
+++ b/river/metrics/precision.py
@@ -270,12 +270,11 @@ class PerClassPrecision(metrics.MultiClassMetric):
     """
 
     def get(self) -> dict:
-        result = {}
-        for c in self.cm.classes:
-            tp = self.cm.true_positives(c)
-            fp = self.cm.false_positives(c)
-            result[c] = tp / (tp + fp) if tp + fp > 0.0 else 0.0
-        return result
+        return {
+            class_label: self.cm.true_positives(class_label) / self.cm.sum_col[class_label]
+            if self.cm.sum_col[class_label] > 0.0 else 0.0
+            for class_label in self.cm.classes
+        }
 
     def __repr__(self):
         """Return the class name along with the current value of the metric."""
@@ -325,12 +324,11 @@ class PerLabelPrecision(metrics.MultiOutputClassificationMetric):
         return True
 
     def get(self) -> dict:
-        result = {}
-        for label in self.cm.labels:
-            tp = self.cm.data[label].true_positives(1)
-            fp = self.cm.data[label].false_positives(1)
-            result[label] = tp / (tp + fp) if tp + fp > 0.0 else 0.0
-        return result
+        return {
+                label: matrix.true_positives(1) / matrix.sum_col[1]
+                if matrix.sum_col[1] > 0.0 else 0.0
+                for label, matrix in self.cm.data.items()
+            }
 
     def __repr__(self):
         """Return the class name along with the current value of the metric."""

--- a/river/metrics/precision.py
+++ b/river/metrics/precision.py
@@ -271,8 +271,10 @@ class PerClassPrecision(metrics.MultiClassMetric):
 
     def get(self) -> dict:
         return {
-            class_label: self.cm.true_positives(class_label) / self.cm.sum_col[class_label]
-            if self.cm.sum_col[class_label] > 0.0 else 0.0
+            class_label: self.cm.true_positives(class_label)
+            / self.cm.sum_col[class_label]
+            if self.cm.sum_col[class_label] > 0.0
+            else 0.0
             for class_label in self.cm.classes
         }
 
@@ -325,10 +327,11 @@ class PerLabelPrecision(metrics.MultiOutputClassificationMetric):
 
     def get(self) -> dict:
         return {
-                label: matrix.true_positives(1) / matrix.sum_col[1]
-                if matrix.sum_col[1] > 0.0 else 0.0
-                for label, matrix in self.cm.data.items()
-            }
+            label: matrix.true_positives(1) / matrix.sum_col[1]
+            if matrix.sum_col[1] > 0.0
+            else 0.0
+            for label, matrix in self.cm.data.items()
+        }
 
     def __repr__(self):
         """Return the class name along with the current value of the metric."""

--- a/river/metrics/recall.py
+++ b/river/metrics/recall.py
@@ -256,12 +256,11 @@ class PerClassRecall(metrics.MultiClassMetric):
     """
 
     def get(self) -> dict:
-        result = {}
-        for c in self.cm.classes:
-            tp = self.cm.true_positives(c)
-            fn = self.cm.false_negatives(c)
-            result[c] = tp / (tp + fn) if tp + fn > 0.0 else 0.0
-        return result
+        return {
+            class_label: self.cm.true_positives(class_label) / self.cm.sum_row[class_label]
+            if self.cm.sum_row[class_label] > 0.0 else 0.0
+            for class_label in self.cm.classes
+        }
 
     def __repr__(self):
         """Return the class name along with the current value of the metric."""
@@ -311,12 +310,11 @@ class PerLabelRecall(metrics.MultiOutputClassificationMetric):
         return True
 
     def get(self) -> dict:
-        result = {}
-        for label in self.cm.labels:
-            tp = self.cm.data[label].true_positives(1)
-            fn = self.cm.data[label].false_negatives(1)
-            result[label] = tp / (tp + fn) if tp + fn > 0.0 else 0.0
-        return result
+        return {
+                label: matrix.true_positives(1) / matrix.sum_row[1]
+                if matrix.sum_row[1] > 0.0 else 0.0
+                for label, matrix in self.cm.data.items()
+            }
 
     def __repr__(self):
         """Return the class name along with the current value of the metric."""

--- a/river/metrics/recall.py
+++ b/river/metrics/recall.py
@@ -257,8 +257,10 @@ class PerClassRecall(metrics.MultiClassMetric):
 
     def get(self) -> dict:
         return {
-            class_label: self.cm.true_positives(class_label) / self.cm.sum_row[class_label]
-            if self.cm.sum_row[class_label] > 0.0 else 0.0
+            class_label: self.cm.true_positives(class_label)
+            / self.cm.sum_row[class_label]
+            if self.cm.sum_row[class_label] > 0.0
+            else 0.0
             for class_label in self.cm.classes
         }
 
@@ -311,10 +313,11 @@ class PerLabelRecall(metrics.MultiOutputClassificationMetric):
 
     def get(self) -> dict:
         return {
-                label: matrix.true_positives(1) / matrix.sum_row[1]
-                if matrix.sum_row[1] > 0.0 else 0.0
-                for label, matrix in self.cm.data.items()
-            }
+            label: matrix.true_positives(1) / matrix.sum_row[1]
+            if matrix.sum_row[1] > 0.0
+            else 0.0
+            for label, matrix in self.cm.data.items()
+        }
 
     def __repr__(self):
         """Return the class name along with the current value of the metric."""

--- a/river/metrics/recall.py
+++ b/river/metrics/recall.py
@@ -7,6 +7,7 @@ __all__ = [
     "WeightedRecall",
     "ExampleRecall",
     "PerClassRecall",
+    "PerLabelRecall",
 ]
 
 
@@ -254,7 +255,7 @@ class PerClassRecall(metrics.MultiClassMetric):
 
     """
 
-    def get(self):
+    def get(self) -> dict:
         result = {}
         for c in self.cm.classes:
             tp = self.cm.true_positives(c)
@@ -266,5 +267,63 @@ class PerClassRecall(metrics.MultiClassMetric):
         """Return the class name along with the current value of the metric."""
         text = ", ".join(
             [f"{c}: {v:{self._fmt}}".rstrip("0") for c, v in self.get().items()]
+        )
+        return f"{self.__class__.__name__}: {{{text}}}"
+
+
+class PerLabelRecall(metrics.MultiOutputClassificationMetric):
+    """Per-class recall score.
+
+    Parameters
+    ----------
+    cm
+        This parameter allows sharing the same confusion matrix between multiple metrics. Sharing
+        a confusion matrix reduces the amount of storage and computation time.
+
+    Examples
+    --------
+
+    >>> from river import metrics
+
+    >>> y_true = [
+    ...     {0: False, 1: True, 2: True},
+    ...     {0: True, 1: True, 2: False},
+    ...     {0: True, 1: True, 2: False},
+    ... ]
+
+    >>> y_pred = [
+    ...     {0: True, 1: True, 2: True},
+    ...     {0: True, 1: False, 2: False},
+    ...     {0: True, 1: True, 2: False},
+    ... ]
+
+    >>> metric = metrics.PerLabelRecall()
+    >>> for yt, yp in zip(y_true, y_pred):
+    ...     print(metric.update(yt, yp))
+    PerLabelRecall: {0: 0., 1: 1., 2: 1.}
+    PerLabelRecall: {0: 1., 1: 0.5, 2: 1.}
+    PerLabelRecall: {0: 1., 1: 0.666667, 2: 1.}
+
+    """
+
+    @property
+    def bigger_is_better(self):
+        return True
+
+    def get(self) -> dict:
+        result = {}
+        for label in self.cm.labels:
+            tp = self.cm.data[label].true_positives(1)
+            fn = self.cm.data[label].false_negatives(1)
+            result[label] = tp / (tp + fn) if tp + fn > 0.0 else 0.0
+        return result
+
+    def __repr__(self):
+        """Return the class name along with the current value of the metric."""
+        text = ", ".join(
+            [
+                f"{label}: {val:{self._fmt}}".rstrip("0")
+                for label, val in self.get().items()
+            ]
         )
         return f"{self.__class__.__name__}: {{{text}}}"


### PR DESCRIPTION
This PR includes improvements for multi-class/multi-label metrics:

List of changes:

- Refactor the `MultiLabelConfusionMatrix`. Now data is stored as a dictionary of 2x2 `ConfusionMatrix` instances corresponding to each observed label.
- Add per-class metric for precision, recall, f-beta, and f1
- Add per-label metric for precision, recall, f-beta, and f1
- Improve unit tests for the metrics module
- Misc cosmetic changes