### PR TITLE
Fix syntax pypi.yaml

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -2,10 +2,9 @@ name: pypi
 
 on:
   push:
-    push:
-      branches: "master"
     tags:
       - "*"
+
 
 jobs:
   build_wheels:


### PR DESCRIPTION
The GitHub action worked, but the syntax was not good; now, it's cleaner.

