### PR TITLE
Adding support for a variable vocab KMeans

### DIFF
--- a/river/cluster/__init__.py
+++ b/river/cluster/__init__.py
@@ -4,5 +4,13 @@ from .dbstream import DBSTREAM
 from .denstream import DenStream
 from .k_means import KMeans
 from .streamkmeans import STREAMKMeans
+from .variable_vocab_kmeans import VariableVocabKMeans
 
-__all__ = ["CluStream", "DBSTREAM", "DenStream", "KMeans", "STREAMKMeans"]
+__all__ = [
+    "CluStream",
+    "DBSTREAM",
+    "DenStream",
+    "KMeans",
+    "STREAMKMeans",
+    "VariableVocabKMeans",
+]

--- a/river/cluster/variable_vocab_kmeans.py
+++ b/river/cluster/variable_vocab_kmeans.py
@@ -1,0 +1,171 @@
+import collections
+import functools
+import random
+from typing import Dict, List
+
+from river import base, utils
+
+__all__ = ["VariableVocabKMeans"]
+
+
+class VariableVocabKMeans(base.Clusterer):
+    """Variable Vocabulary KMeans
+
+    Instead of requiring a fixed set of features that are numerical, this version
+    of Kmeans:
+
+    1. Allows for providing a vocabulary (string variables) that are stored with the model
+    2. Allows adding new words to the vocabulary.
+
+    When we encounter a new word, given that it isn't in the vocabulary this means that
+    we've never seen it before (and we know that the cluster centers can be given a  0
+    value. The input parameters are the same s for KMeans.
+
+    Parameters
+    ----------
+    n_clusters
+        Maximum number of clusters to assign.
+    halflife
+        Amount by which to move the cluster centers, a reasonable value if between 0 and 1.
+    mu
+        Mean of the normal distribution used to instantiate cluster positions.
+    sigma
+        Standard deviation of the normal distribution used to instantiate cluster positions.
+    p
+        Power parameter for the Minkowski metric. When `p=1`, this corresponds to the Manhattan
+        distance, while `p=2` corresponds to the Euclidean distance.
+    seed
+        Random seed used for generating initial centroid positions.
+
+    Attributes
+    ----------
+    vocab: dict
+        Vocabulary that matches str tokens to their index in each center vector
+    centers : dict
+        Central positions of each cluster.
+
+    Examples
+    --------
+
+    >>> from river import cluster
+    >>> from river import stream
+
+    # Instead of numbers, we provide vectors of tokens (or strings)
+    >>> X = [
+    ...    ["one", "two"],
+    ...    ["one", "four"],
+    ...    ["one", "zero"],
+    ...    ["five", "six"],
+    ...    ["seven", "eight"],
+    ...    ["nine", "nine"]
+    ]
+
+    >>> model = cluster.VariableVocabKMeans(n_clusters=2, halflife=0.4, sigma=3, seed=0)
+
+    >>> for i, vocab in enumerate(stream.iter_counts(X)):
+    ...     model = model.learn_one(vocab)
+    ...     center = model.predict_one(vocab)
+    ...     print(f'{vocab} is assigned to cluster {center}')
+    ...     # Get coord/value for each word
+    ...     model.get_center_vocab(center)
+    ...
+
+    ... {'one': 1, 'two': 1} is assigned to cluster 0
+    ... {'one': 1, 'four': 1} is assigned to cluster 0
+    ... {'one': 1, 'zero': 1} is assigned to cluster 0
+    ... {'five': 1, 'six': 1} is assigned to cluster 1
+    ... {'seven': 1, 'eight': 1} is assigned to cluster 2
+    ... {'nine': 2} is assigned to cluster 3
+    """
+
+    def __init__(
+        self, n_clusters=5, halflife=0.5, mu=0, sigma=1, p=2, seed: int = None
+    ):
+        self.n_clusters = n_clusters
+        self.halflife = halflife
+        self.mu = mu
+        self.sigma = sigma
+        self.p = p
+        self.seed = seed
+        self._rng = random.Random(seed)
+        rand_gauss = functools.partial(self._rng.gauss, self.mu, self.sigma)
+
+        # Vocab is a lookup between vocab items and vector indices
+        self.vocab = {}
+
+        # Current index into vocab array
+        self.index = 0
+        self.centers = {
+            i: collections.defaultdict(rand_gauss) for i in range(n_clusters)
+        }  # type: ignore
+
+    def get_center_vocab(self, center: int):
+        """
+        Given the id of a centroid, get the vocab and weights / counts for it.
+        """
+        # We need to be able to look up words based on index
+        lookup = {idx: word for word, idx in self.vocab.items()}
+        return {lookup[x]: count for x, count in self.centers[center].items()}
+
+    def learn_predict_one(self, x: Dict[str, int]):
+        """Equivalent to `k_means.learn_one(x).predict_one(x)`, but faster."""
+
+        # Find the cluster with the closest center
+        # Don't update vocab yet because it doesn't matter if we haven't
+        # seen a token - it will return a count of 0.
+        closest = self.predict_one(x)
+
+        # Ensure centers have all features for future learning
+        self.update_vocab(x)
+
+        # Move the cluster's center (ONLY the one closest to!)
+        # By this point all words are added to the vocabulary
+        for word, count in x.items():
+            xx = {self.vocab[word]: count}
+            for i, xi in xx.items():
+                self.centers[closest][i] += self.halflife * (
+                    xi - self.centers[closest][i]
+                )
+
+        return closest
+
+    def learn_one(self, x):
+        self.learn_predict_one(x)
+        return self
+
+    def update_vocab(self, vocab: Dict[str, int]):
+        """
+        Given a vector of features, ensure we have each in our vocab
+        """
+        # We can do one dict update per new word
+        updates = {}
+        for word, count in vocab.items():
+            if word not in self.vocab:
+                self.vocab[word] = self.index
+
+                # The word has never been seen by any previous centroid
+                updates[self.index] = 0
+                self.index += 1
+
+        # This is akin to appending a new dimension to each vector
+        for _, center in self.centers.items():
+            center.update(updates)
+
+    def predict_one(self, x: List[List[str]]):
+
+        # Ensure we provide a lookup between features (vocab indices)
+        # This should only include words we have seen before
+        xx = {
+            self.vocab.get(word): count
+            for word, count in x.items()
+            if word in self.vocab
+        }
+
+        def get_distance(c):
+            return utils.math.minkowski_distance(a=self.centers[c], b=xx, p=self.p)
+
+        return min(self.centers, key=get_distance)
+
+    @classmethod
+    def _unit_test_params(cls):
+        yield {"n_clusters": 5}

