### PR TITLE
Handle probabilities in MultiClassEncoder

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Download datasets
         run: |
           source ~/.venv/bin/activate
-          python -c "from river import datasets; datasets.CreditCard().download(); datasets.Elec2().download()"
+          python -c "from river import datasets; datasets.CreditCard().download(); datasets.Elec2().download(); datasets.SMSSpam().download()"
 
       - name: pytest [Branch]
         if: github.event_name == 'pull_request'

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -58,7 +58,7 @@
 
 ## multioutput
 
-- Added `MulticlassEncoder` to convert multi-label tasks into multi-class problems.
+- Added `MultiClassEncoder` to convert multi-label tasks into multi-class problems.
 
 ## preprocessing
 

--- a/river/multioutput/__init__.py
+++ b/river/multioutput/__init__.py
@@ -5,12 +5,12 @@ from .chain import (
     ProbabilisticClassifierChain,
     RegressorChain,
 )
-from .encoder import MulticlassEncoder
+from .encoder import MultiClassEncoder
 
 __all__ = [
     "ClassifierChain",
     "MonteCarloClassifierChain",
-    "MulticlassEncoder",
+    "MultiClassEncoder",
     "ProbabilisticClassifierChain",
     "RegressorChain",
 ]

--- a/river/multioutput/chain.py
+++ b/river/multioutput/chain.py
@@ -47,7 +47,6 @@ class ClassifierChain(BaseChain, base.MultiLabelClassifier):
         A list with the targets order in which to construct the chain. If `None` then the order
         will be inferred from the order of the keys in the target.
 
-
     Examples
     --------
 
@@ -284,7 +283,6 @@ class ProbabilisticClassifierChain(ClassifierChain):
 
     Examples
     --------
-
 
     >>> from river import linear_model
     >>> from river import metrics

--- a/river/multioutput/encoder.py
+++ b/river/multioutput/encoder.py
@@ -51,7 +51,7 @@ class MultiClassEncoder(base.MultiLabelClassifier):
         super().__init__()
         self.model = model
 
-        self._label_map: typing.DefaultDict[tuple, int] = {}
+        self._label_map: dict[tuple, int] = {}
         self._r_label_map: dict[int, tuple] = {}
         self._labels: set[typing.Hashable] = set()
 

--- a/river/multioutput/encoder.py
+++ b/river/multioutput/encoder.py
@@ -18,7 +18,7 @@ class MultiClassEncoder(base.MultiLabelClassifier):
 
     Parameters
     ----------
-    classifier
+    model
         The classifier used for learning.
 
     Examples

--- a/river/multioutput/encoder.py
+++ b/river/multioutput/encoder.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
+
 import typing
 
-from river import base, utils
+from river import base
 
 
 class MultiClassEncoder(base.MultiLabelClassifier):
@@ -50,9 +51,9 @@ class MultiClassEncoder(base.MultiLabelClassifier):
         super().__init__()
         self.model = model
 
-        self._label_map: typing.DefaultDict[typing.Tuple, int] = {}
-        self._r_label_map: typing.Dict[int, typing.Tuple] = {}
-        self._labels: typing.Set[typing.Hashable] = set()
+        self._label_map: typing.DefaultDict[tuple, int] = {}
+        self._r_label_map: dict[int, tuple] = {}
+        self._labels: set[typing.Hashable] = set()
 
     def learn_one(self, x, y):
         self._labels.update(y.keys())


### PR DESCRIPTION
Hey @smastelini! I believe there is a little mistake in `MultiClassEncoder`. Basically, it seems to me that the predicted outputs are always 1 or 0 for each `False/True` of each output. That's because a probability is assigned to `True` or `False`, which is then converted to `1` or `0` with `utils.norm.normalize_values_in_dict`. This is difficult to notice because the metrics we use don't care about the probabilties. I think the implementation I suggest is correct, but I'll let you double check.

Anyway, good work! It's a nice model to have.