### PR TITLE
Make AMRules show a default rule consequent

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,3 +1,8 @@
 # Unreleased
 
 - Moved all metrics in `metrics.cluster` except `metrics.Silhouette` to [river-extra](https://github.com/online-ml/river-extra).
+
+## rules
+
+- Now AMRules' rules representation show a default consequent: the target mean.
+- AMRules's `debug_one` explicitly indicates the prediction strategy used by each rule.

--- a/river/rules/amrules.py
+++ b/river/rules/amrules.py
@@ -542,6 +542,6 @@ class AMRules(base.Regressor):
                 _print(f"Final prediction: {self.predict_one(x)}")
         else:
             _print("Default rule triggered:")
-            _print(f"\tPrediction: {self._default_rule.predict_one(x)}")
+            _print(f"\tPrediction ({self.pred_type}): {self._default_rule.predict_one(x)}")
 
         return buffer.getvalue()

--- a/river/rules/amrules.py
+++ b/river/rules/amrules.py
@@ -155,6 +155,10 @@ class RegRule(HoeffdingRule, base.Regressor, AnomalyDetector):
     def predict_one(self, x: dict):
         return self.pred_model.predict_one(x)
 
+    def __repr__(self):
+        base_repr = super().__repr__()
+        return f"{base_repr} -> {self.statistics.mean.get()}"
+
 
 class AMRules(base.Regressor):
     """Adaptive Model Rules.
@@ -516,8 +520,8 @@ class AMRules(base.Regressor):
         ...     model = model.learn_one(x, y)
 
         >>> print(model.debug_one(x))
-        Rule 0: 3 > 0.5060027751338432 and 0 > 0.25379161985850063
-            Prediction: 18.72169583862947
+        Rule 0: 3 > 0.5060027751338432 and 0 > 0.25379161985850063 -> 18.28248930883455
+            Prediction (adaptive): 18.72169583862947
         <BLANKLINE>
 
         """
@@ -529,7 +533,7 @@ class AMRules(base.Regressor):
             if rule.covers(x):
                 any_covered = True
                 _print(f"Rule {i}: {repr(rule)}")
-                _print(f"\tPrediction: {rule.predict_one(x)}")
+                _print(f"\tPrediction ({self.pred_type}): {rule.predict_one(x)}")
             if self.ordered_rule_set:
                 break
 

--- a/river/rules/amrules.py
+++ b/river/rules/amrules.py
@@ -542,6 +542,8 @@ class AMRules(base.Regressor):
                 _print(f"Final prediction: {self.predict_one(x)}")
         else:
             _print("Default rule triggered:")
-            _print(f"\tPrediction ({self.pred_type}): {self._default_rule.predict_one(x)}")
+            _print(
+                f"\tPrediction ({self.pred_type}): {self._default_rule.predict_one(x)}"
+            )
 
         return buffer.getvalue()

--- a/river/rules/amrules.py
+++ b/river/rules/amrules.py
@@ -157,7 +157,7 @@ class RegRule(HoeffdingRule, base.Regressor, AnomalyDetector):
 
     def __repr__(self):
         base_repr = super().__repr__()
-        return f"{base_repr} -> {self.statistics.mean.get()}"
+        return f"{base_repr} -> {self.statistics.mean.get():.4f}"
 
 
 class AMRules(base.Regressor):
@@ -520,8 +520,8 @@ class AMRules(base.Regressor):
         ...     model = model.learn_one(x, y)
 
         >>> print(model.debug_one(x))
-        Rule 0: 3 > 0.5060027751338432 and 0 > 0.25379161985850063 -> 18.28248930883455
-            Prediction (adaptive): 18.72169583862947
+        Rule 0: 3 > 0.5060 and 0 > 0.2538 -> 18.2825
+            Prediction (adaptive): 18.7217
         <BLANKLINE>
 
         """
@@ -533,7 +533,7 @@ class AMRules(base.Regressor):
             if rule.covers(x):
                 any_covered = True
                 _print(f"Rule {i}: {repr(rule)}")
-                _print(f"\tPrediction ({self.pred_type}): {rule.predict_one(x)}")
+                _print(f"\tPrediction ({self.pred_type}): {rule.predict_one(x):.4f}")
             if self.ordered_rule_set:
                 break
 
@@ -543,7 +543,7 @@ class AMRules(base.Regressor):
         else:
             _print("Default rule triggered:")
             _print(
-                f"\tPrediction ({self.pred_type}): {self._default_rule.predict_one(x)}"
+                f"\tPrediction ({self.pred_type}): {self._default_rule.predict_one(x):.4f}"
             )
 
         return buffer.getvalue()

--- a/river/rules/base.py
+++ b/river/rules/base.py
@@ -229,7 +229,7 @@ class HoeffdingRule(base.Estimator, metaclass=abc.ABCMeta):
                 # Add a new literal
                 self.literals.append(lit)
 
-            # Reset all the statistics stored in the the decision rule
+            # Reset all the statistics stored in the decision rule
             updated_rule = self.clone()
             # Keep the literals
             updated_rule.literals.extend(self.literals)

--- a/river/rules/base.py
+++ b/river/rules/base.py
@@ -39,9 +39,9 @@ class NumericLiteral(Literal):
 
     def describe(self):
         if not self.neg:
-            return f"{self.on} ≤ {self.at}"
+            return f"{self.on} ≤ {self.at:.4f}"
         else:
-            return f"{self.on} > {self.at}"
+            return f"{self.on} > {self.at:.4f}"
 
 
 class NominalLiteral(Literal):


### PR DESCRIPTION
The `repr` method from AMRules' rules only shows the literals. Even when we don't pass an instance for debugging purposed (as in `debug_one`) it is nice to have an idea of what the rules output.

This PR makes the regression rules show the target mean as the default consequent of a rule. `debug_one` was slightly updated to explicitly show the prediction strategy.
