### PR TITLE
venv caching for faster CI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -49,6 +49,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m venv ~/.venv
           source ~/.venv/bin/activate
+          pip install wheel
           pip install scikit-learn sqlalchemy
           pip install pytest-xdist[psutil]
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feature/dep_cache
 
 jobs:
   test:
@@ -33,21 +34,28 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      - name: Cache Python dependencies
+      - name: Cache the Python environment
         uses: actions/cache@v2
+        id: cache-venv
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-${{ matrix.python }}-pip-${{ hashFiles('**/setup.py') }}
+          path: ~/.venv
+          key: ${{ runner.os }}-${{ matrix.python }}-venv-${{ hashFiles('**/setup.py') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.python }}-pip-
+            ${{ runner.os }}-${{ matrix.python }}-venv-
 
       - name: Install Python dependencies
+        if: ${{ steps.cache-venv.outputs.cache-hit != 'true' }}
         run: |
           python -m pip install --upgrade pip
-          pip install wheel
-          pip install -e ".[dev]"
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
           pip install scikit-learn sqlalchemy
           pip install pytest-xdist[psutil]
+
+      - name: Build River
+        run: |
+          source ~/.venv/bin/activate
+          pip install -e ".[dev]"
 
       - name: Cache River datasets
         uses: actions/cache@v2
@@ -62,7 +70,11 @@ jobs:
           key: ${{ runner.os }}
 
       - name: Download datasets
-        run: python -c "from river import datasets; datasets.CreditCard().download(); datasets.Elec2().download()"
+        run: |
+          source ~/.venv/bin/activate
+          python -c "from river import datasets; datasets.CreditCard().download(); datasets.Elec2().download()"
 
       - name: pytest
-        run: pytest -m "not datasets" --durations=10 -n logical # Run pytest on all logical CPU cores
+        run: |
+          source ~/.venv/bin/activate
+          pytest -m "not datasets" --durations=10 -n logical # Run pytest on all logical CPU cores


### PR DESCRIPTION
<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->

As discussed with @MaxHalford on [Discord](https://discord.com/channels/1049726457515102238/1051186195775893564), caching the virtual environment allows us to bypass completely `pip install`s. The existing approach caches downloaded pip packages, although `pip install` takes considerable amounts of time even then. 
