### PR TITLE
Type-check KNNR targets

### DIFF
--- a/river/neighbors/knn_regressor.py
+++ b/river/neighbors/knn_regressor.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import functools
 import statistics
+from decimal import Decimal
+from fractions import Fraction
+from numbers import Integral
 
 from river import base, utils
 from river.neighbors import NearestNeighbors
@@ -114,6 +117,8 @@ class KNNRegressor(base.Regressor):
             )
 
     def learn_one(self, x, y):
+        assert isinstance(y, (int, float, Decimal, Fraction, Integral))
+
         self._nn.update((x, y), n_neighbors=self.n_neighbors)
         return self
 


### PR DESCRIPTION
`learn_one` only saves instances in KNN models. This means that without this type-check it is easy to face confusing exceptions when attempting to use the `predict_one` method.

I was very confused when I saw the following error when predicting after an initial training phase: `TypeError: can't convert type 'dict' to numerator/denominator`. It finally turned out that my target source array had shape `(n, 1)` instead of `(n,)` and that was messing with the aggregation function in prediction time.