### PR TITLE
Refactor code and use Welford's algorithm to CluStream

### DIFF
--- a/river/cluster/clustream.py
+++ b/river/cluster/clustream.py
@@ -241,7 +241,9 @@ class CluStream(base.Clusterer):
         if re_cluster is True or self._kmeans_mc is None:
             self._mc_centers = {i: mc.center for i, mc in self.micro_clusters.items()}
 
-            self._kmeans_mc = cluster.KMeans(n_clusters=self.n_macro_clusters, seed=self.seed, **self.kwargs)
+            self._kmeans_mc = cluster.KMeans(
+                n_clusters=self.n_macro_clusters, seed=self.seed, **self.kwargs
+            )
             for center in self._mc_centers.values():
                 self._kmeans_mc = self._kmeans_mc.learn_one(center)
 

--- a/river/cluster/clustream.py
+++ b/river/cluster/clustream.py
@@ -32,11 +32,6 @@ class CluStream(base.Clusterer):
     the use of Welford's algorithm [^2] to calculate the incremental variance, facilitated
     through `stats.Var()` available within `River`.
 
-    Since `River` does not support an actual "off-line" phase of the clustering algorithm (as data points
-    are assumed to arrive continuously, one at a time), we introduce a new parameter `time_gap`. After each
-    `time_gap`, an incremental K-Means clustering algorithm will be initialized and applied on currently available
-    micro-clusters to form the final solution, i.e. macro-clusters.
-
     Parameters
     ----------
     n_macro_clusters
@@ -50,9 +45,6 @@ class CluStream(base.Clusterer):
     time_window
         If the current time is `T` and the time window is `h`, we only consider
         the data that arrived within the period `(T-h,T)`.
-    time_gap
-        After each `time_gap`, the incremental K-Means will be applied on the current set of micro-clusters
-        to form the final macro-clusters (final solution).
     seed
        Random seed used for generating initial centroid positions.
     kwargs
@@ -96,7 +88,6 @@ class CluStream(base.Clusterer):
     >>> clustream = cluster.CluStream(
     ...     n_macro_clusters=3,
     ...     max_micro_clusters=5,
-    ...     time_gap=3,
     ...     seed=0,
     ...     halflife=0.4
     ... )
@@ -121,7 +112,6 @@ class CluStream(base.Clusterer):
         max_micro_clusters: int = 100,
         micro_cluster_r_factor: int = 2,
         time_window: int = 1000,
-        time_gap: int = 100,
         seed: int = None,
         **kwargs,
     ):
@@ -130,7 +120,6 @@ class CluStream(base.Clusterer):
         self.max_micro_clusters = max_micro_clusters
         self.micro_cluster_r_factor = micro_cluster_r_factor
         self.time_window = time_window
-        self.time_gap = time_gap
         self.seed = seed
 
         self.kwargs = kwargs
@@ -140,9 +129,6 @@ class CluStream(base.Clusterer):
 
         self._timestamp = -1
         self._initialized = False
-
-        self._mc_centers: typing.Dict[int, typing.DefaultDict] = {}
-        self._kmeans_mc = None
 
     def _maintain_micro_clusters(self, x, w):
         # Calculate the threshold to delete old micro-clusters
@@ -243,27 +229,20 @@ class CluStream(base.Clusterer):
         # Otherwise, closest micro-clusters are merged with each other.
         self._maintain_micro_clusters(x=x, w=w)
 
-        # Apply incremental K-Means on micro-clusters after each time_gap
-        if self._timestamp % self.time_gap == self.time_gap - 1:
-            # Micro-cluster centers will only be saved when the calculation of macro-cluster centers
-            # is required, in order not to take up memory and time unnecessarily
-            self._mc_centers = {i: mc.center for i, mc in self.micro_clusters.items()}
-
-            self._kmeans_mc = cluster.KMeans(
-                n_clusters=self.n_macro_clusters, seed=self.seed, **self.kwargs
-            )
-            for center in self._mc_centers.values():
-                self._kmeans_mc = self._kmeans_mc.learn_one(center)
-
-            self.centers = self._kmeans_mc.centers
-
         return self
 
     def predict_one(self, x):
