### PR TITLE
Add debug_one method to all FMRegressors

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,1 +1,6 @@
 # Unreleased
+
+## facto
+
+- Moved `_calculate_interactions` from each of FM implementations to `BaseFM`.
+- Addd `debug_one` method to `BaseFM`.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -3,4 +3,4 @@
 ## facto
 
 - Moved `_calculate_interactions` from each of FM implementations to `BaseFM`.
-- Addd `debug_one` method to `BaseFM`.
+- Added `debug_one` method to `BaseFM`.

--- a/river/facto/base.py
+++ b/river/facto/base.py
@@ -133,21 +133,21 @@ class BaseFM:
         interaction_coefficient: latents[xi] * latents[xj]
         """
         return sum(
-            [
-                self._interaction_coefficient(combination)
-                * self._interaction_val(x, combination)
-                for combination in self._interaction_combination_keys(x)
-            ]
+            self._interaction_coefficient(combination)
+            * self._interaction_val(x, combination)
+            for combination in self._interaction_combination_keys(x)
         )
 
     def debug_one(self, x: dict, decimals: int = 5) -> str:
         """Debugs the output of the FM regressor.
+
         Parameters
         ----------
         x
             A dictionary of features.
         decimals
             The number of decimals use for printing each numeric value.
+
         Returns
         -------
         A table which explains the output.

--- a/river/facto/base.py
+++ b/river/facto/base.py
@@ -1,6 +1,7 @@
 import abc
 import collections
 import numbers
+from typing import Iterable
 
 from .. import optim, utils
 
@@ -122,9 +123,32 @@ class BaseFM:
         """Infers feature field name."""
         return j.split("_")[0]
 
-    @abc.abstractmethod
     def _calculate_interactions(self, x: dict) -> float:
-        """Calculates greater than unary interactions."""
+        """Calculates greater than unary interactions.
+        For normal FM: sigma (i < j) product(latents[xi] * latents[xj]) xi * xj
+        interaction_combination_keys: sigma (i < j)
+        interaction_val: xi * xj
+        interaction_coefficient: latents[xi] * latents[xj]
+        """
+        return sum(
+            [
+                self._interaction_coefficient(combination)
+                * self._interaction_val(x, combination)
+                for combination in self._interaction_combination_keys(x)
+            ]
+        )
+
+    @abc.abstractmethod
+    def _interaction_combination_keys(self, x) -> Iterable:
+        """Return combinations for interactions."""
+
+    @abc.abstractmethod
+    def _interaction_val(self) -> float:
+        """Return values corresponding to combination keys for interactions."""
+
+    @abc.abstractmethod
+    def _interaction_coefficient(self) -> float:
+        """Return coefficient corresponding to combination keys for interactions."""
 
     @abc.abstractmethod
     def _calculate_weights_gradients(self, x: dict, g_loss: float) -> dict:

--- a/river/facto/base.py
+++ b/river/facto/base.py
@@ -216,12 +216,12 @@ class BaseFM:
         """Return combinations for interactions."""
 
     @abc.abstractmethod
-    def _interaction_val(self) -> float:
-        """Return values corresponding to combination keys for interactions."""
+    def _interaction_val(self, x, combination) -> float:
+        """Return values corresponding to a given combination of interaction."""
 
     @abc.abstractmethod
-    def _interaction_coefficient(self) -> float:
-        """Return coefficient corresponding to combination keys for interactions."""
+    def _interaction_coefficient(self, combination) -> float:
+        """Return coefficient corresponding to a given combination of interaction."""
 
     @abc.abstractmethod
     def _calculate_weights_gradients(self, x: dict, g_loss: float) -> dict:

--- a/river/facto/base.py
+++ b/river/facto/base.py
@@ -3,6 +3,8 @@ import collections
 import numbers
 from typing import Iterable
 
+import numpy as np
+
 from .. import optim, utils
 
 
@@ -137,6 +139,77 @@ class BaseFM:
                 for combination in self._interaction_combination_keys(x)
             ]
         )
