### PR TITLE
Remove n_classes parameter in Mondrian trees

### DIFF
--- a/river/forest/aggregated_mondrian_forest.py
+++ b/river/forest/aggregated_mondrian_forest.py
@@ -101,8 +101,10 @@ class AMFClassifier(AMFLearner, base.Classifier):
         Controls if aggregation is used in the trees. It is highly recommended to
         leave it as `True`.
     dirichlet
-        Regularization level of the class frequencies used for predictions in each
-        node. Default is dirichlet=0.5 for binary problems and dirichlet=0.01 otherwise.
+        Regularization level of the class frequencies used for predictions in each node. A rule of
+        thumb is to set this to `1 / n_classes`, where `n_classes` is the expected number of
+        classes which might appear. Default is `dirichlet = 0.5`, which works well for binary
+        classification problems.
     split_pure
         Controls if nodes that contains only sample of the same class should be
         split ("pure" nodes). Default is `False`, namely pure nodes are not split,
@@ -112,18 +114,18 @@ class AMFClassifier(AMFLearner, base.Classifier):
 
     Notes
     -----
-    Only log_loss used for the computation of the aggregation weights is supported for now, namely the log-loss
-    for multi-class classification.
+    Only log_loss used for the computation of the aggregation weights is supported for now, namely
+    the log-loss for multi-class classification.
 
     Examples
     --------
 
+    >>> from river import datasets
     >>> from river import evaluate
     >>> from river import forest
     >>> from river import metrics
-    >>> from river.datasets import Bananas
 
-    >>> dataset = Bananas().take(500)
+    >>> dataset = datasets.Bananas().take(500)
 
     >>> model = forest.AMFClassifier(
     ...     n_estimators=10,

--- a/river/forest/aggregated_mondrian_forest.py
+++ b/river/forest/aggregated_mondrian_forest.py
@@ -92,9 +92,6 @@ class AMFClassifier(AMFLearner, base.Classifier):
 
     Parameters
     ----------
-    n_classes
-        Number of expected classes in the labels. This is required since we
-        don't know the number of classes in advance in a online setting.
     n_estimators
         The number of trees in the forest.
     step
@@ -129,17 +126,16 @@ class AMFClassifier(AMFLearner, base.Classifier):
     >>> dataset = Bananas().take(500)
 
     >>> model = forest.AMFClassifier(
-    ...     n_classes=2,
     ...     n_estimators=10,
     ...     use_aggregation=True,
-    ...     dirichlet=0.2,
+    ...     dirichlet=0.5,
     ...     seed=1
     ... )
 
     >>> metric = metrics.Accuracy()
 
     >>> evaluate.progressive_val_score(dataset, model, metric)
-    Accuracy: 84.77%
+    Accuracy: 84.97%
 
     References
     ----------
@@ -149,11 +145,10 @@ class AMFClassifier(AMFLearner, base.Classifier):
 
     def __init__(
         self,
-        n_classes: int = 2,
         n_estimators: int = 10,
         step: float = 1.0,
         use_aggregation: bool = True,
-        dirichlet: float = None,
+        dirichlet: float = 0.5,
         split_pure: bool = False,
         seed: int = None,
     ):
@@ -165,16 +160,7 @@ class AMFClassifier(AMFLearner, base.Classifier):
             split_pure=split_pure,
             seed=seed,
         )
-
-        self.n_classes = n_classes
-        if dirichlet is None:
-            if self.n_classes == 2:
-                self.dirichlet = 0.5
-            else:
-                self.dirichlet = 0.01
-        else:
-            self.dirichlet = dirichlet
-
+        self.dirichlet = dirichlet
         # memory of the classes
         self._classes: set[base.typing.ClfTarget] = set()
 