+        mc_centers = {i: mc.center for i, mc in self.micro_clusters.items()}
+
+        kmeans = cluster.KMeans(n_clusters=self.n_macro_clusters, seed=self.seed, **self.kwargs)
+        for center in mc_centers.values():
+            kmeans = kmeans.learn_one(center)
+
+        self.centers = kmeans.centers
 
         index, _ = self._get_closest_mc(x)
         try:
-            return self._kmeans_mc.predict_one(self._mc_centers[index])
+            return kmeans.predict_one(mc_centers[index])
         except KeyError:
             return 0
 

--- a/river/cluster/clustream.py
+++ b/river/cluster/clustream.py
@@ -32,8 +32,8 @@ class CluStream(base.Clusterer):
     the use of Welford's algorithm [^2] to calculate the incremental variance, facilitated
     through `stats.Var()` available within `River`.
 
-    Since `River` does not support an actual "off-line" phase of the clustering algorithm (as data points
-    are assumed to arrive continuously, one at a time), we introduce a new parameter `time_gap`. After each
+    Since River does not support an actual "off-line" phase of the clustering algorithm (as data points
+    are assumed to arrive continuously, one at a time), a `time_gap` parameter is introduced. After each
     `time_gap`, an incremental K-Means clustering algorithm will be initialized and applied on currently available
     micro-clusters to form the final solution, i.e. macro-clusters.
 
@@ -51,8 +51,8 @@ class CluStream(base.Clusterer):
         If the current time is `T` and the time window is `h`, we only consider
         the data that arrived within the period `(T-h,T)`.
     time_gap
-        After each `time_gap`, the incremental K-Means will be applied on the current set of micro-clusters
-        to form the final macro-clusters (final solution).
+        An incremental k-means is applied on the current set of micro-clusters after each `time_gap` to form
+        the final macro-cluster solution.
     seed
        Random seed used for generating initial centroid positions.
     kwargs

--- a/river/cluster/clustream.py
+++ b/river/cluster/clustream.py
@@ -32,6 +32,11 @@ class CluStream(base.Clusterer):
     the use of Welford's algorithm [^2] to calculate the incremental variance, facilitated
     through `stats.Var()` available within `River`.
 
+    Since `River` does not support an actual "off-line" phase of the clustering algorithm (as data points
+    are assumed to arrive continuously, one at a time), we introduce a new parameter `time_gap`. After each
+    `time_gap`, an incremental K-Means clustering algorithm will be initialized and applied on currently available
+    micro-clusters to form the final solution, i.e. macro-clusters.
+
     Parameters
     ----------
     n_macro_clusters
@@ -45,6 +50,9 @@ class CluStream(base.Clusterer):
     time_window
         If the current time is `T` and the time window is `h`, we only consider
         the data that arrived within the period `(T-h,T)`.
+    time_gap
+        After each `time_gap`, the incremental K-Means will be applied on the current set of micro-clusters
+        to form the final macro-clusters (final solution).
     seed
        Random seed used for generating initial centroid positions.
     kwargs
@@ -88,6 +96,7 @@ class CluStream(base.Clusterer):
     >>> clustream = cluster.CluStream(
     ...     n_macro_clusters=3,
     ...     max_micro_clusters=5,
+    ...     time_gap=3,
     ...     seed=0,
     ...     halflife=0.4
     ... )
@@ -112,6 +121,7 @@ class CluStream(base.Clusterer):
         max_micro_clusters: int = 100,
         micro_cluster_r_factor: int = 2,
         time_window: int = 1000,
+        time_gap: int = 100,
         seed: int = None,
         **kwargs,
     ):
@@ -120,6 +130,7 @@ class CluStream(base.Clusterer):
         self.max_micro_clusters = max_micro_clusters
         self.micro_cluster_r_factor = micro_cluster_r_factor
         self.time_window = time_window
