### PR TITLE
Add systematic tests for anomaly detectors

### DIFF
--- a/river/anomaly/filter.py
+++ b/river/anomaly/filter.py
@@ -139,14 +139,14 @@ class QuantileFilter(anomaly.base.AnomalyFilter):
     >>> report
                    Precision   Recall   F1       Support
     <BLANKLINE>
-           0      99.91%   97.78%   98.83%      7975
-           1       9.23%   72.00%   16.36%        25
+           0      99.75%   98.46%   99.10%      7975
+           1       3.91%   20.00%    6.54%        25
     <BLANKLINE>
-       Macro      54.57%   84.89%   57.60%
-       Micro      97.70%   97.70%   97.70%
-    Weighted      99.63%   97.70%   98.58%
+       Macro      51.83%   59.23%   52.82%
+       Micro      98.21%   98.21%   98.21%
+    Weighted      99.45%   98.21%   98.81%
     <BLANKLINE>
-                     97.70% accuracy
+                     98.21% accuracy
 
     """
 

--- a/river/anomaly/hst.py
+++ b/river/anomaly/hst.py
@@ -174,7 +174,7 @@ class HalfSpaceTrees(anomaly.base.AnomalyDetector):
     ...     auc = auc.update(y, score)
 
     >>> auc
-    ROCAUC: 93.94%
+    ROCAUC: 91.15%
 
     References
     ----------
@@ -226,7 +226,7 @@ class HalfSpaceTrees(anomaly.base.AnomalyDetector):
         if not self.trees:
             self.trees = [
                 make_padded_tree(
-                    limits={i: self.limits[i] for i in x},
+                    limits={i: self.limits[i] for i in sorted(x)},
                     height=self.height,
                     padding=0.15,
                     rng=self.rng,

--- a/river/anomaly/test_hst.py
+++ b/river/anomaly/test_hst.py
@@ -25,6 +25,6 @@ def test_missing_features():
     ...     auc = auc.update(y, score)
 
     >>> auc
-    ROCAUC: 88.36%
+    ROCAUC: 88.68%
 
     """

--- a/river/checks/__init__.py
+++ b/river/checks/__init__.py
@@ -106,6 +106,11 @@ def _yield_datasets(model: Estimator):
         if model._multiclass and base.tags.POSITIVE_INPUT not in model._tags:  # type: ignore
             yield datasets.ImageSegments().take(200)
 
+    # Anomaly detection
+    elif utils.inspect.isanomalydetector(model):
+
+        yield datasets.CreditCard().take(1000)
+
 
 def yield_checks(model: Estimator) -> typing.Iterator[typing.Callable]:
     """Generates unit tests for a given model.

--- a/river/checks/__init__.py
+++ b/river/checks/__init__.py
@@ -10,7 +10,7 @@ from river.base import Estimator
 from river.model_selection.base import ModelSelector
 from river.reco.base import Ranker
 
-from . import clf, common, model_selection, reco
+from . import anomaly, clf, common, model_selection, reco
 
 __all__ = ["check_estimator", "yield_checks"]
 
@@ -140,7 +140,7 @@ def yield_checks(model: Estimator) -> typing.Iterator[typing.Callable]:
         yield clf.check_multiclass_is_bool
 
     # Checks that make use of datasets
-    checks = [
+    dataset_checks = [
         common.check_learn_one,
         common.check_pickling,
         common.check_shuffle_features_no_impact,
@@ -149,27 +149,32 @@ def yield_checks(model: Estimator) -> typing.Iterator[typing.Callable]:
     ]
 
     if hasattr(model, "debug_one"):
-        checks.append(common.check_debug_one)
+        dataset_checks.append(common.check_debug_one)
 
     if model._is_stochastic:
-        checks.append(common.check_seeding_is_idempotent)
+        dataset_checks.append(common.check_seeding_is_idempotent)
 
     # Classifier checks
     if utils.inspect.isclassifier(model) and not utils.inspect.ismoclassifier(model):
-        checks.append(_allow_exception(clf.check_predict_proba_one, NotImplementedError))
+        dataset_checks.append(_allow_exception(clf.check_predict_proba_one, NotImplementedError))
         # Specific checks for binary classifiers
         if not model._multiclass:  # type: ignore
-            checks.append(_allow_exception(clf.check_predict_proba_one_binary, NotImplementedError))
+            dataset_checks.append(
+                _allow_exception(clf.check_predict_proba_one_binary, NotImplementedError)
+            )
 
     if isinstance(utils.inspect.extract_relevant(model), ModelSelector):
-        checks.append(model_selection.check_model_selection_order_does_not_matter)
+        dataset_checks.append(model_selection.check_model_selection_order_does_not_matter)
 
     if isinstance(utils.inspect.extract_relevant(model), Ranker):
         yield reco.check_reco_routine
 
-    for check in checks:
+    if utils.inspect.isanomalydetector(model):
+        dataset_checks.append(anomaly.check_roc_auc)
+
+    for dataset_check in dataset_checks:
         for dataset in _yield_datasets(model):
-            yield _wrapped_partial(check, dataset=dataset)
+            yield _wrapped_partial(dataset_check, dataset=dataset)
 
 
 def check_estimator(model: Estimator):

--- a/river/checks/anomaly.py
+++ b/river/checks/anomaly.py
@@ -1,0 +1,17 @@
+def check_roc_auc(anomaly_detector, dataset):
+    """The ROC AUC should always be above 50%."""
+
+    from sklearn import metrics
+
+    scores = []
+    labels = []
+
+    for x, y in dataset:
+
+        anomaly_detector.learn_one(x)
+        y_pred = anomaly_detector.score_one(x)
+
+        scores.append(y_pred)
+        labels.append(y)
+
+    assert metrics.roc_auc_score(labels, scores) > 0.5

--- a/river/compose/pipeline.py
+++ b/river/compose/pipeline.py
@@ -713,6 +713,8 @@ class Pipeline(base.Estimator):
             _print()
             if utils.inspect.isclassifier(final):
                 print_dict(final.predict_proba_one(x), show_types=False, space_after=False)
+            elif utils.inspect.isanomalydetector(final):
+                _print(f"Score: {format_value(final.score_one(x))}")
             else:
                 _print(f"Prediction: {format_value(final.predict_one(x))}")
 

--- a/river/test_estimators.py
+++ b/river/test_estimators.py
@@ -127,6 +127,7 @@ def iter_estimators_which_can_be_tested():
                 | preprocessing.StandardScaler()
                 | linear_model.LinearRegression()
             ),
+            preprocessing.MinMaxScaler() | anomaly.HalfSpaceTrees(),
         ]
         for check in checks.yield_checks(estimator)
         if check.__name__ not in estimator._unit_test_skips()


### PR DESCRIPTION
`checks.check_estimator` will now run a test suite for anomaly detectors. I got one bug doing this: the half-space trees implementation was sensitive to the feature order.