@@ -182,7 +168,6 @@ class AMFClassifier(AMFLearner, base.Classifier):
         self.data: list[MondrianTreeClassifier] = []
         for _ in range(self.n_estimators):
             tree = MondrianTreeClassifier(
-                self.n_classes,
                 self.step,
                 self.use_aggregation,
                 self.dirichlet,

--- a/river/tree/mondrian/mondrian_tree.py
+++ b/river/tree/mondrian/mondrian_tree.py
@@ -43,4 +43,5 @@ class MondrianTree(abc.ABC):
         self.iteration = iteration
 
         # Controls the randomness in the tree
+        self.seed = seed
         self._rng = random.Random(seed)

--- a/river/tree/mondrian/mondrian_tree_classifier.py
+++ b/river/tree/mondrian/mondrian_tree_classifier.py
@@ -17,8 +17,6 @@ class MondrianTreeClassifier(MondrianTree, base.Classifier):
 
     Parameters
     ----------
-    n_classes
-        Number of classes of the problem.
     step
         Step of the tree.
     use_aggregation
@@ -68,10 +66,9 @@ class MondrianTreeClassifier(MondrianTree, base.Classifier):
 
     def __init__(
         self,
-        n_classes: int = 2,
         step: float = 0.1,
         use_aggregation: bool = True,
-        dirichlet: float = None,
+        dirichlet: float = 0.5,
         split_pure: bool = False,
         iteration: int = 0,
         seed: int = None,
@@ -85,17 +82,7 @@ class MondrianTreeClassifier(MondrianTree, base.Classifier):
             iteration=iteration,
             seed=seed,
         )
-        self.n_classes = n_classes
-        if dirichlet is None:
-            if self.n_classes == 2:
-                self.dirichlet = 0.5
-            else:
-                self.dirichlet = 0.01
-        else:
-            self.dirichlet = dirichlet
-
-        # Controls the randomness in the tree
-        self.seed = seed
+        self.dirichlet = dirichlet
 
         # Training attributes
         # The previously observed classes set
@@ -124,7 +111,7 @@ class MondrianTreeClassifier(MondrianTree, base.Classifier):
             Node to evaluate the score.
         """
 
-        return node.score(self._y, self.dirichlet, self.n_classes)
+        return node.score(self._y, self.dirichlet, len(self._classes))
 
     def _predict(self, node: MondrianNodeClassifier) -> dict[base.typing.ClfTarget, float]:
         """Compute the predictions scores of the node regarding all the classes scores.
@@ -135,7 +122,7 @@ class MondrianTreeClassifier(MondrianTree, base.Classifier):
             Node to make predictions.
         """
 
-        return node.predict(self.dirichlet, self._classes, self.n_classes)
+        return node.predict(self.dirichlet, self._classes, len(self._classes))
 
     def _loss(self, node: MondrianNodeClassifier) -> float:
         """Compute the loss for the given node regarding the current label
@@ -146,7 +133,7 @@ class MondrianTreeClassifier(MondrianTree, base.Classifier):
             Node to evaluate the loss.
         """
 
-        return node.loss(self._y, self.dirichlet, self.n_classes)
+        return node.loss(self._y, self.dirichlet, len(self._classes))
 
     def _update_weight(self, node: MondrianNodeClassifier) -> float:
         """Update the weight of the node regarding the current label with the tree parameters.
@@ -158,7 +145,7 @@ class MondrianTreeClassifier(MondrianTree, base.Classifier):
         """
 
         return node.update_weight(
-            self._y, self.dirichlet, self.use_aggregation, self.step, self.n_classes
+            self._y, self.dirichlet, self.use_aggregation, self.step, len(self._classes)
         )
 
     def _update_count(self, node: MondrianNodeClassifier):
@@ -191,7 +178,7 @@ class MondrianTreeClassifier(MondrianTree, base.Classifier):
             self.use_aggregation,
             self.step,
             do_weight_update,
-            self.n_classes,
+            len(self._classes),
         )
 
     def _compute_split_time(


### PR DESCRIPTION
- Ok I just removed the `n_classes` and added some documentation to `dirichlet`. Honestly I think this is more than fine for now.
- I also tidied up the code a tiny bit.