### PR TITLE
[drift] Expose more parameters of adwin

### DIFF
--- a/river/drift/adwin.py
+++ b/river/drift/adwin.py
@@ -19,6 +19,14 @@ class ADWIN(DriftDetector):
     ----------
     delta
         Significance value.
+    clock
+        How often ADWIN should check for change. 1 means every new data point, default is 32. Higher values speed up processing, but may also lead to increased delay in change detection.
+    max_buckets
+        The maximum number of buckets of each size that ADWIN should keep before merging buckets (default is 5).
+    min_window_length
+        The minimum length of each subwindow (default is 5). Lower values may decrease delay in change detection but may also lead to more false positives.
+    grace_period
+        ADWIN does not perform any change detection until at least this many data points have arrived (default is 10).
 
     Examples
     --------
@@ -47,14 +55,24 @@ class ADWIN(DriftDetector):
 
     """
 
-    def __init__(self, delta=0.002):
+    def __init__(self, delta=0.002, clock=32, max_buckets=5, min_window_length=5, grace_period=10):
         super().__init__()
         self.delta = delta
+        self.clock = clock
+        self.max_buckets = max_buckets
+        self.min_window_length = min_window_length
+        self.grace_period = grace_period
         self._reset()
 
     def _reset(self):
         super()._reset()
-        self._helper = AdaptiveWindowing(delta=self.delta)
+        self._helper = AdaptiveWindowing(
+            delta=self.delta,
+            clock=self.clock,
+            max_buckets=self.max_buckets,
+            min_window_length=self.min_window_length,
+            grace_period=self.grace_period,
+        )
 
     @property
     def width(self):

--- a/river/drift/adwin_c.pyx
+++ b/river/drift/adwin_c.pyx
@@ -17,30 +17,37 @@ cdef class AdaptiveWindowing:
     ----------
     delta
         Confidence value.
+    clock
+        How often ADWIN should check for change. 1 means every new data point, default is 32. Higher values speed up processing, but may also lead to increased delay in change detection.
+    max_buckets
+        The maximum number of buckets of each size that ADWIN should keep before merging buckets (default is 5).
+    min_window_length
+        The minimum length of each subwindow (default is 5). Lower values may decrease delay in change detection but may also lead to more false positives.
+    grace_period
+        ADWIN does not perform any change detection until at least this many data points have arrived (default is 10).
 
     """
     cdef:
         dict __dict__
         double delta, total, variance, total_width, width
         int n_buckets, grace_period, min_window_length, tick, n_detections,\
-            clock, max_n_buckets, detect, detect_twice
+            clock, max_n_buckets, detect, detect_twice, max_buckets
 
-    MAX_BUCKETS = 5
-
-    def __init__(self, delta=.002):
+    def __init__(self, delta=.002, clock=32, max_buckets=5, min_window_length=5, grace_period=10):
         self.delta = delta
-        self.bucket_deque: Deque['Bucket'] = deque([Bucket()])
+        self.bucket_deque: Deque['Bucket'] = deque([Bucket(max_size=max_buckets)])
         self.total = 0.
         self.variance = 0.
         self.width = 0.
         self.n_buckets = 0
-        self.grace_period = 10
+        self.grace_period = grace_period
         self.tick = 0
         self.total_width = 0
         self.n_detections = 0
-        self.clock = 32
+        self.clock = clock
         self.max_n_buckets = 0
-        self.min_window_length = 5
+        self.min_window_length = min_window_length
+        self.max_buckets = max_buckets
 
     def get_n_detections(self):
         return self.n_detections
@@ -148,12 +155,12 @@ cdef class AdaptiveWindowing:
         idx = 0
         while bucket is not None:
             k = bucket.current_idx
-            # Merge buckets if there are more than MAX_BUCKETS
-            if k == self.MAX_BUCKETS + 1:
+            # Merge buckets if there are more than max_buckets
+            if k == self.max_buckets + 1:
                 try:
                     next_bucket = self.bucket_deque[idx + 1]
                 except IndexError:
-                    self.bucket_deque.append(Bucket())
+                    self.bucket_deque.append(Bucket(max_size=self.max_buckets))
                     next_bucket = self.bucket_deque[-1]
                 n1 = self._calculate_bucket_size(idx)   # length of bucket 1
                 n2 = self._calculate_bucket_size(idx)   # length of bucket 2
@@ -168,7 +175,7 @@ cdef class AdaptiveWindowing:
                 self.n_buckets += 1
                 bucket.compress(2)
 
-                if next_bucket.current_idx <= self.MAX_BUCKETS:
+                if next_bucket.current_idx <= self.max_buckets:
                     break
             else:
                 break
@@ -311,8 +318,8 @@ cdef class Bucket:
         int current_idx, max_size
         np.ndarray total_array, variance_array
 
-    def __init__(self):
-        self.max_size = AdaptiveWindowing.MAX_BUCKETS
+    def __init__(self, max_size):
+        self.max_size = max_size
 
         self.current_idx = 0
         self.total_array = np.zeros(self.max_size + 1, dtype=float)


### PR DESCRIPTION
As discussed in https://github.com/online-ml/river/issues/1061

# Benchmarks
I used the example from the adwin.py documentation (drift at index 1000).

## Varying `clock`
Fixed: `delta=0.002, max_buckets=5, min_window_length=5, grace_period=10`
| clock                    | 1    | 2    | 4    | 8    | 16   | 32   | 64   |
|--------------------------|------|------|------|------|------|------|------|
| processing time (ms)     | 49   | 29   | 16   | 11   | 8    | 7    | 6    |
| change detected at index | 1005 | 1005 | 1007 | 1007 | 1007 | 1023 | 1023 |

This shows nicely that the processing time decreases but the change detection delay increases with a higher `clock`.

## Varying `max_buckets`
Fixed: `delta=0.002, clock=16, min_window_length=5, grace_period=10`
| max_buckets              | 2    | 3    | 4    | 5    | 6    | 7    | 8    | 9    |
|--------------------------|------|------|------|------|------|------|------|------|
| processing time (ms)     | 5    | 6    | 8    | 9    | 10   | 11   | 12   | 12   |
| change detected at index | 1039 | 1023 | 1039 | 1007 | 1023 | 1023 | 1007 | 1007 |

This shows that processing time increases slightly but change detection has less delay/is more fine-grained with higher `max_buckets`.

I couldn't think of any sensible experiments for `min_window_length` and `grace_period`, but the effects should be as I described in the documentation.

The four new parameters should all be at least 1, but I am not sure if it is necessary to check the user-specified value since that should IMO be clear from the documentation.