### PR TITLE
Fix bug that DDM reports drift on data stream with only ones

### DIFF
--- a/river/drift/ddm.py
+++ b/river/drift/ddm.py
@@ -141,12 +141,12 @@ class DDM(DriftDetector):
                 self._s_min = s_i
                 self._ps_min = self._p_min + self._s_min
 
-            if p_i + s_i >= self._p_min + self.warning_threshold * self._s_min:
+            if p_i + s_i > self._p_min + self.warning_threshold * self._s_min:
                 self._warning_detected = True
             else:
                 self._warning_detected = False
 
-            if p_i + s_i >= self._p_min + self.drift_threshold * self._s_min:
+            if p_i + s_i > self._p_min + self.drift_threshold * self._s_min:
                 self._drift_detected = True
                 self._warning_detected = False
 

--- a/river/drift/test_drift_detectors.py
+++ b/river/drift/test_drift_detectors.py
@@ -37,6 +37,10 @@ def test_ddm():
     detected_indices = perform_test(DDM(), data_stream_2)
     assert detected_indices == expected_indices
 
+    expected_indices = []
+    detected_indices = perform_test(DDM(), np.ones(1000))
+    assert detected_indices == expected_indices
+
 
 def test_eddm():
     expected_indices = [1059]


### PR DESCRIPTION
Consider a data stream with only ones and no zeros. When the code block inside `if n > self.warm_start:` in method `river.drift.DDM.update` is entered the first time, `p_i`, `s_i`, `self._p_min`, `self._s_min` will be 1.0, 0.0, 1.0, 0.0 respectively, then `p_i + s_i >= self._p_min + self.drift_threshold * self._s_min` will hold and a drift will be reported. I fix this bug by replacing `>=` with `>` and add the corrosponding testcase to `river/drift/test_drift_detectors.py`.