### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,16 +32,10 @@ $ conda create -n river -y python=3.9
 $ conda activate river
 ```
 
-Then, navigate to your cloned fork and install the required dependencies:
+Then, navigate to your cloned fork and install `river` and the required dependencies in [development mode](https://stackoverflow.com/questions/19048732/python-setup-py-develop-vs-install):
 
 ```sh
 $ pip install -e ".[dev]"
-```
-
-Next, install `river` in [development mode](https://stackoverflow.com/questions/19048732/python-setup-py-develop-vs-install):
-
-```sh
-$ python setup.py develop
 ```
 
 Finally, install the [pre-commit](https://pre-commit.com/) push hooks. This will run some code quality checks every time you push to GitHub.


### PR DESCRIPTION
There is no need to run both `pip install -e ".[dev]"` and `python setup.py develop` when installing `river` and its development dependencies locally, the first command already does everything.

As indicated in the note section of the [updated first answer](https://stackoverflow.com/a/19048754/7952850) of the SO link:

> **Note:** It is highly recommended to use `pip install .` (regular install) and `pip install -e .` (developer install) to install packages, as invoking `setup.py` directly will do the wrong things for many dependencies, such as pull prereleases and incompatible package versions, or make the package hard to uninstall with `pip`.