### PR TITLE
Optimized append sorted window

### DIFF
--- a/river/utils/sorted_window.py
+++ b/river/utils/sorted_window.py
@@ -47,7 +47,7 @@ class SortedWindow(collections.UserList):
     def append(self, x):
 
         if len(self) >= self.size:
-            # The window is sorted, and a binary search is more optimized
+            # The window is sorted, and a binary search is more optimized than linear search
             start_deque = bisect.bisect_left(self, self.unsorted_window[0])
             del self[start_deque]
 

--- a/river/utils/sorted_window.py
+++ b/river/utils/sorted_window.py
@@ -47,7 +47,9 @@ class SortedWindow(collections.UserList):
     def append(self, x):
 
         if len(self) >= self.size:
-            self.remove(self.unsorted_window[0])
+            # The window is sorted, and a binary search is more optimized
+            start_deque = bisect.bisect_left(self, self.unsorted_window[0])
+            del self[start_deque]
 
         bisect.insort_left(self, x)
         self.unsorted_window.append(x)


### PR DESCRIPTION
This pull request is an optimization for rolling methods.

When the window size reaches its maximum capacity to insert a new element, it is necessary to find the "oldest" element in the sorted list to delete it.

Usually, this search is done using a linear search with a complexity of o(n); however, in our case, the elements of the list are sorted, so it is possible to do a binary search o(log(n)). 
This optimization is a simple solution for large sliding windows https://github.com/online-ml/river/issues/906.