### PR TITLE
Ensure TargetAgg is treat as supervised

### DIFF
--- a/river/feature_extraction/agg.py
+++ b/river/feature_extraction/agg.py
@@ -204,7 +204,7 @@ class Agg(base.Transformer):
         return self._feature_name
 
 
-class TargetAgg(Agg, base.SupervisedTransformer):
+class TargetAgg(base.SupervisedTransformer, Agg):
     """Computes a streaming aggregate of the target values.
 
     This transformer is identical to `feature_extraction.Agg`, the only difference is that it


### PR DESCRIPTION
<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->

While running the bike-sharing forecasting example, I discovered a bug. `TargetAgg` is treated as an unsupervised transformer. By swapping the inheritance order the issue is solved.