### PR TITLE
Introduce base.DriftAndWarningDetector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,9 @@ venv.bak/
 .dmypy.json
 dmypy.json
 
+# ruff
+.ruff_cache
+
 # Pyre type checker
 .pyre/
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -3,6 +3,7 @@
 ## base
 
 - Fixed an issue where an estimator that has attribute a pipeline could not be cloned.
+- Added a `base.DriftAndWarningDetector` to clarify the difference between drift detectors that have a `warning_detected` property and those that don't.
 
 ## conf
 

--- a/river/base/__init__.py
+++ b/river/base/__init__.py
@@ -15,7 +15,7 @@ from . import tags, typing
 from .base import Base
 from .classifier import Classifier, MiniBatchClassifier
 from .clusterer import Clusterer
-from .drift_detector import DriftDetector
+from .drift_detector import DriftDetector, DriftAndWarningDetector
 from .ensemble import Ensemble, WrapperEnsemble
 from .estimator import Estimator
 from .multi_output import MultiOutputMixin
@@ -33,6 +33,7 @@ __all__ = [
     "Classifier",
     "Clusterer",
     "DriftDetector",
+    "DriftAndWarningDetector",
     "Ensemble",
     "Estimator",
     "MiniBatchClassifier",

--- a/river/base/__init__.py
+++ b/river/base/__init__.py
@@ -15,7 +15,7 @@ from . import tags, typing
 from .base import Base
 from .classifier import Classifier, MiniBatchClassifier
 from .clusterer import Clusterer
-from .drift_detector import DriftDetector, DriftAndWarningDetector
+from .drift_detector import DriftAndWarningDetector, DriftDetector
 from .ensemble import Ensemble, WrapperEnsemble
 from .estimator import Estimator
 from .multi_output import MultiOutputMixin

--- a/river/base/drift_detector.py
+++ b/river/base/drift_detector.py
@@ -8,20 +8,11 @@ class DriftDetector(base.Base):
     """A drift detector."""
 
     def __init__(self):
-        self._drift_detected = False
+        self.drift_detected = False
 
     def _reset(self):
         """Reset the change detector."""
-        self._drift_detected = False
-
-    @property
-    def drift_detected(self) -> bool:
-        """Concept drift alarm.
-
-        True if concept drift is detected.
-
-        """
-        return self._drift_detected
+        self.drift_detected = False
 
     @abc.abstractmethod
     def update(self, x: numbers.Number) -> "DriftDetector":
@@ -37,3 +28,16 @@ class DriftDetector(base.Base):
         self
 
         """
+
+
+class WarningAndDriftDetector(DriftDetector):
+    """A drift detector that is also capable of issuing warnings."""
+
+    def __init__(self):
+        super().__init__()
+        self.warning_detected = False
+
+    def _reset(self):
+        """Reset the change detector."""
+        super()._reset()
+        self.warning_detected = False

--- a/river/base/drift_detector.py
+++ b/river/base/drift_detector.py
@@ -18,16 +18,17 @@ class DriftDetector(base.Base):
         self._drift_detected = False
 
     def _reset(self):
-        """Reset the change detector."""
+        """Reset the detector's state."""
         self._drift_detected = False
 
     @property
     def drift_detected(self):
+        """Whether or not a drift is detected following the last update."""
         return self._drift_detected
 
     @abc.abstractmethod
     def update(self, x: numbers.Number) -> "DriftDetector":
-        """Update the change detector with a single data point.
+        """Update the detector with a single data point.
 
         Parameters
         ----------
@@ -49,10 +50,10 @@ class DriftAndWarningDetector(DriftDetector):
         self._warning_detected = False
 
     def _reset(self):
-        """Reset the change detector."""
         super()._reset()
         self._warning_detected = False
 
     @property
     def warning_detected(self):
+        """Whether or not a drift is detected following the last update."""
         return self._warning_detected

--- a/river/base/drift_detector.py
+++ b/river/base/drift_detector.py
@@ -1,3 +1,10 @@
+"""Base classes for drift detection.
+
+The _drift_detected and _warning_detected properties are stored as private attributes
+and are exposed through the corresponding properties. This is done for documentation
+purposes. The properties are not meant to be modified by the user.
+
+"""
 import abc
 import numbers
 
@@ -8,11 +15,15 @@ class DriftDetector(base.Base):
     """A drift detector."""
 
     def __init__(self):
-        self.drift_detected = False
+        self._drift_detected = False
 
     def _reset(self):
         """Reset the change detector."""
-        self.drift_detected = False
+        self._drift_detected = False
+
+    @property
+    def drift_detected(self):
+        return self._drift_detected
 
     @abc.abstractmethod
     def update(self, x: numbers.Number) -> "DriftDetector":
@@ -30,14 +41,18 @@ class DriftDetector(base.Base):
         """
 
 
-class WarningAndDriftDetector(DriftDetector):
+class DriftAndWarningDetector(DriftDetector):
     """A drift detector that is also capable of issuing warnings."""
 
     def __init__(self):
         super().__init__()
-        self.warning_detected = False
+        self._warning_detected = False
 
     def _reset(self):
         """Reset the change detector."""
         super()._reset()
-        self.warning_detected = False
+        self._warning_detected = False
+
+    @property
+    def warning_detected(self):
+        return self._warning_detected

--- a/river/drift/adwin.py
+++ b/river/drift/adwin.py
@@ -121,7 +121,7 @@ class ADWIN(DriftDetector):
         self
 
         """
-        if self._drift_detected:
+        if self.drift_detected:
             self._reset()
 
         self._drift_detected = self._helper.update(x)

--- a/river/drift/ddm.py
+++ b/river/drift/ddm.py
@@ -1,10 +1,10 @@
 import math
 
 from river import stats
-from river.base import DriftDetector
+from river.base import DriftAndWarningDetector
 
 
-class DDM(DriftDetector):
+class DDM(DriftAndWarningDetector):
     """Drift Detection Method.
 
     DDM (Drift Detection Method) is a concept change detection method
@@ -107,7 +107,6 @@ class DDM(DriftDetector):
 
     def _reset(self):
         super()._reset()
-        self._warning_detected = False
 
         # Probability of error/failure
         self._p = stats.Mean()
@@ -120,7 +119,7 @@ class DDM(DriftDetector):
         self._ps_min = float("inf")
 
     def update(self, x):
-        if self._drift_detected:
+        if self.drift_detected:
             self._reset()
 
         # Probability of error/failure

--- a/river/drift/ddm.py
+++ b/river/drift/ddm.py
@@ -119,10 +119,6 @@ class DDM(DriftDetector):
         # The sum of p_min and s_min, to avoid calculating it every time
         self._ps_min = float("inf")
 
-    @property
-    def warning_detected(self) -> bool:
-        return self._warning_detected
-
     def update(self, x):
         if self._drift_detected:
             self._reset()

--- a/river/drift/eddm.py
+++ b/river/drift/eddm.py
@@ -1,8 +1,8 @@
 from river import stats
-from river.base import DriftDetector
+from river.base import DriftAndWarningDetector
 
 
-class EDDM(DriftDetector):
+class EDDM(DriftAndWarningDetector):
     r"""Early Drift Detection Method.
 
     EDDM (Early Drift Detection Method) aims to improve the detection rate of gradual
@@ -103,7 +103,6 @@ class EDDM(DriftDetector):
 
     def _reset(self):
         super()._reset()
-        self._warning_detected = False
 
         # Variance of the distance between two error/failure reports
         self._error_distances = stats.Var()
@@ -131,7 +130,7 @@ class EDDM(DriftDetector):
 
         """
 
-        if self._drift_detected:
+        if self.drift_detected:
             self._reset()
 
         # Update the sample counter

--- a/river/drift/eddm.py
+++ b/river/drift/eddm.py
@@ -116,10 +116,6 @@ class EDDM(DriftDetector):
 
         self._p2s_prime_max = -1
 
-    @property
-    def warning_detected(self):
-        return self._warning_detected
-
     def update(self, x):
         """Update the change detector with a single data point.
 

--- a/river/drift/hddm_a.py
+++ b/river/drift/hddm_a.py
@@ -1,10 +1,10 @@
 import math
 
 from river import stats
-from river.base import DriftDetector
+from river.base import DriftAndWarningDetector
 
 
-class HDDM_A(DriftDetector):
+class HDDM_A(DriftAndWarningDetector):
     """Drift Detection Method based on Hoeffding's bounds with moving average-test.
 
     HDDM_A is a drift detection method based on the Hoeffding's inequality which uses
@@ -77,7 +77,6 @@ class HDDM_A(DriftDetector):
 
     def _reset(self):
         super()._reset()
-        self._warning_detected = False
 
         # To check if the global mean increased
         self._x_mn = stats.Mean()
@@ -104,7 +103,7 @@ class HDDM_A(DriftDetector):
 
         """
 
-        if self._drift_detected:
+        if self.drift_detected:
             self._reset()
 
         self._z.update(x)

--- a/river/drift/hddm_a.py
+++ b/river/drift/hddm_a.py
@@ -86,10 +86,6 @@ class HDDM_A(DriftDetector):
         # Global mean
         self._z = stats.Mean()
 
-    @property
-    def warning_detected(self) -> bool:
-        return self._warning_detected
-
     def _hoeffding_bound(self, n):
         return math.sqrt(1.0 / (2 * n) * math.log(1.0 / self.drift_confidence))
 

--- a/river/drift/hddm_w.py
+++ b/river/drift/hddm_w.py
@@ -98,10 +98,6 @@ class HDDM_W(DriftDetector):
         self._incr_cutpoint = float("inf")
         self._decr_cutpoint = -float("inf")
 
-    @property
-    def warning_detected(self) -> bool:
-        return self._warning_detected
-
     def _mcdiarmid_bound(self, ibc: float, confidence: float):
         return math.sqrt(ibc * math.log(1 / confidence) / 2)
 

--- a/river/drift/hddm_w.py
+++ b/river/drift/hddm_w.py
@@ -2,10 +2,10 @@ import copy
 import math
 
 from river import stats
-from river.base import DriftDetector
+from river.base import DriftAndWarningDetector
 
 
-class HDDM_W(DriftDetector):
+class HDDM_W(DriftAndWarningDetector):
     """Drift Detection Method based on Hoeffding's bounds with moving weighted average-test.
 
     HDDM_W is an online drift detection method based on McDiarmid's bounds. HDDM_W uses the
@@ -89,7 +89,6 @@ class HDDM_W(DriftDetector):
 
     def _reset(self):
         super()._reset()
-        self._warning_detected = False
         self._total = SampleInfo(self.lambda_val)
         self._s1_decr = SampleInfo(self.lambda_val)
         self._s1_incr = SampleInfo(self.lambda_val)
@@ -116,7 +115,7 @@ class HDDM_W(DriftDetector):
 
         """
 
-        if self._drift_detected:
+        if self.drift_detected:
             self._reset()
 
         self._total.update(x)

--- a/river/drift/kswin.py
+++ b/river/drift/kswin.py
@@ -127,7 +127,7 @@ class KSWIN(DriftDetector):
 
         """
 
-        if self._drift_detected:
+        if self.drift_detected:
             self._reset()
 
         self.n += 1

--- a/river/drift/page_hinkley.py
+++ b/river/drift/page_hinkley.py
@@ -104,7 +104,7 @@ class PageHinkley(DriftDetector):
         return test_increase > self.threshold or test_decrease > self.threshold
 
     def update(self, x):
-        if self._drift_detected:
+        if self.drift_detected:
             self._reset()
 
         self._x_mean.update(x)

--- a/river/drift/periodic_trigger.py
+++ b/river/drift/periodic_trigger.py
@@ -166,7 +166,7 @@ class PeriodicTrigger(base.DriftDetector):
         threshold = 1 / (1 + math.exp(-4 * (t - t_0) / self.w))
         self._drift_detected = self._rng.random() < threshold
 
-        if self._drift_detected:
+        if self.drift_detected:
             self._n = 0
 
     def update(self, x):

--- a/river/drift/retrain.py
+++ b/river/drift/retrain.py
@@ -39,7 +39,7 @@ class DriftRetrainingClassifier(base.Wrapper, base.Classifier):
 
     """
 
-    def __init__(self, model: base.Classifier, drift_detector: base.DriftDetector = None):
+    def __init__(self, model: base.Classifier, drift_detector: base.DriftAndWarningDetector = None):
         self.model = model
         self.bkg_model = model.clone()
         self.drift_detector = drift_detector if drift_detector is not None else drift.DDM()


### PR DESCRIPTION
Some drift detectors have a `warning_detected` property, some don't. I believe introducing a new base class clarifies this difference.