### PR TITLE
Add coding_method parameter to OCC

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -19,6 +19,10 @@
 
 - Renamed `use_dist` to `with_dist` in `linear_model.BayesianLinearRegression`'s `predict_one` method.
 
+## multiclass
+
+- Added a `coding_method` method to `multiclass.OCC` to control how the codes are randomly generated.
+
 ## preprocessing
 
 - Renamed `alpha` to `fading_factor` in `preprocessing.AdaptiveStandardScaler`.

--- a/river/multiclass/occ.py
+++ b/river/multiclass/occ.py
@@ -108,6 +108,7 @@ class OutputCodeClassifier(base.Wrapper, base.Classifier):
     ):
         self.classifier = classifier
         self.code_size = code_size
+        self.coding_method = coding_method
         self.seed = seed
         self._rng = random.Random(seed)
 

--- a/river/multiclass/occ.py
+++ b/river/multiclass/occ.py
@@ -1,5 +1,6 @@
 import collections
 import copy
+import functools
 import random
 import typing
 
@@ -10,6 +11,22 @@ __all__ = ["OutputCodeClassifier"]
 
 def l1_dist(a, b):
     return sum(abs(ai - bi) for ai, bi in zip(a, b))
+
+
+def _sample_codes_exact(code_size, rng=random):
+    """Lists all possible codes of a given size in memory, and streams them in a random order."""
+    integers = list(range(2**code_size))
+    rng.shuffle(integers)
+    for i in integers:
+        b = bin(i)[2:]  # convert to a string of 0s and 1s
+        b = b.zfill(code_size)  # ensure the code is of length code_size
+        yield tuple(int(c) for c in b)
+
+
+def _sample_codes_random(code_size, rng=random):
+    """Generates random codes of a given size on the fly."""
+    while True:
+        yield tuple(rng.randint(0, 1) for _ in range(code_size))
 
 
 class OutputCodeClassifier(base.Wrapper, base.Classifier):
@@ -40,6 +57,13 @@ class OutputCodeClassifier(base.Wrapper, base.Classifier):
     code_size
         The code size, which dictates how many copies of the provided classifiers to train. Must be
         strictly positive.
+    coding_method
+        The method used to generate the codes. Can be either 'exact' or 'random'. The 'exact'
+        method generates all possible codes of a given size in memory, and streams them in a random
+        order. The 'random' method generates random codes of a given size on the fly. The 'exact'
+        method necessarily generates different codes for each class, but requires more memory. The
+        'random' method can generate duplicate codes for different classes, but requires less
+        memory.
     seed
         A random seed number that can be set for reproducibility.
 
@@ -59,23 +83,29 @@ class OutputCodeClassifier(base.Wrapper, base.Classifier):
     >>> ooc = multiclass.OutputCodeClassifier(
     ...     classifier=linear_model.LogisticRegression(),
     ...     code_size=10,
-    ...     seed=24
+    ...     seed=1
     ... )
     >>> model = scaler | ooc
 
     >>> metric = metrics.MacroF1()
 
     >>> evaluate.progressive_val_score(dataset, model, metric)
-    MacroF1: 79.71%
+    MacroF1: 79.32%
 
     References
     ----------
     [^1]: [Dietterich, T.G. and Bakiri, G., 1994. Solving multiclass learning problems via error-correcting output codes. Journal of artificial intelligence research, 2, pp.263-286.](https://arxiv.org/pdf/cs/9501101.pdf)
-    [^2]: [Allwein, E.L., Schapire, R.E. and Singer, Y., 2000. Reducing multiclass to binary: A unifying approach for margin classifiers. Journal of machine learning research, 1(Dec), pp.113-141.](https://www.cs.princeton.edu/~schapire/talks/ecoc-icml10.pdf)
+    [^2]: [James, G. and Hastie, T., 1998. The error coding method and PICTs. Journal of Computational and Graphical statistics, 7(3), pp.377-387.](https://www.semanticscholar.org/paper/The-Error-Coding-Method-and-PICTs-James-Hastie/73abc83ed720921ed912a709aab6b734915b1012)
 
     """
 
-    def __init__(self, classifier: base.Classifier, code_size: int, seed: int = None):
+    def __init__(
+        self,
+        classifier: base.Classifier,
+        code_size: int,
+        coding_method: str = "random",
+        seed: int = None,
+    ):
         self.classifier = classifier
         self.code_size = code_size
         self.seed = seed
@@ -85,17 +115,16 @@ class OutputCodeClassifier(base.Wrapper, base.Classifier):
 
         # We don't know how many classes there are, therefore we can't generate the code book
         # from the start. Therefore, we define a random queue of integers. When a new class
-        # appears, we get the next integer and convert it to a code.
-        integers = list(range(2**code_size))
-        self._rng.shuffle(integers)
-        self._ints = iter(integers)
-        self.code_book: typing.DefaultDict = collections.defaultdict(self._next_code)
-
-    def _next_code(self):
-        i = next(self._ints)
-        b = bin(i)[2:]  # convert to a string of 0s and 1s
-        b = b.zfill(self.code_size)  # ensure the code is of length code_size
-        return tuple(int(c) for c in b)
+        # appears, we get the next integer and convert it to a code. There are different ways to do
+        # this.
+        self._codes = (
+            _sample_codes_random(code_size, rng=self._rng)
+            if coding_method == "random"
+            else _sample_codes_exact(code_size, rng=self._rng)
+        )
+        self.code_book: typing.DefaultDict = collections.defaultdict(
+            functools.partial(next, self._codes)
+        )
 
     @property
     def _multiclass(self):

--- a/river/multiclass/occ.py
+++ b/river/multiclass/occ.py
@@ -1,6 +1,5 @@
 import collections
 import copy
-import functools
 import random
 import typing
 

--- a/river/stream/shuffling.py
+++ b/river/stream/shuffling.py
@@ -14,7 +14,7 @@ def shuffle(stream: typing.Iterator, buffer_size: int, seed: int = None):
 
     If you really want to stream over your dataset in a "good" random order, the best way is to
     split your dataset into smaller datasets and loop over them in a round-robin fashion. You may
-    do this by using the ``roundrobin`` recipe from the `itertools` module.
+    do this by using the `roundrobin` recipe from the `itertools` module.
 
     Parameters
     ----------


### PR DESCRIPTION
@Yasmen-Wahba I found the issue to #1116. The problem was that the list of all possible codes were generated in memory and then sampled from. This takes too memory when the code size is big, say 30. I added a way to choose what code sampling method to use. The `'random'` method is what scikit-learn does, while the `'exact'` method is what we did before.