### PR TITLE
docs: Enable to render equations for instant loading

### DIFF
--- a/docs/javascripts/config.js
+++ b/docs/javascripts/config.js
@@ -10,3 +10,7 @@ window.MathJax = {
     processHtmlClass: "arithmatex"
   }
 };
+
+document$.subscribe(() => {
+  MathJax.typesetPromise()
+})


### PR DESCRIPTION
# why

To fix broken equations for instant loading

example:

![スクリーンショット 2021-12-07 6 59 02](https://user-images.githubusercontent.com/883228/144929512-88dcac29-f080-4bef-bcc3-2f8c8d6ae700.png)

steps to reproduce
1. Open https://riverml.xyz/latest/api/facto/FFMClassifier/
2. Click on any link from the leftside navigation.
![スクリーンショット 2021-12-07 7 11 19](https://user-images.githubusercontent.com/883228/144930934-25373af5-5a2a-427a-bb3e-384356a99bd2.png)


# what

add the following lines to `docs/javascrpts/config.js` 

```javascript
document$.subscribe(() => {
  MathJax.typesetPromise()
})
```

reference: https://squidfunk.github.io/mkdocs-material/reference/mathjax/?h=math#configuration

# Check

Checked the fixed behavior in my local with `make livedoc`