+        self.time_gap = time_gap
         self.seed = seed
 
         self.kwargs = kwargs
@@ -129,6 +140,9 @@ class CluStream(base.Clusterer):
 
         self._timestamp = -1
         self._initialized = False
+
+        self._mc_centers: typing.Dict[int, typing.DefaultDict] = {}
+        self._kmeans_mc = None
 
     def _maintain_micro_clusters(self, x, w):
         # Calculate the threshold to delete old micro-clusters
@@ -229,20 +243,27 @@ class CluStream(base.Clusterer):
         # Otherwise, closest micro-clusters are merged with each other.
         self._maintain_micro_clusters(x=x, w=w)
 
+        # Apply incremental K-Means on micro-clusters after each time_gap
+        if self._timestamp % self.time_gap == self.time_gap - 1:
+            # Micro-cluster centers will only be saved when the calculation of macro-cluster centers
+            # is required, in order not to take up memory and time unnecessarily
+            self._mc_centers = {i: mc.center for i, mc in self.micro_clusters.items()}
+
+            self._kmeans_mc = cluster.KMeans(
+                n_clusters=self.n_macro_clusters, seed=self.seed, **self.kwargs
+            )
+            for center in self._mc_centers.values():
+                self._kmeans_mc = self._kmeans_mc.learn_one(center)
+
+            self.centers = self._kmeans_mc.centers
+
         return self
 
     def predict_one(self, x):
-        mc_centers = {i: mc.center for i, mc in self.micro_clusters.items()}
-
-        kmeans = cluster.KMeans(n_clusters=self.n_macro_clusters, seed=self.seed, **self.kwargs)
-        for center in mc_centers.values():
-            kmeans = kmeans.learn_one(center)
-
-        self.centers = kmeans.centers
 
         index, _ = self._get_closest_mc(x)
         try:
-            return kmeans.predict_one(mc_centers[index])
+            return self._kmeans_mc.predict_one(self._mc_centers[index])
         except KeyError:
             return 0
 

--- a/river/cluster/clustream.py
+++ b/river/cluster/clustream.py
@@ -1,12 +1,8 @@
 import math
 import typing
-from abc import ABCMeta
 from collections import defaultdict
 
-from river import base, cluster, utils
-
-EPSILON = 0.00005
-MIN_VARIANCE = 1e-50
+from river import base, cluster, stats, utils
 
 
 class CluStream(base.Clusterer):
@@ -20,7 +16,7 @@ class CluStream(base.Clusterer):
 
     Training with a new point `p` is performed in two main tasks:
 
-    * Determinate closest micro-cluster to `p`
+    * Determinate the closest micro-cluster to `p`.
 
     * Check whether `p` fits (memory) into the closest micro-cluster:
 
@@ -30,28 +26,27 @@ class CluStream(base.Clusterer):
           This is done in two ways, delete an old micro-cluster or merge the
           two micro-clusters closest to each other.
 
+    This implementation is an improved version from the original algorithm. Instead
+    of calculating the traditional cluster feature vector of the number of observations,
+    linear sum and sum of squares of data points and time stamps, this implementation adopts
+    the use of Welford's algorithm [^2] to calculate the incremental variance, facilitated
+    through `stats.Var()` available within `River`.
+
     Parameters
     ----------
-    seed
-       Random seed used for generating initial centroid positions.
-
+    n_macro_clusters
+        The number of clusters (k) for the k-means algorithm.
+    max_micro_clusters
+        The maximum number of micro-clusters to use.
+    micro_cluster_r_factor
+        Multiplier for the micro-cluster radius. When deciding to add a new data point to a micro-cluster,
+        the maximum boundary is defined as a factor of the `micro_cluster_r_factor` of
+        the RMS deviation of the data points in the micro-cluster from the centroid.
     time_window
         If the current time is `T` and the time window is `h`, we only consider
         the data that arrived within the period `(T-h,T)`.
