### PR TITLE
fixed typo in file OCC.py

### DIFF
--- a/river/multiclass/occ.py
+++ b/river/multiclass/occ.py
@@ -56,7 +56,7 @@ class OutputCodeClassifier(base.Wrapper, base.Classifier):
     >>> dataset = datasets.ImageSegments()
 
     >>> scaler = preprocessing.StandardScaler()
-    >>> ooc = OutputCodeClassifier(
+    >>> ooc = multiclass.OutputCodeClassifier(
     ...     classifier=linear_model.LogisticRegression(),
     ...     code_size=10,
     ...     seed=24


### PR DESCRIPTION
line 59 missing reference to imported library multiclass

<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->
