### PR TITLE
Postpone pandas import in base module

### DIFF
--- a/river/base/classifier.py
+++ b/river/base/classifier.py
@@ -5,6 +5,9 @@ from river import base
 
 from . import estimator
 
+if typing.TYPE_CHECKING:
+    import pandas as pd
+
 
 class Classifier(estimator.Estimator):
     """A classifier."""

--- a/river/base/classifier.py
+++ b/river/base/classifier.py
@@ -1,8 +1,6 @@
 import abc
 import typing
 
-import pandas as pd
-
 from river import base
 
 from . import estimator
@@ -82,7 +80,7 @@ class MiniBatchClassifier(Classifier):
     """A classifier that can operate on mini-batches."""
 
     @abc.abstractmethod
-    def learn_many(self, X: pd.DataFrame, y: pd.Series) -> "MiniBatchClassifier":
+    def learn_many(self, X: "pd.DataFrame", y: "pd.Series") -> "MiniBatchClassifier":
         """Update the model with a mini-batch of features `X` and boolean targets `y`.
 
         Parameters
@@ -98,7 +96,7 @@ class MiniBatchClassifier(Classifier):
 
         """
 
-    def predict_proba_many(self, X: pd.DataFrame) -> pd.DataFrame:
+    def predict_proba_many(self, X: "pd.DataFrame") -> "pd.DataFrame":
         """Predict the outcome probabilities for each given sample.
 
         Parameters
@@ -118,7 +116,7 @@ class MiniBatchClassifier(Classifier):
         # that a classifier does not support predict_proba_many.
         raise NotImplementedError
 
-    def predict_many(self, X: pd.DataFrame) -> pd.Series:
+    def predict_many(self, X: "pd.DataFrame") -> "pd.Series":
         """Predict the outcome for each given sample.
 
         Parameters

--- a/river/base/regressor.py
+++ b/river/base/regressor.py
@@ -1,7 +1,5 @@
 import abc
 
-import pandas as pd
-
 from river import base
 
 from . import estimator
@@ -47,7 +45,7 @@ class MiniBatchRegressor(Regressor):
     """A regressor that can operate on mini-batches."""
 
     @abc.abstractmethod
-    def learn_many(self, X: pd.DataFrame, y: pd.Series) -> "MiniBatchRegressor":
+    def learn_many(self, X: "pd.DataFrame", y: "pd.Series") -> "MiniBatchRegressor":
         """Update the model with a mini-batch of features `X` and real-valued targets `y`.
 
         Parameters
@@ -64,7 +62,7 @@ class MiniBatchRegressor(Regressor):
         """
 
     @abc.abstractmethod
-    def predict_many(self, X: pd.DataFrame) -> pd.Series:
+    def predict_many(self, X: "pd.DataFrame") -> "pd.Series":
         """Predict the outcome for each given sample.
 
         Parameters

--- a/river/base/regressor.py
+++ b/river/base/regressor.py
@@ -4,6 +4,8 @@ from river import base
 
 from . import estimator
 
+if typing.TYPE_CHECKING:
+    import pandas as pd
 
 class Regressor(estimator.Estimator):
     """A regressor."""

--- a/river/base/regressor.py
+++ b/river/base/regressor.py
@@ -1,4 +1,5 @@
 import abc
+import typing
 
 from river import base
 

--- a/river/base/regressor.py
+++ b/river/base/regressor.py
@@ -8,6 +8,7 @@ from . import estimator
 if typing.TYPE_CHECKING:
     import pandas as pd
 
+
 class Regressor(estimator.Estimator):
     """A regressor."""
 

--- a/river/base/transformer.py
+++ b/river/base/transformer.py
@@ -2,6 +2,8 @@ import abc
 
 from river import base
 
+if typing.TYPE_CHECKING:
+    import pandas as pd
 
 class BaseTransformer:
     def __add__(self, other):

--- a/river/base/transformer.py
+++ b/river/base/transformer.py
@@ -1,7 +1,5 @@
 import abc
 
-import pandas as pd
-
 from river import base
 
 
@@ -107,7 +105,7 @@ class MiniBatchTransformer(Transformer):
     """A transform that can operate on mini-batches."""
 
     @abc.abstractmethod
-    def transform_many(self, X: pd.DataFrame) -> pd.DataFrame:
+    def transform_many(self, X: "pd.DataFrame") -> "pd.DataFrame":
         """Transform a mini-batch of features.
 
         Parameters
@@ -121,7 +119,7 @@ class MiniBatchTransformer(Transformer):
 
         """
 
-    def learn_many(self, X: pd.DataFrame) -> "Transformer":
+    def learn_many(self, X: "pd.DataFrame") -> "Transformer":
         """Update with a mini-batch of features.
 
         A lot of transformers don't actually have to do anything during the `learn_many` step
@@ -150,7 +148,7 @@ class MiniBatchSupervisedTransformer(Transformer):
         return True
 
     @abc.abstractmethod
-    def learn_many(self, X: pd.DataFrame, y: pd.Series) -> "MiniBatchSupervisedTransformer":
+    def learn_many(self, X: "pd.DataFrame", y: "pd.Series") -> "MiniBatchSupervisedTransformer":
         """Update the model with a mini-batch of features `X` and targets `y`.
 
         Parameters
@@ -168,7 +166,7 @@ class MiniBatchSupervisedTransformer(Transformer):
         return self
 
     @abc.abstractmethod
-    def transform_many(self, X: pd.DataFrame) -> pd.DataFrame:
+    def transform_many(self, X: "pd.DataFrame") -> "pd.DataFrame":
         """Transform a mini-batch of features.
 
         Parameters

--- a/river/base/transformer.py
+++ b/river/base/transformer.py
@@ -6,6 +6,7 @@ from river import base
 if typing.TYPE_CHECKING:
     import pandas as pd
 
+
 class BaseTransformer:
     def __add__(self, other):
         """Fuses with another Transformer into a TransformerUnion."""

--- a/river/base/transformer.py
+++ b/river/base/transformer.py
@@ -1,4 +1,5 @@
 import abc
+import typing
 
 from river import base
 


### PR DESCRIPTION
Before, on my laptop:

```sh
python -c "from river import stats"  0.91s user 0.22s system 268% cpu 0.419 total
```

Afterwards:

```sh
python -c "from river import stats"  0.36s user 0.09s system 263% cpu 0.174 total
```

I did specifically to make importing the `stats` module faster. There are many other places in the code base where we import pandas and scipy, so this doesn't have an impact in all modules. But it's a nice idea to have in mind.