### PR TITLE
fix rstrip in clf report support

### DIFF
--- a/river/metrics/report.py
+++ b/river/metrics/report.py
@@ -124,7 +124,7 @@ class ClassificationReport(metrics.base.MultiClassMetric):
                 ),
             ],
             # Support
-            ["", *[str(self.cm.sum_row[c]).rstrip(".0") for c in classes], *[""] * 4],
+            ["", *[str(self.cm.sum_row[c]).rstrip("0").rstrip(".") for c in classes], *[""] * 4],
         ]
 
         # Build the table


### PR DESCRIPTION
We can't cast to int because the support can be a decimal when sample weights are used. Using `.rstrip` correctly is the answer. I checked and this is the only place we used it incorrectly.

Closes #1068