-
-    max_micro_clusters
-        The maximum number of micro-clusters to use.
-
-    micro_cluster_r_factor
-        Multiplier for the micro-cluster radius.
-        When deciding to add a new data point to a micro-cluster, the maximum
-        boundary is defined as a factor of the `micro_cluster_r_factor` of
-        the RMS deviation of the data points in the micro-cluster from the
-        centroid.
-
-    n_macro_clusters
-        The number of clusters (k) for the k-means algorithm.
-
+    seed
+       Random seed used for generating initial centroid positions.
     kwargs
         Other parameters passed to the incremental kmeans at `cluster.KMeans`.
 
@@ -62,18 +57,18 @@ class CluStream(base.Clusterer):
 
     References
     ----------
-    [^1]: Aggarwal, C.C., Philip, S.Y., Han, J. and Wang, J., 2003,
-          A framework for clustering evolving data streams.
-          In Proceedings 2003 VLDB conference (pp. 81-92). Morgan Kaufmann.
+    [^1]: Aggarwal, C.C., Philip, S.Y., Han, J. and Wang, J., 2003, A framework for clustering evolving data
+    streams. In Proceedings 2003 VLDB conference (pp. 81-92). Morgan Kaufmann.
+    [^2]: Chan, T.F., Golub, G.H. and LeVeque, R.J., 1982. Updating formulae and a pairwise algorithm for
+    computing sample variances. In COMPSTAT 1982 5th Symposium held at Toulouse 1982 (pp. 30-41).
+    Physica, Heidelberg. https://doi.org/10.1007/978-3-642-51461-6_3.
 
     Examples
     --------
 
-    In the following example, `max_micro_clusters` and `time_window` are set
-    relatively low due to the limited number of training points.
-    Moreover, all points are learnt before any predictions are made.
-    The `halflife` is set at 0.4, to show that you can pass `cluster.KMeans`
-    parameters via keyword arguments.
+    In the following example, `max_micro_clusters` is set relatively low due to the
+    limited number of training points. Moreover, all points are learnt before any predictions are made.
+    The `halflife` is set at 0.4, to show that you can pass `cluster.KMeans` parameters via keyword arguments.
 
     >>> from river import cluster
     >>> from river import stream
@@ -82,313 +77,222 @@ class CluStream(base.Clusterer):
     ...     [1, 2],
     ...     [1, 4],
     ...     [1, 0],
-    ...     [4, 2],
-    ...     [4, 4],
-    ...     [4, 0]
+    ...     [-4, 2],
+    ...     [-4, 4],
+    ...     [-4, 0],
+    ...     [5, 0],
+    ...     [5, 2],
+    ...     [5, 4]
     ... ]
 
-    >>> clustream = cluster.CluStream(time_window=1,
-    ...                               max_micro_clusters=3,
-    ...                               n_macro_clusters=2,
-    ...                               seed=0,
-    ...                               halflife=0.4)
+    >>> clustream = cluster.CluStream(
+    ...     n_macro_clusters=3,
+    ...     max_micro_clusters=5,
+    ...     seed=0,
+    ...     halflife=0.4
+    ... )
 
-    >>> for i, (x, _) in enumerate(stream.iter_array(X)):
+    >>> for x, _ in stream.iter_array(X):
     ...     clustream = clustream.learn_one(x)
 
     >>> clustream.predict_one({0: 1, 1: 1})
     1
 
