### PR TITLE
[HOFM] Simplify the latent scalar calculation with numpy.multiply

### DIFF
--- a/river/facto/hofm.py
+++ b/river/facto/hofm.py
@@ -3,6 +3,8 @@ import functools
 import itertools
 import typing
 
+import numpy as np
+
 from river import base, optim, utils
 
 from .base import BaseFM
@@ -72,9 +74,9 @@ class HOFM(BaseFM):
         )
         latent_scalar_product = sum(
             functools.reduce(
-                lambda x, y: x * y, (self.latents[j][d][f] for j in combination)
+                lambda x, y: np.multiply(x, y),
+                (self.latents[j][d] for j in combination),
             )
-            for f in range(self.n_factors)
         )
         return feature_product * latent_scalar_product
 


### PR DESCRIPTION
<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->
# Why

To make the logic simpler and more performant

# What

Use [numpy.multiply](https://numpy.org/doc/stable/reference/generated/numpy.multiply.html) instead of for loop for `n_factors`.

# Local check

Used [the example in the doc](https://riverml.xyz/latest/examples/matrix-factorization-for-recommender-systems-part-2/#higher-order-factorization-machines-hofm) and it reduced almost 30% of the time for the whole calculation.

Before:

```
[25,000] MAE: 0.761297, RMSE: 0.962054 – 0:00:52.080646 – 2.61 MB
[50,000] MAE: 0.751865, RMSE: 0.951499 – 0:01:44.105094 – 3.08 MB
[75,000] MAE: 0.750853, RMSE: 0.951526 – 0:02:36.503243 – 3.6 MB
[100,000] MAE: 0.750607, RMSE: 0.951982 – 0:03:27.302165 – 4.07 MB
```

After:

```
[25,000] MAE: 0.761297, RMSE: 0.962054 – 0:00:35.615119 – 2.61 MB
[50,000] MAE: 0.751865, RMSE: 0.951499 – 0:01:11.346501 – 3.08 MB
[75,000] MAE: 0.750853, RMSE: 0.951526 – 0:01:45.804468 – 3.6 MB
[100,000] MAE: 0.750607, RMSE: 0.951982 – 0:02:20.757665 – 4.07 MB
```