### PR TITLE
[AMRules] Revert default rule consequent

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -14,7 +14,6 @@
 
 ## rules
 
-- Now AMRules' rules representation show a default consequent: the target mean.
 - AMRules's `debug_one` explicitly indicates the prediction strategy used by each rule.
 - Fix bug in `debug_one` (AMRules) where prediction explanations were incorrectly displayed when `ordered_rule_set=True`.
 

--- a/river/rules/amrules.py
+++ b/river/rules/amrules.py
@@ -155,10 +155,6 @@ class RegRule(HoeffdingRule, base.Regressor, AnomalyDetector):
     def predict_one(self, x: dict):
         return self.pred_model.predict_one(x)
 
-    def __repr__(self):
-        base_repr = super().__repr__()
-        return f"{base_repr} -> {self.statistics.mean.get():.4f}"
-
 
 class AMRules(base.Regressor):
     """Adaptive Model Rules.
@@ -520,7 +516,7 @@ class AMRules(base.Regressor):
         ...     model = model.learn_one(x, y)
 
         >>> print(model.debug_one(x))
-        Rule 0: 3 > 0.5060 and 0 > 0.2538 -> 18.2825
+        Rule 0: 3 > 0.5060 and 0 > 0.2538
             Prediction (adaptive): 18.7217
         <BLANKLINE>
 


### PR DESCRIPTION
After second thought as testing, I decided to revert the rules' repr method to its previous state.

Here's some history for future generations:

- After training an AMRules model, it might be interesting to check the created rules for interpretation. We are not interested in predictions for specific instances, just the ruleset in this scenario.
- The default representation of the rules did not show a consequent, i.e., the output for each rule (in `debug_one`, we use the input `x` to generate predictions). That's why I decided to make the rules output the mean `y` value by default.
- However, after some extensive testing, I discovered some downsides with that approach:
    a. Clutter: calls to `debug_one` become confusing, as we show two outputs, namely, the "default consequent" and the actual rule output
    b. *Inconsistency* (the worst part): as it's up to the user to select the prediction strategy for AMRules, we do not have a standardized way to get predictions for each rule without an `x`. I used the split statistics to obtain the mean  `y` value (and ignored the prediction model of the rule). But here's the deal: after each rule expansion, the split statistics are reset for consistency, whereas the prediction models are kept. When using split statistics as outputs, I started getting `0` as the default outcome of a rule, which doesn't make sense. In summary, there were discrepancies between calls to `debug_one` and the `repr` of standalone rules.

Long story short, I decided to roll back those changes. If someone, like me, wants to inspect standalone rules and get predictions, even without passing `x`, here's my tip:

1. Use `pred_type="mean"`
2. Get the rules' literals by calling `repr(rule)`
3. Get predictions by accessing the mean predictor: `rule.pred_model.mean.get()`
4. Join and print everything in a nice way

Tricky for now, but this is a very specific use case. All other use cases can always rely on `debug_one` :)