### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,11 @@ from setuptools_rust import Binding, RustExtension  # type: ignore
 
 try:
     from numpy import get_include
+    from numpy import __version__ as numpy_version
 except ImportError:
     subprocess.check_call([sys.executable, "-m", "pip", "install", "numpy"])
     from numpy import get_include
+    from numpy import __version__ as numpy_version
 
 try:
     from Cython.Build import cythonize
@@ -49,7 +51,7 @@ setuptools.setup(
     python_requires=REQUIRES_PYTHON,
     url=URL,
     packages=setuptools.find_packages(exclude=("tests",)),
-    install_requires=(base_packages := ["numpy>=1.22", "scipy>=1.5", "pandas>=1.3"]),
+    install_requires=(base_packages := [f"numpy>={numpy_version}", "scipy>=1.5", "pandas>=1.3"]),
     extras_require={
         "dev": base_packages + [
             "black>=22.1.0",


### PR DESCRIPTION
I think this will solve #1047.

I believe the issue with numpy is that we install the latest version of numpy when we build the wheels (see [here](https://github.com/online-ml/river/actions/runs/3061885681/jobs/4942209481#step:8:245)) but then we don't necessarily require the latest version in `setup.py`. Importing numpy and grabbing the version dynamically should fix this issue.