### PR TITLE
Fix RollingROCAUC Cython build on macOS

### DIFF
--- a/river/metrics/efficient_rollingrocauc/efficient_rollingrocauc.pyx
+++ b/river/metrics/efficient_rollingrocauc/efficient_rollingrocauc.pyx
@@ -1,4 +1,6 @@
 # distutils: language = c++
+# distutils: extra_compile_args = "-std=c++11"
+
 import cython
 
 from .efficient_rollingrocauc cimport RollingROCAUC as CppRollingROCAUC

--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,6 @@ setuptools.setup(
                 include_dirs=[get_include()],
                 libraries=[] if platform.system() == "Windows" else ["m"],
                 define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
-                extra_compile_args=["-std=c++11"],
             )
         ],
         compiler_directives={


### PR DESCRIPTION
Make the flag `-std=c++11` on `efficient_rollingrocauc.pyx` explicit to avoid errors on compiling on macOS.
