### PR TITLE
Remove unused attributes in stats.Cov

### DIFF
--- a/river/stats/cov.py
+++ b/river/stats/cov.py
@@ -47,7 +47,6 @@ class Cov(stats.base.Bivariate):
         self.ddof = ddof
         self.mean_x = stats.Mean()
         self.mean_y = stats.Mean()
-        self.n = 0
         self._C = 0
         self.cov = 0
 


### PR DESCRIPTION
Hi, 
While recoding the covariance in another language, I realized that the `n` attribute of `Cov` is never used.
