### PR TITLE
Fix for protect_anomaly_detector logic

### DIFF
--- a/river/anomaly/filter.py
+++ b/river/anomaly/filter.py
@@ -168,7 +168,7 @@ class QuantileFilter(anomaly.base.AnomalyFilter):
 
     def learn_one(self, *args):
         score = self.score_one(*args)
-        if self.protect_anomaly_detector and not self.classify(score):
+        if not self.protect_anomaly_detector or not self.classify(score):
             self.anomaly_detector.learn_one(*args)
         self.quantile.update(score)
         return self


### PR DESCRIPTION
The anomaly_dector should be updated if we are not protecting the detector or if it is not an anomaly.  I.e. the only time it should not be updated is when we are protecting the detector and it is an anomaly.