### PR TITLE
dbstream: allow microcluster centoid update to have different terms

### DIFF
--- a/river/cluster/dbstream.py
+++ b/river/cluster/dbstream.py
@@ -196,11 +196,13 @@ class DBSTREAM(base.Clusterer):
                     )
                     + 1
                 )
+
+                # Update the center (i) with overlapping keys (j)
                 self.micro_clusters[i].center = {
                     j: self.micro_clusters[i].center[j]
                     + self._gaussian_neighborhood(x, self.micro_clusters[i].center)
                     * (x[j] - self.micro_clusters[i].center[j])
-                    for j in self.micro_clusters[i].center.keys()
+                    for j in self.micro_clusters[i].center.keys() if j in x
                 }
                 self.micro_clusters[i].last_update = self.time_stamp
 

--- a/river/cluster/dbstream.py
+++ b/river/cluster/dbstream.py
@@ -202,7 +202,8 @@ class DBSTREAM(base.Clusterer):
                     j: self.micro_clusters[i].center[j]
                     + self._gaussian_neighborhood(x, self.micro_clusters[i].center)
                     * (x[j] - self.micro_clusters[i].center[j])
-                    for j in self.micro_clusters[i].center.keys() if j in x
+                    for j in self.micro_clusters[i].center.keys()
+                    if j in x
                 }
                 self.micro_clusters[i].last_update = self.time_stamp
 


### PR DESCRIPTION
I was going to open an issue, but figured this was a small enough change that it would be easier to open a pull request to both discuss and show what I mean! I was testing dbstream out more, and hit this case where the microcluster center couldn't update because of a key index error. This issue is a lot like the previous changes that we made to allow for updates only given the overlapping keys. So the solution of course is to add the "if j in x" to mapping of j to the new i center, and then you are allowed to have different keys without throwing an error.

Of course I'm doing this almost at 1am so no promises that my brain is working correctly :laughing: 