### PR TITLE
Protect AdaptiveStandardScaler against numerical inconsistencies

### DIFF
--- a/river/preprocessing/scale.py
+++ b/river/preprocessing/scale.py
@@ -543,9 +543,13 @@ class AdaptiveStandardScaler(base.Transformer):
 
     def transform_one(self, x):
         return {
-            i: safe_div(xi - self.vars[i].mean.get(), self.vars[i].get() ** 0.5)
-            for i, xi in x.items()
+            i: safe_div(x[i] - m, s2**0.5 if s2 > 0 else 0)
+            for i, m, s2 in ((i, self.vars[i].mean.get(), self.vars[i].get()) for i in x)
         }
+
+    @property
+    def _mutable_attributes(self):
+        return {"alpha"}
 
 
 class TargetStandardScaler(compose.TargetTransformRegressor):


### PR DESCRIPTION
Sometimes `stats.EWVar` can output negative values due to numeric imprecision. The underlying variance formulae are known to be unstable and sometimes called the "naive" approach in textbooks. For the time being, we don't have a version leveraging the Welford algorithm.

This PR protects `preprocessing.AdaptiveStandardScaler` against the numerical instability of EWVar.