+
+    def debug_one(self, x: dict, decimals: int = 5) -> str:
+        """Debugs the output of the FM regressor.
+        Parameters
+        ----------
+        x
+            A dictionary of features.
+        decimals
+            The number of decimals use for printing each numeric value.
+        Returns
+        -------
+        A table which explains the output.
+        """
+
+        x = self._ohe_cat_features(x)
+
+        def fmt_float(x):
+            return "{: ,.{prec}f}".format(x, prec=decimals)
+
+        names = (
+            self._interaction_names(x)  # latents
+            + list(map(str, x.keys()))  # weights
+            + ["Intercept"]  # intercept
+        )
+
+        values = list(
+            map(
+                fmt_float,
+                [
+                    self._interaction_val(x, combination)
+                    for combination in self._interaction_combination_keys(x)
+                ]  # latents
+                + list(x.values())  # weights
+                + [1],  # intercept
+            )
+        )
+
+        weights = list(
+            map(
+                fmt_float,
+                [
+                    self._interaction_coefficient(combination)
+                    for combination in self._interaction_combination_keys(x)
+                ]  # latents
+                + [self.weights.get(i, 0) for i in x]  # weights
+                + [self.intercept],  # intercept
+            )
+        )
+        contributions = (
+            [
+                self._interaction_coefficient(combination)
+                * self._interaction_val(x, combination)
+                for combination in self._interaction_combination_keys(x)
+            ]  # latents
+            + [xi * self.weights.get(i, 0) for i, xi in x.items()]  # weights
+            + [self.intercept]  # intercept
+        )
+        order = reversed(np.argsort(contributions))
+        contributions = list(map(fmt_float, contributions))
+
+        table = utils.pretty.print_table(
+            headers=["Name", "Value", "Weight", "Contribution"],
+            columns=[names, values, weights, contributions],
+            order=order,
+        )
+
+        return table
+
+    @abc.abstractmethod
+    def _interaction_names(self, x) -> list:
+        "Return names for interactions."
 
     @abc.abstractmethod
     def _interaction_combination_keys(self, x) -> Iterable:

