### PR TITLE
Fix PyTorch classifier

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -18,3 +18,4 @@
 - Implemented median absolute deviation in `stats.MAD`.
 - Refactored `compat.PyTorch2RiverRegressor`
 - Fixed an issue where some statistics could not be printed if they had not seen any data yet.
+- Fixed an issue where `compat.PyTorch2RiverClassifier` could not adapt to new classes.

--- a/river/compat/pytorch.py
+++ b/river/compat/pytorch.py
@@ -196,22 +196,26 @@ class PyTorch2RiverClassifier(PyTorch2RiverBase, base.Classifier):
     def _update_classes(self):
         self.n_classes = len(self.classes)
         layers = list(self.net.children())
+        # Get last trainable layer
         i = -1
         layer_to_convert = layers[i]
         while not hasattr(layer_to_convert, "weight"):
             layer_to_convert = layers[i]
             i -= 1
-
-        removed = list(self.net.children())[: i + 1]
-        new_net = removed
+        if i == -1:
+            i = -2
+        # Get first Layers
+        new_net = list(self.net.children())[:i + 1]
         new_layer = torch.nn.Linear(
             in_features=layer_to_convert.in_features, out_features=self.n_classes
         )
-        # copy the original weights back
+        # Copy the original weights back
         with torch.no_grad():
             new_layer.weight[:-1, :] = layer_to_convert.weight
             new_layer.weight[-1:, :] = torch.mean(layer_to_convert.weight, 0)
+        # Append new Layer
         new_net.append(new_layer)
+        # Add non trainable layers
         if i + 1 < -1:
             for layer in layers[i + 2 :]:
                 new_net.append(layer)

--- a/river/compat/pytorch.py
+++ b/river/compat/pytorch.py
@@ -205,7 +205,7 @@ class PyTorch2RiverClassifier(PyTorch2RiverBase, base.Classifier):
         if i == -1:
             i = -2
         # Get first Layers
-        new_net = list(self.net.children())[:i + 1]
+        new_net = list(self.net.children())[: i + 1]
         new_layer = torch.nn.Linear(
             in_features=layer_to_convert.in_features, out_features=self.n_classes
         )

--- a/river/compat/pytorch.py
+++ b/river/compat/pytorch.py
@@ -32,15 +32,35 @@ class PyTorch2RiverBase(base.Estimator):
         torch.manual_seed(seed)
         self.net = None
 
+    @classmethod
     def _unit_test_params(self):
         def build_torch_linear_regressor(n_features):
-            net = torch.nn.Sequential(torch.nn.Linear(n_features, 1))
+            net = torch.nn.Sequential(
+                torch.nn.Linear(n_features, 1), torch.nn.Sigmoid()
+            )
             return net
 
         return {
             "build_fn": build_torch_linear_regressor,
             "loss_fn": torch.nn.MSELoss,
             "optimizer_fn": torch.optim.SGD,
+        }
+
+    @classmethod
+    def _unit_test_skips(self):
+        """Indicates which checks to skip during unit testing.
+
+        Most estimators pass the full test suite. However, in some cases, some estimators might not
+        be able to pass certain checks.
+
+        """
+        return {
+            "check_pickling",
+            "check_shuffle_features_no_impact",
+            "check_emerging_features",
+            "check_disappearing_features",
+            "check_predict_proba_one",
+            "check_predict_proba_one_binary",
         }
 
     def _learn_one(self, x: torch.Tensor, y: torch.Tensor):

--- a/river/compat/pytorch.py
+++ b/river/compat/pytorch.py
@@ -33,7 +33,7 @@ class PyTorch2RiverBase(base.Estimator):
         self.net = None
 
     @classmethod
-    def _unit_test_params(self):
+    def _unit_test_params(cls):
         def build_torch_linear_regressor(n_features):
             net = torch.nn.Sequential(
                 torch.nn.Linear(n_features, 1), torch.nn.Sigmoid()
@@ -49,10 +49,8 @@ class PyTorch2RiverBase(base.Estimator):
     @classmethod
     def _unit_test_skips(self):
         """Indicates which checks to skip during unit testing.
-
         Most estimators pass the full test suite. However, in some cases, some estimators might not
         be able to pass certain checks.
-
         """
         return {
             "check_pickling",


### PR DESCRIPTION
Hi,

this PR contains a quick fix for `compat.PyTorch2RiverClassifier`, where the Classifier could not adapt to new classes when the last layer of from the PyTorch model was trainable.

Best
Cedric
