### PR TITLE
Fix possible bug in hddm_w

### DIFF
--- a/river/drift/hddm_w.py
+++ b/river/drift/hddm_w.py
@@ -145,6 +145,8 @@ class HDDM_W(DriftDetector):
     def _has_mean_changed(
         self, sample1: "SampleInfo", sample2: "SampleInfo", confidence: float
     ) -> bool:
+        if sample1.is_initialized or sample2.is_initialized:
+            return False
         ibc_sum = sample1.ibc + sample2.ibc
         bound = self._mcdiarmid_bound(ibc_sum, confidence)
 
@@ -180,6 +182,7 @@ class HDDM_W(DriftDetector):
 class SampleInfo:
     def __init__(self, lambd: float):
         self._ewma = stats.EWMean(lambd)
+        self._is_initialized = True
         # Independent bound condition
         self._ibc = 1.0
         self._lambd_sq = lambd * lambd
@@ -187,6 +190,7 @@ class SampleInfo:
 
     def update(self, x):
         self._ewma.update(x)
+        self._is_initialized = False
         self._ibc = self._lambd_sq + self._c_lambd_sq * self._ibc
 
     @property

--- a/river/drift/hddm_w.py
+++ b/river/drift/hddm_w.py
@@ -7,22 +7,15 @@ from river.base import DriftDetector
 
 class HDDM_W(DriftDetector):
     """Drift Detection Method based on Hoeffding's bounds with moving weighted average-test.
-
     HDDM_W is an online drift detection method based on McDiarmid's bounds. HDDM_W uses the
     Exponentially Weighted Moving Average (EWMA) statistic as estimator.
-
     **Input:** `x` is an entry in a stream of bits, where 1 indicates error/failure and 0
     represents correct/normal values.
-
     For example, if a classifier's prediction $y'$ is right or wrong w.r.t. the
     true target label $y$:
-
     - 0: Correct, $y=y'$
-
      - 1: Error, $y \\neq y'$
-
     *Implementation based on MOA.*
-
     Parameters
     ----------
     drift_confidence
@@ -34,21 +27,17 @@ class HDDM_W(DriftDetector):
     two_sided_test
         If True, will monitor error increments and decrements (two-sided). By default will only
         monitor increments (one-sided).
-
     Examples
     --------
     >>> import random
     >>> from river import drift
-
     >>> rng = random.Random(42)
     >>> hddm_w = drift.HDDM_W()
-
     >>> # Simulate a data stream where the first 1000 instances come from a uniform distribution
     >>> # of 1's and 0's
     >>> data_stream = rng.choices([0, 1], k=1000)
     >>> # Increase the probability of 1's appearing in the next 1000 instances
     >>> data_stream = data_stream + rng.choices([0, 1], k=1000, weights=[0.3, 0.7])
-
     >>> print_warning = True
     >>> # Update drift detector and verify if change is detected
     >>> for i, x in enumerate(data_stream):
@@ -61,7 +50,6 @@ class HDDM_W(DriftDetector):
     ...         print_warning = True
     Warning detected at index 451
     Change detected at index 1077
-
      References
      ----------
      [^1]: Frías-Blanco I, del Campo-Ávila J, Ramos-Jimenez G, et al. Online and non-parametric drift
@@ -69,7 +57,6 @@ class HDDM_W(DriftDetector):
      Engineering, 2014, 27(3): 810-823.
      [^2]: Albert Bifet, Geoff Holmes, Richard Kirkby, Bernhard Pfahringer. MOA: Massive Online Analysis;
      Journal of Machine Learning Research 11: 1601-1604, 2010.
-
     """
 
     def __init__(
@@ -107,17 +94,14 @@ class HDDM_W(DriftDetector):
 
     def update(self, x):
         """Update the change detector with a single data point.
-
         Parameters
         ----------
         x
             This parameter indicates whether the last sample analyzed was
             correctly classified or not. 1 indicates an error (miss-classification).
-
         Returns
         -------
         self
-
         """
 
         if self._drift_detected:
@@ -145,7 +129,7 @@ class HDDM_W(DriftDetector):
     def _has_mean_changed(
         self, sample1: "SampleInfo", sample2: "SampleInfo", confidence: float
     ) -> bool:
-        if sample1.is_initialized or sample2.is_initialized:
+        if not (sample1._is_init and sample2._is_init):
             return False
         ibc_sum = sample1.ibc + sample2.ibc
         bound = self._mcdiarmid_bound(ibc_sum, confidence)
@@ -182,7 +166,7 @@ class HDDM_W(DriftDetector):
 class SampleInfo:
     def __init__(self, lambd: float):
         self._ewma = stats.EWMean(lambd)
-        self._is_initialized = True
+        self._is_init = False
         # Independent bound condition
         self._ibc = 1.0
         self._lambd_sq = lambd * lambd
@@ -190,7 +174,7 @@ class SampleInfo:
 
     def update(self, x):
         self._ewma.update(x)
-        self._is_initialized = False
+        self._is_init = True
         self._ibc = self._lambd_sq + self._c_lambd_sq * self._ibc
 
     @property
@@ -200,3 +184,7 @@ class SampleInfo:
     @property
     def ibc(self):
         return self._ibc
+    
+    @property
+    def is_init(self):
+        return self._is_init


### PR DESCRIPTION
I noticed what appears to be a bug in HDDM_W when two_sided_test is True. Because of how "_has_mean_changed" works, the check for a change when the mean _decreases_ always defaults to True. I noticed that the recent refactoring removed two lines that, in essence, checked if sample 1 or sample 2 had just been initialized (i.e., lines 149 and 150: 
```
if sample1.EWMA_estimator < 0 or sample2.EWMA_estimator < 0:
            return False
```
)

This pull request fixes that, if it indeed is a bug.

<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->
