### PR TITLE
Upgrade NumPy dependency version - ImportError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ AUTHOR = "Max Halford"
 REQUIRES_PYTHON = ">=3.7.0"
 
 # Package requirements.
-base_packages = ["numpy>=1.18.1", "scipy>=1.4.1", "pandas>=1.0.1"]
+base_packages = ["numpy>=1.20.0", "scipy>=1.4.1", "pandas>=1.0.1"]
 
 compat_packages = base_packages + [
     "scikit-learn",


### PR DESCRIPTION
This pull request is dedicated to the discussion #815.  When the version of NumPy is < `1.2.0` we get an error `E ImportError: numpy.core.multiarray failed to import`. I edited the requirements so that the version of NumPy is >= `1.2.0` when installing river. ☀️

Here is the complete error when NumPy version is lower than `1.2.0`:

```sh
Traceback:
__init__.pxd:943: in numpy.import_array
    ???
E   RuntimeError: module compiled against API version 0xe but this version of numpy is 0xd

During handling of the above exception, another exception occurred:
../../../opt/miniconda3/envs/cherche/lib/python3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
cherche/retrieve/__init__.py:7: in <module>
    from .tfidf import TfIdf
cherche/retrieve/tfidf.py:7: in <module>
    from river import feature_extraction
../../../opt/miniconda3/envs/cherche/lib/python3.8/site-packages/river/__init__.py:9: in <module>
    from . import (
../../../opt/miniconda3/envs/cherche/lib/python3.8/site-packages/river/ensemble/__init__.py:10: in <module>
    from .adaptive_random_forest import (
../../../opt/miniconda3/envs/cherche/lib/python3.8/site-packages/river/ensemble/adaptive_random_forest.py:9: in <module>
    from river import base, metrics, stats, tree
../../../opt/miniconda3/envs/cherche/lib/python3.8/site-packages/river/metrics/__init__.py:35: in <module>
    from .expected_mutual_info import expected_mutual_info
build/lib.macosx-10.9-x86_64-3.7/river/metrics/expected_mutual_info.pyx:11: in init river.metrics.expected_mutual_info
    ???
__init__.pxd:945: in numpy.import_array
    ???
E   ImportError: numpy.core.multiarray failed to import
```