### PR TITLE
Add Python 3.11 to list of built wheels

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.3.0
         env:
-          CIBW_BUILD: "cp38-* cp39-* cp310-*"
+          CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-*"
           CIBW_BEFORE_BUILD: "pip install cython"
 
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
See https://github.com/pypa/cibuildwheel/releases/tag/v2.9.0