--- a/river/stream/__init__.py
+++ b/river/stream/__init__.py
@@ -6,6 +6,7 @@ The module includes tools to iterate over data streams.
 from .cache import Cache
 from .iter_arff import iter_arff
 from .iter_array import iter_array
+from .iter_counts import iter_counts
 from .iter_csv import iter_csv
 from .iter_libsvm import iter_libsvm
 from .qa import simulate_qa
@@ -16,6 +17,7 @@ __all__ = [
     "iter_arff",
     "iter_array",
     "iter_csv",
+    "iter_counts",
     "iter_libsvm",
     "simulate_qa",
     "shuffle",

--- a/river/stream/iter_counts.py
+++ b/river/stream/iter_counts.py
@@ -1,0 +1,47 @@
+from typing import List
+
+__all__ = ["iter_counts"]
+
+
+def iter_counts(X: List[List[str]]):
+    """
+    Given lists of words, return vocabularies with counts. This is useful
+    for the VariableVocabKMeans model that expects this input.
+
+    Parameters
+    ----------
+    X
+        A list of lists of words (str)
+
+    Example
+    -------
+
+    >>> X = [
+    ...    ["one", "two"],
+    ...    ["one", "four"],
+    ...    ["one", "zero"],
+    ...    ["four", "two"],
+    ...    ["four", "four"],
+    ...    ["four", "zero"]
+    ... ]
+
+    >>> for i, vocab in enumerate(stream.iter_counts(X)):
+    ...    print(vocab)
+
+    ... {'one': 1, 'two': 1}
+    ... {'one': 1, 'four': 1}
+    ... {'one': 1, 'zero': 1}
+    ... {'four': 1, 'two': 1}
+    ... {'four': 2}
+    ... {'four': 1, 'zero': 1}
+    """
+    # Convert to counts (vocabulary)
+    counts = []
+    for words in X:
+        vocab = {}
+        for word in words:
+            if word not in vocab:
+                vocab[word] = 0
+            vocab[word] += 1
+        counts.append(vocab)
+    return counts


### PR DESCRIPTION
Currently the kmeans model(s) require providing a set of indexed values to map to the currently known centroids, and the models allow prediction given a feature has not yet been seen, but it is not clear that it is easy to update models with new
features, and especially when they are strings! This pull request adds a new KMeans class, VariableVocabKMeans that allows:

1. providing a dictionary of strings and integers more suitable for NLP / text processing
2. updating the model and vocabulary with new words as they are seen.
 
This means that to learn, the user provides a vocabulary (lookup/dict of keys as words, values as counts or other value for the word) that is then mapped into the same model space as the traditional KMeans via a vocabulary lookup. To support this I added `stream.iter_counts` that can transform a vector of tokens into the suitable input (since the user will need to do it every time!). I am also adding a function to get a centroid and return the words instead of the indices, since that might be useful.

The use case for this is what I'm working on - I started out with Word2Vec/Doc2Vec to generate vectors (which would work nicely with the current KMeans implementation since that dimension does not change) but then I realized I really don't want to have to carry around two models - the word2vec AND the online-ml KMeans to basically better visualize that space. With this new model I can simply do my processing of the text to generate tokens and feed them directly to the online-ml system, and I don't need Word2Vec. We of course lose context with that, but since my data is standardized error messages, we can be pretty confident that when we see a set of tokens, they are going to generally come from the same order. Here is an example of running my new model:

```python
from river import cluster, stream


def main():

    # Create variable vocab kmeans
    # You'd typically do some kind of NLP preprocessing to get tokens
    X = [
        ["one", "two"],
        ["one", "four"],
        ["one", "zero"],
        ["five", "six"],
        ["seven", "eight"],
        ["nine", "nine"]
    ]

    model = cluster.VariableVocabKMeans(n_clusters=4, halflife=0.4, sigma=3, seed=0)

    # We want to convert a vector of words into counts
    for i, vocab in enumerate(stream.iter_counts(X)):
        model = model.learn_one(vocab)
        center = model.predict_one(vocab)
        print(f'{vocab} is assigned to cluster {center}')

        # this has words (key) and coordinate (value)
        coords = model.get_center_vocab(center)
        print(coords)

if __name__ == "__main__":
    main()
```
I ran the pre-commit for black, isort, etc., and please let me know how/where to test and what other changes you would like, and if you'll accept this idea, period! I hope that you will consider it because I know a lot of researchers do NLP stuffs and this seems like a nice way to extend that to KMeans clustering.

And a follow up question - I was looking through metrics and the only one that seemed suitable for clustering was https://github.com/online-ml/river/blob/main/river/metrics/fowlkes_mallows.py but I believe that is for _between_ clusters and not appropriate for a single cluster. Is there anything akin to looking at average distances to centroids or something like that? You can probably guess I'm anticipating adding a "cluster" class to django-river-ml and I want some metrics associated :)

Thank you!


Signed-off-by: vsoch <vsoch@users.noreply.github.com>

<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->
