### PR TITLE
Rename deep-river

### DIFF
--- a/docs/introduction/related-projects.md
+++ b/docs/introduction/related-projects.md
@@ -2,6 +2,6 @@
 
 Here is a list of projects which are more or less coupled with River:
 
-- [river-torch](https://github.com/online-ml/river-torch) interfaces PyTorch models with River.
+- [deep-river](https://github.com/online-ml/deep-river) interfaces PyTorch models with River.
 - [river-extra](https://github.com/online-ml/river-extra) regroups experimental features which have yet to prove themselves to make it into the main River repository. Between us we call this "the arena".
 - [Beaver](https://github.com/online-ml/beaver) is an MLOps tool for covering the whole lifecycle of online machine learning models.

--- a/docs/introduction/related-projects.md
+++ b/docs/introduction/related-projects.md
@@ -3,5 +3,6 @@
 Here is a list of projects which are more or less coupled with River:
 
 - [deep-river](https://github.com/online-ml/deep-river) interfaces PyTorch models with River.
+- [light-river](https://github.com/online-ml/light-river) implements fast algorithms in rust. 
 - [river-extra](https://github.com/online-ml/river-extra) regroups experimental features which have yet to prove themselves to make it into the main River repository. Between us we call this "the arena".
 - [Beaver](https://github.com/online-ml/beaver) is an MLOps tool for covering the whole lifecycle of online machine learning models.

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setuptools.setup(
             "watermark",
         ],
         "extra": ["river_extra"],
-        "torch": ["river_torch"],
+        "deep": ["deep-river"],
         ":python_version == '3.6'": ["dataclasses"],
     },
     include_package_data=True,


### PR DESCRIPTION
Hi 👋,
this PR switches the installation for deep-river in river.

We can merge it after river-torch was renamed ☺️