### PR TITLE
Fixed access to previous predictions in CC

### DIFF
--- a/river/multioutput/chain.py
+++ b/river/multioutput/chain.py
@@ -147,7 +147,7 @@ class ClassifierChain(BaseChain, base.Classifier, base.MultiOutputMixin):
 
             # The predictions are stored as features for the next label
             if clf._multiclass:
-                for label, proba in y_pred.items():
+                for label, proba in y_pred[o].items():
                     x[f"{o}_{label}"] = proba
             else:
                 x[o] = y_pred[o][True]


### PR DESCRIPTION
Hi:
I'm working in multi-label stream learning using this nice library and I've found a slight bug –I think–, in the `prediction_proba_one` method of `ClassifierChain`. Specifically, in the part of storing the probabilities of the prediction for the next labels, the iteration is made at *labelset level*, so the probabilities are saved in a sub-dictionary of the instance. This makes the base classifier fails or, in the best-case scenario, ignore the previous probabilities in prediction time. You can check it with the following code:
```
import itertools
from river.datasets import Music
from river.multioutput import ClassifierChain
from river.neighbors import KNNClassifier

stream = Music().take(20)

model = ClassifierChain(KNNClassifier())
for x, y in itertools.islice(stream, 19):
    model.learn_one(x, y)

model.predict_proba_one(next(stream)[0])
```
Which will produce the output:
```
TypeError                                 Traceback (most recent call last)
Cell In [16], line 12
      9 for x, y in itertools.islice(stream, 19):
     10     model.learn_one(x, y)
---> 12 model.predict_proba_one(next(stream)[0])

File ~/git/river/river/multioutput/chain.py:148, in ClassifierChain.predict_proba_one(self, x)
    144 print(x)
    146 clf = self[o]
--> 148 y_pred[o] = clf.predict_proba_one(x)
    150 # The predictions are stored as features for the next label
    151 if clf._multiclass:

File ~/git/river/river/neighbors/knn_classifier.py:150, in KNNClassifier.predict_proba_one(self, x)
    149 def predict_proba_one(self, x):
--> 150     nearest = self._nn.find_nearest((x, None), n_neighbors=self.n_neighbors)
    152     # Default prediction for every class we know is 0.
    153     # If class_cleanup is false this can include classes not in window
    154     y_pred = {c: 0.0 for c in self.classes}

File ~/git/river/river/neighbors/base.py:142, in NearestNeighbors.find_nearest(self, item, n_neighbors)
    139 points = ((*p, self.distance_func(item, p[0])) for p in self.window)
    141 # Return the k closest points (last index is distance)
--> 142 return sorted(points, key=operator.itemgetter(-1))[:n_neighbors]
...
    161 
    162     """
--> 163     return sum((abs(a.get(k, 0.0) - b.get(k, 0.0))) ** p for k in set([*a.keys(), *b.keys()]))

TypeError: unsupported operand type(s) for -: 'dict' and 'float'
```
Because `x` has the following format after the prediction of the first label: `{'Mean_Acc1298_Mean_Mem40_Centroid': 0.030467, 'Mean_Acc1298_Mean_Mem40_Rolloff': 0.044338, ... , 'amazed-suprised_amazed-suprised': {False: 0.8037652189980823, True: 0.19623478100191769}}`

Thus, I think it can be fixed iterating over the probabilities of the current label instead of the whole labelset with the change proposed in this pull request, which will expand the instance in the following way: `{'Mean_Acc1298_Mean_Mem40_Centroid': 0.030467, 'Mean_Acc1298_Mean_Mem40_Rolloff': 0.044338, ... , 'amazed-suprised_False': 0.8037652189980823, 'amazed-suprised_True': 0.19623478100191769, ...}`