### PR TITLE
Inherit AnomalyDetector from Classifier

### DIFF
--- a/river/anomaly/base.py
+++ b/river/anomaly/base.py
@@ -1,17 +1,24 @@
 import abc
+import typing
 
 from river import base
 
 
-class AnomalyDetector(base.Estimator):
+class AnomalyDetector(base.Classifier):
     """An anomaly detector."""
 
     @property
     def _supervised(self):
         return False
 
+    @property
+    def _multiclass(self):
+        return False
+
     @abc.abstractmethod
-    def learn_one(self, x: dict) -> "AnomalyDetector":
+    def learn_one(
+        self, x: dict, y: base.typing.ClfTarget = None, **kwargs
+    ) -> "AnomalyDetector":
         """Update the model.
 
         Parameters
@@ -42,3 +49,7 @@ class AnomalyDetector(base.Estimator):
         normal observation.
 
         """
+
+    def predict_proba_one(self, x: dict) -> typing.Dict[base.typing.ClfTarget, float]:
+        p = self.score_one(x=x)
+        return {True: p, False: 1.0 - p}

--- a/river/anomaly/hst.py
+++ b/river/anomaly/hst.py
@@ -221,7 +221,7 @@ class HalfSpaceTrees(AnomalyDetector):
         """The largest potential anomaly score."""
         return self.n_trees * self.window_size * (2 ** (self.height + 1) - 1)
 
-    def learn_one(self, x):
+    def learn_one(self, x: dict, y: base.typing.ClfTarget = None, **kwargs):
 
         # The trees are built when the first observation comes in
         if not self.trees:

--- a/river/anomaly/svm.py
+++ b/river/anomaly/svm.py
@@ -3,6 +3,7 @@ import typing
 import pandas as pd
 
 from river import optim
+from river.base import typing as river_typing
 from river.linear_model.glm import GLM
 
 from .base import AnomalyDetector
@@ -83,10 +84,15 @@ class OneClassSVM(GLM, AnomalyDetector):
             + 2.0 * self.intercept_lr.get(self.optimizer.n_iterations) * self.l2
         )
 
-    def learn_one(self, x):
+    def learn_one(self, x: dict, y: river_typing.ClfTarget = None, **kwargs):
         return super().learn_one(x, y=1)
 
-    def learn_many(self, X):
+    def learn_many(
+        self,
+        X: pd.DataFrame,
+        y: pd.Series = None,
+        w: typing.Union[float, pd.Series] = 1,
+    ):
         return super().learn_many(X, y=pd.Series(True, index=X.index))
 
     def score_one(self, x):

--- a/river/anomaly/threshold.py
+++ b/river/anomaly/threshold.py
@@ -1,4 +1,4 @@
-from river.base import Wrapper
+from river.base import Wrapper, typing
 from river.stats import Quantile
 
 from .base import AnomalyDetector
@@ -14,7 +14,7 @@ class Thresholder(AnomalyDetector, Wrapper):
     def _wrapped_model(self):
         return self.anomaly_detector
 
-    def learn_one(self, x):
+    def learn_one(self, x: dict, y: typing.ClfTarget = None, **kwargs):
         self.anomaly_detector.learn_one(x)
         return self
 


### PR DESCRIPTION
Hi all,

based on #794 I changed the `AnomalyDetector` to inherit from a `base.Classifier`.
However, I think there are still some smaller bugs and open questions / discussion points:

Errors / Bugs:
- For the tests, the Pishing dataset is not found in cache - Here, I don't know how to solve this issue.

Discussion / Open Questions:
- the `learn_one` function of the `base.Classifier` takes the arguments `self, x: dict, y: base.typing.ClfTarget, **kwargs`. Since an `AnomalyDetector` is now a `base.Classifier` a work around is to pass `y = None` as default, as suggested in the PR. 
- I added the `predict_proba_one` function, which differs from the `score_one` function in the return type.
- In the future I would suggest to move the `AnomalyDetector` into the base directory?
- In the future a `predict_learn_one`method, could lead to faster Estimators, since in some cases one only need to predict once to update the model. 

What do you think? 

Best
Cedric