--- a/river/facto/ffm.py
+++ b/river/facto/ffm.py
@@ -288,7 +288,8 @@ class FFMRegressor(FFM, base.Regressor):
             map(
                 fmt_float,
                 [
-                    x[j1] * x[j2] for j1, j2 in itertools.combinations(x.keys(), 2)
+                    self._interaction_combination_vals(x, combination)
+                    for combination in self._interaction_combination_keys(x)
                 ]  # latents
                 + list(x.values())  # weights
                 + [1],  # intercept
@@ -299,11 +300,8 @@ class FFMRegressor(FFM, base.Regressor):
             map(
                 fmt_float,
                 [
-                    np.dot(
-                        self.latents[j1][self._field(j2)],
-                        self.latents[j2][self._field(j1)],
-                    )
-                    for j1, j2 in itertools.combinations(x.keys(), 2)
+                    self._interaction_coefficient(combination)
+                    for combination in self._interaction_combination_keys(x)
                 ]  # latents
                 + [self.weights.get(i, 0) for i in x]  # weights
                 + [self.intercept],  # intercept
@@ -311,12 +309,9 @@ class FFMRegressor(FFM, base.Regressor):
         )
         contributions = (
             [
-                x[j1]
-                * x[j2]
-                * np.dot(
-                    self.latents[j1][self._field(j2)], self.latents[j2][self._field(j1)]
-                )
-                for j1, j2 in itertools.combinations(x.keys(), 2)
+                self._interaction_coefficient(combination)
+                * self._interaction_combination_vals(x, combination)
+                for combination in self._interaction_combination_keys(x)
             ]  # latents
             + [xi * self.weights.get(i, 0) for i, xi in x.items()]  # weights
             + [self.intercept]  # intercept

--- a/river/facto/ffm.py
+++ b/river/facto/ffm.py
@@ -196,6 +196,18 @@ class FFMRegressor(FFM, base.Regressor):
     >>> model.predict_one({'user': 'Bob', 'item': 'Harry Potter', 'time': .14})
     5.319945
 
+    >>> report = model.debug_one({'user': 'Bob', 'item': 'Harry Potter', 'time': .14})
+
+    >>> print(report)
+    Name                                       Value      Weight     Contribution
+                                   Intercept    1.00000    5.23501        5.23501
+                                    user_Bob    1.00000    0.11438        0.11438
+                                        time    0.14000    0.03186        0.00446
+        item_Harry Potter(time) - time(item)    0.14000    0.03153        0.00441
+                 user_Bob(time) - time(user)    0.14000    0.02864        0.00401
+                           item_Harry Potter    1.00000    0.00000        0.00000
+    user_Bob(item) - item_Harry Potter(user)    1.00000   -0.04232       -0.04232
+
     References
     ----------
     [^1]: [Juan, Y., Zhuang, Y., Chin, W.S. and Lin, C.J., 2016, September. Field-aware factorization machines for CTR prediction. In Proceedings of the 10th ACM Conference on Recommender Systems (pp. 43-50).](https://www.csie.ntu.edu.tw/~cjlin/papers/ffm.pdf)
@@ -242,6 +254,81 @@ class FFMRegressor(FFM, base.Regressor):
     def predict_one(self, x):
         x = self._ohe_cat_features(x)
         return self._raw_dot(x)
+
+    def debug_one(self, x: dict, decimals: int = 5) -> str:
+        """Debugs the output of the ffm regressor.
+        Parameters
+        ----------
+        x
+            A dictionary of features.
+        decimals
+            The number of decimals use for printing each numeric value.
+        Returns
+        -------
+        A table which explains the output.
+        """
+
+        x = self._ohe_cat_features(x)
+
+        def fmt_float(x):
+            return "{: ,.{prec}f}".format(x, prec=decimals)
+
+        names = (
+            [
+                f"{j1}({self._field(j2)}) - {j2}({self._field(j1)})"
+                for j1, j2 in itertools.combinations(x.keys(), 2)
+            ]  # latents
+            + list(map(str, x.keys()))  # weights
+            + ["Intercept"]  # intercept
+        )
+
+        values = list(
+            map(
+                fmt_float,
+                [
+                    x[j1] * x[j2] for j1, j2 in itertools.combinations(x.keys(), 2)
+                ]  # latents
+                + list(x.values())  # weights
+                + [1],  # intercept
+            )
+        )
+
+        weights = list(
+            map(
+                fmt_float,
+                [
+                    np.dot(
+                        self.latents[j1][self._field(j2)],
+                        self.latents[j2][self._field(j1)],
+                    )
+                    for j1, j2 in itertools.combinations(x.keys(), 2)
+                ]  # latents
+                + [self.weights.get(i, 0) for i in x]  # weights
+                + [self.intercept],  # intercept
+            )
+        )
+        contributions = (
+            [
+                x[j1]
+                * x[j2]
+                * np.dot(
+                    self.latents[j1][self._field(j2)], self.latents[j2][self._field(j1)]
+                )
+                for j1, j2 in itertools.combinations(x.keys(), 2)
+            ]  # latents
+            + [xi * self.weights.get(i, 0) for i, xi in x.items()]  # weights
+            + [self.intercept]  # intercept
+        )
+        order = reversed(np.argsort(contributions))
+        contributions = list(map(fmt_float, contributions))
+
+        table = utils.pretty.print_table(
+            headers=["Name", "Value", "Weight", "Contribution"],
+            columns=[names, values, weights, contributions],
+            order=order,
+        )
+
+        return table
 
 
 class FFMClassifier(FFM, base.Classifier):

--- a/river/facto/ffm.py
+++ b/river/facto/ffm.py
@@ -58,14 +58,16 @@ class FFM(BaseFM):
         field_latents_dict = functools.partial(collections.defaultdict, random_latents)
         return collections.defaultdict(field_latents_dict)
 
-    def _calculate_interactions(self, x):
-        """Calculates pairwise interactions."""
-        field = self._field
-        return sum(
-            x[j1]
-            * x[j2]
-            * np.dot(self.latents[j1][field(j2)], self.latents[j2][field(j1)])
-            for j1, j2 in itertools.combinations(x.keys(), 2)
+    def _interaction_combination_keys(self, x):
+        return itertools.combinations(x.keys(), 2)
+
+    def _interaction_val(self, x, combination):
+        return functools.reduce(lambda x, y: x * y, (x[j] for j in combination))
+
+    def _interaction_coefficient(self, combination):
+        j1, j2 = combination
+        return np.dot(
+            self.latents[j1][self._field(j2)], self.latents[j2][self._field(j1)]
         )
 
     def _calculate_weights_gradients(self, x, g_loss):

--- a/river/facto/fm.py
+++ b/river/facto/fm.py
@@ -57,6 +57,9 @@ class FM(BaseFM):
         )
         return collections.defaultdict(random_latents)
 
+    def _interaction_names(self, x):
+        return [f"{j1} - {j2}" for j1, j2 in itertools.combinations(x.keys(), 2)]
+
     def _interaction_combination_keys(self, x):
         return itertools.combinations(x.keys(), 2)
 
@@ -240,75 +243,6 @@ class FMRegressor(FM, base.Regressor):
     def predict_one(self, x):
         x = self._ohe_cat_features(x)
         return self._raw_dot(x)
-
-    def debug_one(self, x: dict, decimals: int = 5) -> str:
-        """Debugs the output of the fm regressor.
-        Parameters
-        ----------
-        x
-            A dictionary of features.
-        decimals
-            The number of decimals use for printing each numeric value.
-        Returns
-        -------
-        A table which explains the output.
-        """
-
-        x = self._ohe_cat_features(x)
-
-        def fmt_float(x):
-            return "{: ,.{prec}f}".format(x, prec=decimals)
-
-        names = (
-            [
-                f"{j1} - {j2}" for j1, j2 in itertools.combinations(x.keys(), 2)
-            ]  # latents
-            + list(map(str, x.keys()))  # weights
-            + ["Intercept"]  # intercept
-        )
-
-        values = list(
-            map(
-                fmt_float,
-                [
-                    self._interaction_combination_vals(x, combination)
-                    for combination in self._interaction_combination_keys(x)
-                ]  # latents
-                + list(x.values())  # weights
-                + [1],  # intercept
-            )
-        )
-
-        weights = list(
-            map(
-                fmt_float,
-                [
-                    self._interaction_coefficient(combination)
-                    for combination in self._interaction_combination_keys(x)
-                ]  # latents
-                + [self.weights.get(i, 0) for i in x]  # weights
-                + [self.intercept],  # intercept
-            )
-        )
-        contributions = (
-            [
-                self._interaction_coefficient(combination)
-                * self._interaction_combination_vals(x, combination)
-                for combination in self._interaction_combination_keys(x)
-            ]  # latents
-            + [xi * self.weights.get(i, 0) for i, xi in x.items()]  # weights
-            + [self.intercept]  # intercept
-        )
-        order = reversed(np.argsort(contributions))
-        contributions = list(map(fmt_float, contributions))
-
-        table = utils.pretty.print_table(
-            headers=["Name", "Value", "Weight", "Contribution"],
-            columns=[names, values, weights, contributions],
-            order=order,
-        )
-
-        return table
 
 
 class FMClassifier(FM, base.Classifier):

--- a/river/facto/fm.py
+++ b/river/facto/fm.py
@@ -271,7 +271,8 @@ class FMRegressor(FM, base.Regressor):
             map(
                 fmt_float,
                 [
-                    x[j1] * x[j2] for j1, j2 in itertools.combinations(x.keys(), 2)
+                    self._interaction_combination_vals(x, combination)
+                    for combination in self._interaction_combination_keys(x)
                 ]  # latents
                 + list(x.values())  # weights
                 + [1],  # intercept
@@ -282,8 +283,8 @@ class FMRegressor(FM, base.Regressor):
             map(
                 fmt_float,
                 [
-                    np.dot(self.latents[j1], self.latents[j2])
-                    for j1, j2 in itertools.combinations(x.keys(), 2)
+                    self._interaction_coefficient(combination)
+                    for combination in self._interaction_combination_keys(x)
                 ]  # latents
                 + [self.weights.get(i, 0) for i in x]  # weights
                 + [self.intercept],  # intercept

--- a/river/facto/fwfm.py
+++ b/river/facto/fwfm.py
@@ -308,7 +308,8 @@ class FwFMRegressor(FwFM, base.Regressor):
             map(
                 fmt_float,
                 [
-                    x[j1] * x[j2] for j1, j2 in itertools.combinations(x.keys(), 2)
+                    self._interaction_combination_vals(x, combination)
+                    for combination in self._interaction_combination_keys(x)
                 ]  # latents
                 + list(x.values())  # weights
                 + [1],  # intercept
@@ -319,9 +320,8 @@ class FwFMRegressor(FwFM, base.Regressor):
             map(
                 fmt_float,
                 [
-                    np.dot(self.latents[j1], self.latents[j2])
-                    * self.interaction_weights[self._field(j1) + self._field(j2)]
-                    for j1, j2 in itertools.combinations(x.keys(), 2)
+                    self._interaction_coefficient(combination)
+                    for combination in self._interaction_combination_keys(x)
                 ]  # latents
                 + [self.weights.get(i, 0) for i in x]  # weights
                 + [self.intercept],  # intercept
@@ -329,11 +329,9 @@ class FwFMRegressor(FwFM, base.Regressor):
         )
         contributions = (
             [
-                x[j1]
-                * x[j2]
-                * np.dot(self.latents[j1], self.latents[j2])
-                * self.interaction_weights[self._field(j1) + self._field(j2)]
-                for j1, j2 in itertools.combinations(x.keys(), 2)
+                self._interaction_coefficient(combination)
+                * self._interaction_combination_vals(x, combination)
+                for combination in self._interaction_combination_keys(x)
             ]  # latents
             + [xi * self.weights.get(i, 0) for i, xi in x.items()]  # weights
             + [self.intercept]  # intercept

--- a/river/facto/fwfm.py
+++ b/river/facto/fwfm.py
@@ -217,6 +217,15 @@ class FwFMRegressor(FwFM, base.Regressor):
     >>> model.predict_one({'Bob': 1, 'Harry Potter': 1})
     5.236501
 
+    >>> report = model.debug_one({'Bob': 1, 'Harry Potter': 1})
+
+    >>> print(report)
+    Name                                    Value      Weight     Contribution
+                                Intercept    1.00000    5.23426        5.23426
+    Bob(Harry Potter) - Harry Potter(Bob)    1.00000    0.00224        0.00224
+                             Harry Potter    1.00000    0.00000        0.00000
+                                      Bob    1.00000    0.00000        0.00000
+
     References
     ----------
     [^1]: [Junwei Pan, Jian Xu, Alfonso Lobos Ruiz, Wenliang Zhao, Shengjun Pan, Yu Sun, and Quan Lu, 2018, April. Field-weighted Factorization Machines for Click-Through Rate Prediction in Display Advertising. In Proceedings of the 2018 World Wide Web Conference on World Wide Web. International World Wide Web Conferences Steering Committee, (pp. 1349–1357).](https://arxiv.org/abs/1806.03514)
@@ -265,6 +274,78 @@ class FwFMRegressor(FwFM, base.Regressor):
     def predict_one(self, x):
         x = self._ohe_cat_features(x)
         return self._raw_dot(x)
+
+    def debug_one(self, x: dict, decimals: int = 5) -> str:
+        """Debugs the output of the fwfm regressor.
+        Parameters
+        ----------
+        x
+            A dictionary of features.
+        decimals
+            The number of decimals use for printing each numeric value.
+        Returns
+        -------
+        A table which explains the output.
+        """
+
+        x = self._ohe_cat_features(x)
+
+        def fmt_float(x):
+            return "{: ,.{prec}f}".format(x, prec=decimals)
+
+        names = (
+            [
+                f"{j1}({self._field(j2)}) - {j2}({self._field(j1)})"
+                for j1, j2 in itertools.combinations(x.keys(), 2)
+            ]  # latents
+            + list(map(str, x.keys()))  # weights
+            + ["Intercept"]  # intercept
+        )
+
+        values = list(
+            map(
+                fmt_float,
+                [
+                    x[j1] * x[j2] for j1, j2 in itertools.combinations(x.keys(), 2)
+                ]  # latents
+                + list(x.values())  # weights
+                + [1],  # intercept
+            )
+        )
+
+        weights = list(
+            map(
+                fmt_float,
+                [
+                    np.dot(self.latents[j1], self.latents[j2])
+                    * self.interaction_weights[self._field(j1) + self._field(j2)]
+                    for j1, j2 in itertools.combinations(x.keys(), 2)
+                ]  # latents
+                + [self.weights.get(i, 0) for i in x]  # weights
+                + [self.intercept],  # intercept
+            )
+        )
+        contributions = (
+            [
+                x[j1]
+                * x[j2]
+                * np.dot(self.latents[j1], self.latents[j2])
+                * self.interaction_weights[self._field(j1) + self._field(j2)]
+                for j1, j2 in itertools.combinations(x.keys(), 2)
+            ]  # latents
+            + [xi * self.weights.get(i, 0) for i, xi in x.items()]  # weights
+            + [self.intercept]  # intercept
+        )
+        order = reversed(np.argsort(contributions))
+        contributions = list(map(fmt_float, contributions))
+
+        table = utils.pretty.print_table(
+            headers=["Name", "Value", "Weight", "Contribution"],
+            columns=[names, values, weights, contributions],
+            order=order,
+        )
+
+        return table
 
 
 class FwFMClassifier(FwFM, base.Classifier):

--- a/river/facto/fwfm.py
+++ b/river/facto/fwfm.py
@@ -65,6 +65,12 @@ class FwFM(BaseFM):
         )
         return collections.defaultdict(random_latents)
 
+    def _interaction_names(self, x):
+        return [
+            f"{j1}({self._field(j2)}) - {j2}({self._field(j1)})"
+            for j1, j2 in itertools.combinations(x.keys(), 2)
+        ]
+
     def _interaction_combination_keys(self, x):
         return itertools.combinations(x.keys(), 2)
 
@@ -276,76 +282,6 @@ class FwFMRegressor(FwFM, base.Regressor):
     def predict_one(self, x):
         x = self._ohe_cat_features(x)
         return self._raw_dot(x)
-
-    def debug_one(self, x: dict, decimals: int = 5) -> str:
-        """Debugs the output of the fwfm regressor.
-        Parameters
-        ----------
-        x
-            A dictionary of features.
-        decimals
-            The number of decimals use for printing each numeric value.
-        Returns
-        -------
-        A table which explains the output.
-        """
-
-        x = self._ohe_cat_features(x)
-
-        def fmt_float(x):
-            return "{: ,.{prec}f}".format(x, prec=decimals)
-
-        names = (
-            [
-                f"{j1}({self._field(j2)}) - {j2}({self._field(j1)})"
-                for j1, j2 in itertools.combinations(x.keys(), 2)
-            ]  # latents
-            + list(map(str, x.keys()))  # weights
-            + ["Intercept"]  # intercept
-        )
-
-        values = list(
-            map(
-                fmt_float,
-                [
-                    self._interaction_combination_vals(x, combination)
-                    for combination in self._interaction_combination_keys(x)
-                ]  # latents
-                + list(x.values())  # weights
-                + [1],  # intercept
-            )
-        )
-
-        weights = list(
-            map(
-                fmt_float,
-                [
-                    self._interaction_coefficient(combination)
-                    for combination in self._interaction_combination_keys(x)
-                ]  # latents
-                + [self.weights.get(i, 0) for i in x]  # weights
-                + [self.intercept],  # intercept
-            )
-        )
-        contributions = (
-            [
-                self._interaction_coefficient(combination)
-                * self._interaction_combination_vals(x, combination)
-                for combination in self._interaction_combination_keys(x)
-            ]  # latents
-            + [xi * self.weights.get(i, 0) for i, xi in x.items()]  # weights
-            + [self.intercept]  # intercept
-        )
-        order = reversed(np.argsort(contributions))
-        contributions = list(map(fmt_float, contributions))
-
-        table = utils.pretty.print_table(
-            headers=["Name", "Value", "Weight", "Contribution"],
-            columns=[names, values, weights, contributions],
-            order=order,
-        )
-
-        return table
 
 
 class FwFMClassifier(FwFM, base.Classifier):

--- a/river/facto/fwfm.py
+++ b/river/facto/fwfm.py
@@ -65,15 +65,17 @@ class FwFM(BaseFM):
         )
         return collections.defaultdict(random_latents)
 
-    def _calculate_interactions(self, x):
-        """Calculates pairwise interactions."""
+    def _interaction_combination_keys(self, x):
+        return itertools.combinations(x.keys(), 2)
 
-        # For notational convenience
-        v, w_int, field = self.latents, self.interaction_weights, self._field
+    def _interaction_val(self, x, combination):
+        return functools.reduce(lambda x, y: x * y, (x[j] for j in combination))
 
-        return sum(
-            x[j1] * x[j2] * np.dot(v[j1], v[j2]) * w_int[field(j1) + field(j2)]
-            for j1, j2 in itertools.combinations(x.keys(), 2)
+    def _interaction_coefficient(self, combination):
+        j1, j2 = combination
+        return (
+            np.dot(self.latents[j1], self.latents[j2])
+            * self.interaction_weights[self._field(j1) + self._field(j2)]
         )
 
     def _calculate_weights_gradients(self, x, g_loss):

--- a/river/facto/hofm.py
+++ b/river/facto/hofm.py
@@ -60,6 +60,13 @@ class HOFM(BaseFM):
         order_latents_dict = functools.partial(collections.defaultdict, random_latents)
         return collections.defaultdict(order_latents_dict)
 
+    def _interaction_names(self, x):
+        return [
+            " - ".join(map(str, combination))
+            for d in range(2, self.degree + 1)
+            for combination in itertools.combinations(x.keys(), d)
+        ]
+
     def _interaction_combination_keys(self, x):
         for d in range(2, self.degree + 1):
             for combination in itertools.combinations(x.keys(), d):
@@ -69,11 +76,10 @@ class HOFM(BaseFM):
         return functools.reduce(lambda x, y: x * y, (x[j] for j in combination))
 
     def _interaction_coefficient(self, combination):
-        d = len(combination)
         return sum(
             functools.reduce(
                 lambda x, y: np.multiply(x, y),
-                (self.latents[j][d] for j in combination),
+                (self.latents[j][len(combination)] for j in combination),
             )
         )
 
@@ -274,77 +280,6 @@ class HOFMRegressor(HOFM, base.Regressor):
     def predict_one(self, x):
         x = self._ohe_cat_features(x)
         return self._raw_dot(x)
-
-    def debug_one(self, x: dict, decimals: int = 5) -> str:
-        """Debugs the output of the fwfm regressor.
-        Parameters
-        ----------
-        x
-            A dictionary of features.
-        decimals
-            The number of decimals use for printing each numeric value.
-        Returns
-        -------
-        A table which explains the output.
-        """
-
-        x = self._ohe_cat_features(x)
-
-        def fmt_float(x):
-            return "{: ,.{prec}f}".format(x, prec=decimals)
-
-        names = (
-            [
-                " - ".join(map(str, combination))
-                for d in range(2, self.degree + 1)
-                for combination in itertools.combinations(x.keys(), d)
-            ]  # latents
-            + list(map(str, x.keys()))  # weights
-            + ["Intercept"]  # intercept
-        )
-
-        values = list(
-            map(
-                fmt_float,
-                [
-                    self._interaction_combination_vals(x, combination)
-                    for combination in self._interaction_combination_keys(x)
-                ]  # latents
-                + list(x.values())  # weights
-                + [1],  # intercept
-            )
-        )
-
-        weights = list(
-            map(
-                fmt_float,
-                [
-                    self._interaction_coefficient(combination)
-                    for combination in self._interaction_combination_keys(x)
-                ]  # latents
-                + [self.weights.get(i, 0) for i in x]  # weights
-                + [self.intercept],  # intercept
-            )
-        )
-        contributions = (
-            [
-                self._interaction_coefficient(combination)
-                * self._interaction_combination_vals(x, combination)
-                for combination in self._interaction_combination_keys(x)
-            ]  # latents
-            + [xi * self.weights.get(i, 0) for i, xi in x.items()]  # weights
-            + [self.intercept]  # intercept
-        )
-        order = reversed(np.argsort(contributions))
-        contributions = list(map(fmt_float, contributions))
-
-        table = utils.pretty.print_table(
-            headers=["Name", "Value", "Weight", "Contribution"],
-            columns=[names, values, weights, contributions],
-            order=order,
-        )
-
-        return table
 
 
 class HOFMClassifier(HOFM, base.Classifier):

--- a/river/facto/hofm.py
+++ b/river/facto/hofm.py
@@ -60,25 +60,21 @@ class HOFM(BaseFM):
         order_latents_dict = functools.partial(collections.defaultdict, random_latents)
         return collections.defaultdict(order_latents_dict)
 
-    def _calculate_interactions(self, x):
-        """Calculates greater than unary interactions."""
-        return sum(
-            self._calculate_interaction(x, d, combination)
-            for d in range(2, self.degree + 1)
-            for combination in itertools.combinations(x.keys(), d)
-        )
+    def _interaction_combination_keys(self, x):
+        for d in range(2, self.degree + 1):
+            for combination in itertools.combinations(x.keys(), d):
+                yield combination
 
-    def _calculate_interaction(self, x, d, combination):
-        feature_product = functools.reduce(
-            lambda x, y: x * y, (x[j] for j in combination)
-        )
-        latent_scalar_product = sum(
+    def _interaction_val(self, x, combination):
+        return functools.reduce(lambda x, y: x * y, (x[j] for j in combination))
+
+    def _interaction_coefficient(self, combination):
+        return sum(
             functools.reduce(
                 lambda x, y: np.multiply(x, y),
-                (self.latents[j][d] for j in combination),
+                (self.latents[j][len(list(combination))] for j in combination),
             )
         )
-        return feature_product * latent_scalar_product
 
     def _calculate_weights_gradients(self, x, g_loss):
 


### PR DESCRIPTION
# why

To make it easy to check the contribution of each feature and each combination of features in an FM regressor.

# what

1. [Refactor] Introduced common methods to calculate interactions
	- `_calculate_interactions` is moved to `base`, which is calculated by:
		- `_interaction_combination_keys`: combinations of interaction features (e.g. `sigma i < j` for normal FM)
		- `_interaction_val`: value corresponding to a given combination of interaction features (e.g. `xi * xj` for normal FM)
		- `_interaction_coefficient`: coefficient corresponding to a given combination of interaction features (e.g. `latents[xi] * latents[xj]` for normal FM)
1. Added `debug_one` and corresponding `doctest` to the following regressors:
	1. Add `debug_one` in `base` using the common methds introduced above.
	2. Added `_interaction_names`, which is used for feature interaction name in the table created by `debug_one` in `FMRegressor`, `FFMRegressor`, `FwFMRegressor`, and `HOFMRegressor`.

# Related PR

https://github.com/online-ml/river/pull/784