-    >>> clustream.predict_one({0: 4, 1: 3})
+    >>> clustream.predict_one({0: -4, 1: 3})
+    2
+
+    >>> clustream.predict_one({0: 4, 1: 3.5})
     0
 
     """
 
     def __init__(
         self,
-        seed: int = None,
-        time_window: int = 1000,
+        n_macro_clusters: int = 5,
         max_micro_clusters: int = 100,
         micro_cluster_r_factor: int = 2,
-        n_macro_clusters: int = 5,
+        time_window: int = 1000,
+        seed: int = None,
         **kwargs,
     ):
         super().__init__()
-        self.time_window = time_window
-        self.time_stamp = -1
-        self.micro_clusters = {n: None for n in range(max_micro_clusters)}
-        self.initialized = False
-        self.buffer: typing.Dict[int, "CluStreamMicroCluster"] = {}
-        self.centers: typing.Dict[int, typing.DefaultDict] = {}
-        self.micro_cluster_r_factor = micro_cluster_r_factor
-        self.max_micro_clusters = max_micro_clusters
         self.n_macro_clusters = n_macro_clusters
-        self._train_weight_seen_by_model = 0.0
+        self.max_micro_clusters = max_micro_clusters
+        self.micro_cluster_r_factor = micro_cluster_r_factor
+        self.time_window = time_window
         self.seed = seed
+
         self.kwargs = kwargs
 
-    def _initialize(self, x, sample_weight):
+        self.centers: typing.Dict[int, typing.DefaultDict] = {}
+        self.micro_clusters: typing.Dict[int, CluStreamMicroCluster] = {}
 
-        # Create a micro-cluster with the new point
-        if len(self.buffer) < self.max_micro_clusters:
-            self.buffer[len(self.buffer)] = CluStreamMicroCluster(
-                x=x,
-                sample_weight=sample_weight,
-                timestamp=self.time_stamp,
-                micro_cluster_r_factor=self.micro_cluster_r_factor,
-                max_micro_clusters=self.max_micro_clusters,
-            )
-        else:
-            # The buffer is full. Use the micro-clusters centers to create the
-            # micro-clusters set.
-            for i in range(self.max_micro_clusters):
-                self.micro_clusters[i] = CluStreamMicroCluster(
-                    x=self.buffer[i].center,
-                    sample_weight=1.0,
-                    timestamp=self.time_stamp,
-                    micro_cluster_r_factor=self.micro_cluster_r_factor,
-                    max_micro_clusters=self.max_micro_clusters,
-                )
-            self.buffer.clear()
-            self.initialized = True
+        self._timestamp = -1
+        self._initialized = False
 
-    def _maintain_micro_clusters(self, x, sample_weight):
+    def _maintain_micro_clusters(self, x, w):
         # Calculate the threshold to delete old micro-clusters
-        threshold = self.time_stamp - self.time_window
+        threshold = self._timestamp - self.time_window
 
-        # Delete old micro-clusters if its relevance stamp is smaller than the threshold
-        for i, micro_cluster_a in self.micro_clusters.items():
-            if micro_cluster_a.relevance_stamp < threshold:
-                self.micro_clusters[i] = CluStreamMicroCluster(
-                    x=x,
-                    sample_weight=sample_weight,
-                    timestamp=self.time_stamp,
-                    micro_cluster_r_factor=self.micro_cluster_r_factor,
-                    max_micro_clusters=self.max_micro_clusters,
-                )
-                return self
+        # Delete old micro-cluster if its relevance stamp is smaller than the threshold
+        del_id = None
+        for i, mc in self.micro_clusters.items():
+            if mc.relevance_stamp(self.max_micro_clusters) < threshold:
+                del_id = i
+                break
+
+        if del_id is not None:
+            self.micro_clusters[del_id] = CluStreamMicroCluster(
+                x=x,
+                w=w,
+                timestamp=self._timestamp,
+            )
+            return
 
         # Merge the two closest micro-clusters
         closest_a = 0
         closest_b = 0
         min_distance = math.inf
-        for i, micro_cluster_a in self.micro_clusters.items():
-            for j, micro_cluster_b in self.micro_clusters.items():
-                dist = self._distance(micro_cluster_a.center, micro_cluster_b.center)
-                if dist < min_distance and j > i:
+        for i, mc_a in self.micro_clusters.items():
+            for j, mc_b in self.micro_clusters.items():
+                if i <= j:
+                    continue
+                dist = self._distance(mc_a.center, mc_b.center)
+                if dist < min_distance:
                     min_distance = dist
                     closest_a = i
                     closest_b = j
-        self.micro_clusters[closest_a].add(self.micro_clusters[closest_b])
+
+        self.micro_clusters[closest_a] += self.micro_clusters[closest_b]
         self.micro_clusters[closest_b] = CluStreamMicroCluster(
             x=x,
-            sample_weight=sample_weight,
-            timestamp=self.time_stamp,
-            micro_cluster_r_factor=self.micro_cluster_r_factor,
-            max_micro_clusters=self.max_micro_clusters,
+            w=w,
+            timestamp=self._timestamp,
         )
 
-    def _get_micro_clustering_result(self):
-        if not self.initialized:
-            return {}
-        res = {
-            i: CluStreamMicroCluster(
-                micro_cluster=micro_cluster,
-                micro_cluster_r_factor=self.micro_cluster_r_factor,
-                max_micro_clusters=self.max_micro_clusters,
-            )
-            for i, micro_cluster in self.micro_clusters.items()
-        }
-        return res
+    def _get_closest_mc(self, x):
+        closest_dist = math.inf
+        closest_idx = -1
 
-    def _get_closest_micro_cluster(self, x, micro_clusters):
-        min_distance = math.inf
-        closest_micro_cluster_idx = -1
-        for i, micro_cluster in micro_clusters.items():
-            distance = self._distance(micro_cluster.center, x)
-            if distance < min_distance:
-                min_distance = distance
-                closest_micro_cluster_idx = i
-        return closest_micro_cluster_idx, min_distance
+        for mc_idx, mc in self.micro_clusters.items():
+            distance = self._distance(mc.center, x)
+            if distance < closest_dist:
+                closest_dist = distance
+                closest_idx = mc_idx
+        return closest_idx, closest_dist
 
     @staticmethod
     def _distance(point_a, point_b):
-        return math.sqrt(utils.math.minkowski_distance(point_a, point_b, 2))
+        return utils.math.minkowski_distance(point_a, point_b, 2)
 
-    def learn_one(self, x, sample_weight=None):
+    def learn_one(self, x, w=1.0):
 
-        if sample_weight == 0:
-            return
-        elif sample_weight is None:
-            sample_weight = 1.0
+        self._timestamp += 1
 
-        self._train_weight_seen_by_model += sample_weight
+        if not self._initialized:
+            self.micro_clusters[len(self.micro_clusters)] = CluStreamMicroCluster(
+                x=x,
+                w=w,
+                # When initialized, all micro clusters generated previously will have the timestamp reset to the current
+                # time stamp at the time of initialization (i.e. self.max_micro_cluster - 1). Thus, the timestamp is set
+                # as follows.
+                timestamp=self.max_micro_clusters - 1,
+            )
 
-        # merge _learn_one into learn_one
-        self.time_stamp += 1
+            if len(self.micro_clusters) == self.max_micro_clusters:
+                self._initialized = True
 
-        if not self.initialized:
-            self._initialize(x=x, sample_weight=sample_weight)
             return self
 
-        # determine the closest micro-cluster with respect to the new point instance
-        closest_micro_cluster = None
-        min_distance = math.inf
-        for micro_cluster in self.micro_clusters.values():
-            distance = self._distance(x, micro_cluster.center)
-            if distance < min_distance:
-                closest_micro_cluster = micro_cluster
-                min_distance = distance
+        # Determine the closest micro-cluster with respect to the new point instance
+        closest_id, closest_dist = self._get_closest_mc(x)
+        closest_mc = self.micro_clusters[closest_id]
 
-        # check whether the new instance fits into the closest micro-cluster
-        if closest_micro_cluster.weight == 1:
+        # Check whether the new instance fits into the closest micro-cluster
+        if closest_mc.weight == 1:
             radius = math.inf
-            center = closest_micro_cluster.center
-            for micro_cluster in self.micro_clusters.values():
-                if micro_cluster == closest_micro_cluster:
+            center = closest_mc.center
+            for mc_id, mc in self.micro_clusters.items():
+                if mc_id == closest_id:
                     continue
-                distance = self._distance(micro_cluster.center, center)
+                distance = self._distance(mc.center, center)
                 radius = min(distance, radius)
         else:
-            radius = closest_micro_cluster.radius
+            radius = closest_mc.radius(self.micro_cluster_r_factor)
 
-        if min_distance < radius:
-            closest_micro_cluster.insert(x, sample_weight, self.time_stamp)
+        if closest_dist < radius:
+            closest_mc.insert(x, w, self._timestamp)
             return self
 
         # If the new point does not fit in the micro-cluster, micro-clusters
         # whose relevance stamps are less than the threshold are deleted.
         # Otherwise, closest micro-clusters are merged with each other.
-        self._maintain_micro_clusters(x=x, sample_weight=sample_weight)
+        self._maintain_micro_clusters(x=x, w=w)
 
         return self
 
     def predict_one(self, x):
-
-        micro_cluster_centers = {
-            i: result.center for i, result in self._get_micro_clustering_result().items()
-        }
+        mc_centers = {i: mc.center for i, mc in self.micro_clusters.items()}
 
         kmeans = cluster.KMeans(n_clusters=self.n_macro_clusters, seed=self.seed, **self.kwargs)
-        for center in micro_cluster_centers.values():
+        for center in mc_centers.values():
             kmeans = kmeans.learn_one(center)
 
         self.centers = kmeans.centers
 
-        index, _ = self._get_closest_micro_cluster(x, self._get_micro_clustering_result())
+        index, _ = self._get_closest_mc(x)
         try:
-            return kmeans.predict_one(micro_cluster_centers[index])
+            return kmeans.predict_one(mc_centers[index])
         except KeyError:
             return 0
 
 
-class CluStreamMicroCluster(metaclass=ABCMeta):
-    """Micro-cluster class"""
+class CluStreamMicroCluster(base.Base):
+    """Micro-cluster class."""
 
     def __init__(
         self,
-        x: dict = None,
-        sample_weight: float = None,
-        micro_cluster: "CluStreamMicroCluster" = None,
+        x: dict = defaultdict(float),
+        w: float = None,
         timestamp: int = None,
-        micro_cluster_r_factor: int = None,
-        max_micro_clusters: int = None,
     ):
-
-        self.micro_cluster_r_factor = micro_cluster_r_factor
-        self.max_micro_clusters = max_micro_clusters
-
-        if x is not None and sample_weight is not None:
-            # Initialize with sample x
-            self.n_samples = 1
-            self.linear_sum = defaultdict(float)
-            self.squared_sum = defaultdict(float)
-            for key in x.keys():
-                self.linear_sum[key] = x[key] * sample_weight
-                self.squared_sum[key] = x[key] * x[key] * sample_weight
-            self.linear_sum_timestamp = timestamp * sample_weight  # type: ignore
-            self.squared_sum_timestamp = (
-                timestamp * sample_weight * timestamp * sample_weight  # type: ignore
-            )
-        elif micro_cluster is not None:
-            # Initialize with micro-cluster
-            self.n_samples = micro_cluster.n_samples
-            self.linear_sum = micro_cluster.linear_sum.copy()
-            self.squared_sum = micro_cluster.squared_sum.copy()
-            self.linear_sum_timestamp = micro_cluster.linear_sum_timestamp
-            self.squared_sum_timestamp = micro_cluster.squared_sum_timestamp
+        # Initialize with sample x
+        self.var_x = {k: stats.Var().update(x[k], w) for k in x}
+        self.var_time = stats.Var().update(timestamp, w)
 
     @property
     def center(self):
-        return {i: linear_sum_i / self.n_samples for i, linear_sum_i in self.linear_sum.items()}
+        return {k: var.mean.get() for k, var in self.var_x.items()}
 
-    def is_empty(self):
-        return self.n_samples == 0
-
-    @property
-    def radius(self):
-        if self.n_samples == 1:
+    def radius(self, r_factor):
+        if self.weight == 1:
             return 0
-        return self._deviation * self.micro_cluster_r_factor
+        return self._deviation() * r_factor
 
-    @property
     def _deviation(self):
-        variance = self._variance_vector
-        sum_of_deviation = 0
-        for var in variance.values():
-            sum_of_deviation += math.sqrt(var)
-        return sum_of_deviation / len(variance) if len(variance) > 0 else math.inf
-
-    @property
-    def _variance_vector(self):
-        res = {}
-        for key in self.linear_sum.keys():
-            ls = self.linear_sum[key]
-            ss = self.squared_sum[key]
-            ls_div_n = ls / self.weight
-            ls_div_n_squared = ls_div_n * ls_div_n
-            ss_div_n = ss / self.weight
-            res[key] = ss_div_n - ls_div_n_squared
-
-            if res[key] <= 0.0:
-                if res[key] > -EPSILON:
-                    res[key] = MIN_VARIANCE
-        return res
+        dev_sum = 0
+        for var in self.var_x.values():
+            dev_sum += math.sqrt(var.get())
+        return dev_sum / len(self.var_x) if len(self.var_x) > 0 else math.inf
 
     @property
     def weight(self):
-        return self.n_samples
+        return self.var_time.n
 
-    def insert(self, x, sample_weight, timestamp):
-        self.n_samples += 1
-        self.linear_sum_timestamp += timestamp * sample_weight
-        self.squared_sum_timestamp += timestamp * sample_weight * timestamp * sample_weight
+    def insert(self, x, w, timestamp):
+        self.var_time.update(timestamp, w)
         for x_idx, x_val in x.items():
-            self.linear_sum[x_idx] += x_val * sample_weight
-            self.squared_sum[x_idx] += x_val * sample_weight * x_val * sample_weight
+            self.var_x[x_idx].update(x_val, w)
 
-    @property
-    def relevance_stamp(self):
-        if self.n_samples < 2 * self.max_micro_clusters:
-            return self._mu_time
-        return self._mu_time + self._sigma_time * self._quantile(
-            float(self.max_micro_clusters) / (2 * self.n_samples)
-        )
+    def relevance_stamp(self, max_mc):
+        mu_time = self.var_time.mean.get()
+        if self.weight < 2 * max_mc:
+            return mu_time
 
-    @property
-    def _mu_time(self):
-        return self.linear_sum_timestamp / self.n_samples
-
-    @property
-    def _sigma_time(self):
-        return math.sqrt(
-            self.squared_sum_timestamp / self.n_samples
-            - (self.linear_sum_timestamp / self.n_samples)
-            * (self.linear_sum_timestamp / self.n_samples)
-        )
+        sigma_time = math.sqrt(self.var_time.get())
+        return mu_time + sigma_time * self._quantile(max_mc / (2 * self.weight))
 
     def _quantile(self, z):
-        assert 0 <= z <= 1
         return math.sqrt(2) * self.inverse_error(2 * z - 1)
 
     @staticmethod
@@ -417,13 +321,7 @@ class CluStreamMicroCluster(metaclass=ABCMeta):
 
         return res
 
-    def add(self, micro_cluster):
-        self.n_samples += micro_cluster.n_samples
-        self.linear_sum_timestamp += micro_cluster.linear_sum_timestamp
-        self.squared_sum_timestamp += micro_cluster.squared_sum_timestamp
-        utils.skmultiflow_utils.add_dict_values(
-            self.linear_sum, micro_cluster.linear_sum, inplace=True
-        )
-        utils.skmultiflow_utils.add_dict_values(
-            self.squared_sum, micro_cluster.squared_sum, inplace=True
-        )
+    def __iadd__(self, other: "CluStreamMicroCluster"):
+        self.var_time += other.var_time
+        self.var_x = {k: self.var_x[k] + other.var_x.get(k, stats.Var()) for k in self.var_x}
+        return self


### PR DESCRIPTION
This new implementation of CluStream serves two purposes:
- One, this version is a refactor of the previous one with certain improvements, such as shortening variable names, removing redundant portions/loops and ensuring that private parts can not be accessed by users.
- Two, this implementation is an improvement of the original version by using Welford's algorithm to calculate the incremental variance of the data points and time stamps instead of having to save the number of observations, linear sum and sum of squares as per the traditional convention. This is facilitated through `stats.Var` within `River`.

