### PR TITLE
Improvements on GaussianScorer

### DIFF
--- a/river/proba/time_rolling.py
+++ b/river/proba/time_rolling.py
@@ -1,6 +1,7 @@
 import bisect
 import datetime as dt
 import typing
+import pytz
 
 from . import base
 
@@ -52,7 +53,7 @@ class TimeRolling(base.Distribution):
         self.dist = dist
         self.period = period
         self._events: typing.List[typing.Tuple[dt.datetime, typing.Any]] = []
-        self._latest = dt.datetime(1, 1, 1)
+        self._latest =  pytz.utc.localize(dt.datetime.utcfromtimestamp(0))
 
     def update(self, x, t: dt.datetime):
         self.dist.update(x)


### PR DESCRIPTION
This PR adds 2 features and 3 parameters:

### Params

1. `window_size_t=None`
2. `timestamp_label=None` ("de-facto" mandatory if window_size_t != None)
3. `timestamp_format='%Y-%m-%dT%H:%M:%S%z `

### Features

1. GaussianScorer supports `grace_period > window_size`. This was added here: https://github.com/online-ml/river/commit/3163ea3bb67961b23fd7850ace437ef820258e5f
2. GaussianScorer now give options to pass `window_size` as a time_delta. To do this users have to set the `window_size_t` attribute. The .learn_one function will then try to guess the time value from a variable `t` following this priority list:

    a. `t` is a datetime object
    b. `t` is an integer (epoch timestamp)
   c. `t` is something else and will be parsed using the `datetime.strptime` function taking `timestamp_format` as formatting string
   
   The variable `t` is detived by the `_` dictionary using `timestamp_label` as an index