### PR TITLE
Bump watermill version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.16.5", features = ["extension-module"] }
-watermill = "0.1.0"
+watermill = "0.1.1"
 bincode = "1.3.3"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Hi, I fix this issue: https://github.com/online-ml/river/issues/1178.

The bug was in the rust part; I sorted the `height` list after the sixth update, so the initialization wasn't consistent.

The fix here : https://github.com/online-ml/watermill.rs/commit/bb284c4c87dd77cd31a6d39db4893a0ea04cdce1