### PR TITLE
Nested pipeline cloning

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## base
+
+- Fixed an issue where an estimator that has attribute a pipeline could not be cloned.
+
 ## preprocessing
 
 - Renamed `alpha` to `fading_factor` in `preprocessing.AdaptiveStandardScaler`.

--- a/river/base/test_base.py
+++ b/river/base/test_base.py
@@ -1,4 +1,4 @@
-from river import compose, datasets, linear_model, optim, preprocessing, stats
+from river import compose, datasets, linear_model, optim, preprocessing, stats, time_series
 
 
 def test_clone_estimator():
@@ -121,3 +121,16 @@ def test_clone_positional_args():
     assert compose.Select(1, 2, 3).clone().keys == {1, 2, 3}
     assert compose.Discard("a", "b", "c").clone().keys == {"a", "b", "c"}
     assert compose.SelectType(float, int).clone().types == (float, int)
+
+
+def test_clone_nested_pipeline():
+    model = time_series.SNARIMAX(
+        p=2,
+        d=1,
+        q=3,
+        regressor=(
+            preprocessing.StandardScaler()
+            | linear_model.LinearRegression(optimizer=optim.SGD(3e-2))
+        ),
+    )
+    assert model.clone()._get_params() == model._get_params()


### PR DESCRIPTION
@XaviMartiCamarasa stumbled on a bug in #1097. He tried to clone a `SNARIMAX`. The latter's `regressor` parameter was a pipeline. The bug is that cloning the `SNARIMAX` doesn't work because cloning a `Pipeline` nested in an estimator doesn't work. This pull request fixes that. Thankfully, I didn't have to make the code more complex. In fact, it's simpler now :)