### PR TITLE
New parameters for Hoeffding Tree Classifiers

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -18,8 +18,8 @@
 
 ## neighbors
 
-- Add `neighbors.SWINN` to power-up approximate nearest neighbor search. SWINN uses graphs to speed up nearest neighbor search in large sliding windows of data.
-- Rename `neighbors.NearestNeighbors` to `neighbors.LazySearch`.
+- Added `neighbors.SWINN` to power-up approximate nearest neighbor search. SWINN uses graphs to speed up nearest neighbor search in large sliding windows of data.
+- Renamed `neighbors.NearestNeighbors` to `neighbors.LazySearch`.
 - Standardize and create base classes for generic nearest neighbor search utilities.
 - The user can now select the nearest neighbor search engine to use in `neighbors.KNNClassifier` and `neighbors.KNNRegressor`.
 
@@ -31,6 +31,13 @@
 ## proba
 
 - Added a `cdf` method to `proba.Beta`.
+
+## tree
+
+- Expose the `min_branch_fraction` parameter to avoid splits where most of the data goes to a single branch. Affects
+classification trees.
+- Added the `max_share_to_split` parameter to Hoeffding Tree classifiers. This parameters avoids splitting when the majority
+class has most of the data.
 
 ## utils
 

--- a/river/drift/retrain.py
+++ b/river/drift/retrain.py
@@ -39,7 +39,7 @@ class DriftRetrainingClassifier(base.Wrapper, base.Classifier):
     >>> metric = metrics.Accuracy()
 
     >>> evaluate.progressive_val_score(dataset, model, metric)
-    Accuracy: 86.40%
+    Accuracy: 86.46%
 
     """
 

--- a/river/forest/adaptive_random_forest.py
+++ b/river/forest/adaptive_random_forest.py
@@ -159,6 +159,8 @@ class BaseTreeClassifier(HoeffdingTreeClassifier):
         nominal_attributes: list | None = None,
         splitter: Splitter | None = None,
         binary_split: bool = False,
+        min_branch_fraction: float = 0.01,
+        max_share_to_split: float = 0.99,
         max_size: float = 100.0,
         memory_estimate_period: int = 1000000,
         stop_mem_management: bool = False,
@@ -177,6 +179,8 @@ class BaseTreeClassifier(HoeffdingTreeClassifier):
             nominal_attributes=nominal_attributes,
             splitter=splitter,
             binary_split=binary_split,
+            min_branch_fraction=min_branch_fraction,
+            max_share_to_split=max_share_to_split,
             max_size=max_size,
             memory_estimate_period=memory_estimate_period,
             stop_mem_management=stop_mem_management,
@@ -421,6 +425,16 @@ class ARFClassifier(BaseForest, base.Classifier):
         if `splitter` is `None`.
     binary_split
         [*Tree parameter*] If True, only allow binary splits.
+    min_branch_fraction
+        [*Tree parameter*] The minimum percentage of observed data required for branches
+        resulting from split candidates. To validate a split candidate, at least two resulting
+        branches must have a percentage of samples greater than `min_branch_fraction`. This
+        criterion prevents unnecessary splits when the majority of instances are concentrated
+        in a single branch.
+    max_share_to_split
+        [*Tree parameter*] Only perform a split in a leaf if the proportion of elements
+        in the majority class is smaller than this parameter value. This parameter avoids
+        performing splits when most of the data belongs to a single class.
     max_size
         [*Tree parameter*] Maximum memory (MB) consumed by the tree.
     memory_estimate_period
@@ -484,6 +498,8 @@ class ARFClassifier(BaseForest, base.Classifier):
         nominal_attributes: list | None = None,
         splitter: Splitter | None = None,
         binary_split: bool = False,
+        min_branch_fraction: float = 0.01,
+        max_share_to_split: float = 0.99,
         max_size: float = 100.0,
         memory_estimate_period: int = 2_000_000,
         stop_mem_management: bool = False,
@@ -516,6 +532,8 @@ class ARFClassifier(BaseForest, base.Classifier):
         self.nominal_attributes = nominal_attributes
         self.splitter = splitter
         self.binary_split = binary_split
+        self.min_branch_fraction = min_branch_fraction
+        self.max_share_to_split = max_share_to_split
         self.max_size = max_size
         self.memory_estimate_period = memory_estimate_period
         self.stop_mem_management = stop_mem_management
@@ -568,6 +586,8 @@ class ARFClassifier(BaseForest, base.Classifier):
             splitter=self.splitter,
             max_depth=self.max_depth,
             binary_split=self.binary_split,
+            min_branch_fraction=self.min_branch_fraction,
+            max_share_to_split=self.max_share_to_split,
             max_size=self.max_size,
             memory_estimate_period=self.memory_estimate_period,
             stop_mem_management=self.stop_mem_management,

--- a/river/tree/extremely_fast_decision_tree.py
+++ b/river/tree/extremely_fast_decision_tree.py
@@ -59,6 +59,15 @@ class ExtremelyFastDecisionTreeClassifier(HoeffdingTreeClassifier):
         By default, `tree.splitter.GaussianSplitter` is used if `splitter` is `None`.
     binary_split
         If True, only allow binary splits.
+    min_branch_fraction
+        The minimum percentage of observed data required for branches resulting from split
+        candidates. To validate a split candidate, at least two resulting branches must have
+        a percentage of samples greater than `min_branch_fraction`. This criterion prevents
+        unnecessary splits when the majority of instances are concentrated in a single branch.
+    max_share_to_split
+        Only perform a split in a leaf if the proportion of elements in the majority class is
+        smaller than this parameter value. This parameter avoids performing splits when most
+        of the data belongs to a single class.
     max_size
         The max size of the tree, in Megabytes (MB).
     memory_estimate_period
@@ -122,6 +131,8 @@ class ExtremelyFastDecisionTreeClassifier(HoeffdingTreeClassifier):
         nominal_attributes: list | None = None,
         splitter: Splitter | None = None,
         binary_split: bool = False,
+        min_branch_fraction: float = 0.01,
+        max_share_to_split: float = 0.99,
         max_size: float = 100.0,
         memory_estimate_period: int = 1000000,
         stop_mem_management: bool = False,
@@ -139,6 +150,8 @@ class ExtremelyFastDecisionTreeClassifier(HoeffdingTreeClassifier):
             nominal_attributes=nominal_attributes,
             splitter=splitter,
             binary_split=binary_split,
+            min_branch_fraction=min_branch_fraction,
+            max_share_to_split=max_share_to_split,
             max_size=max_size,
             memory_estimate_period=memory_estimate_period,
             stop_mem_management=stop_mem_management,

--- a/river/tree/hoeffding_adaptive_tree_classifier.py
+++ b/river/tree/hoeffding_adaptive_tree_classifier.py
@@ -67,6 +67,15 @@ class HoeffdingAdaptiveTreeClassifier(HoeffdingTreeClassifier):
         than their main subtree counterparts.
     binary_split
         If True, only allow binary splits.
+    min_branch_fraction
+        The minimum percentage of observed data required for branches resulting from split
+        candidates. To validate a split candidate, at least two resulting branches must have
+        a percentage of samples greater than `min_branch_fraction`. This criterion prevents
+        unnecessary splits when the majority of instances are concentrated in a single branch.
+    max_share_to_split
+        Only perform a split in a leaf if the proportion of elements in the majority class is
+        smaller than this parameter value. This parameter avoids performing splits when most
+        of the data belongs to a single class.
     max_size
         The max size of the tree, in Megabytes (MB).
     memory_estimate_period
@@ -139,6 +148,8 @@ class HoeffdingAdaptiveTreeClassifier(HoeffdingTreeClassifier):
         drift_detector: base.DriftDetector | None = None,
         switch_significance: float = 0.05,
         binary_split: bool = False,
+        min_branch_fraction: float = 0.01,
+        max_share_to_split: float = 0.99,
         max_size: float = 100.0,
         memory_estimate_period: int = 1000000,
         stop_mem_management: bool = False,
@@ -157,6 +168,8 @@ class HoeffdingAdaptiveTreeClassifier(HoeffdingTreeClassifier):
             nominal_attributes=nominal_attributes,
             splitter=splitter,
             binary_split=binary_split,
+            min_branch_fraction=min_branch_fraction,
+            max_share_to_split=max_share_to_split,
             max_size=max_size,
             memory_estimate_period=memory_estimate_period,
             stop_mem_management=stop_mem_management,

--- a/river/tree/nodes/efdtc_nodes.py
+++ b/river/tree/nodes/efdtc_nodes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import numbers
 
+from river.tree.utils import BranchFactory
 from river.utils.norm import normalize_values_in_dict
 
 from ..splitter.nominal_splitter_classif import NominalSplitterClassif
@@ -56,6 +57,12 @@ class BaseEFDTLeaf(HTLeaf):
         -------
             The list of split candidates.
         """
+        maj_class = max(self.stats.values())
+        # Only perform split attempts when the majority class does not dominate
+        # the amount of observed instances
+        if maj_class and maj_class / self.total_weight > tree.max_share_to_split:
+            return [BranchFactory()]
+
         best_suggestions = []
         pre_split_dist = self.stats
 

--- a/river/tree/nodes/htc_nodes.py
+++ b/river/tree/nodes/htc_nodes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from river.tree.utils import BranchFactory
 from river.utils.norm import normalize_values_in_dict
 
 from ..splitter.nominal_splitter_classif import NominalSplitterClassif
@@ -49,6 +50,15 @@ class LeafMajorityClass(HTLeaf):
 
         """
         return sum(self.stats.values()) if self.stats else 0
+
+    def best_split_suggestions(self, criterion, tree) -> list[BranchFactory]:
+        maj_class = max(self.stats.values())
+        # Only perform split attempts when the majority class does not dominate
+        # the amount of observed instances
+        if maj_class and maj_class / self.total_weight > tree.max_share_to_split:
+            return [BranchFactory()]
+
+        return super().best_split_suggestions(criterion, tree)
 
     def calculate_promise(self):
         """Calculate how likely a node is going to be split.

--- a/river/tree/split_criterion/gini_split_criterion.py
+++ b/river/tree/split_criterion/gini_split_criterion.py
@@ -1,12 +1,21 @@
 from __future__ import annotations
 
+import math
+
 from .base import SplitCriterion
 
 
 class GiniSplitCriterion(SplitCriterion):
     """Gini Impurity split criterion."""
 
+    def __init__(self, min_branch_fraction):
+        super().__init__()
+        self.min_branch_fraction = min_branch_fraction
+
     def merit_of_split(self, pre_split_dist, post_split_dist):
+        if self.num_subsets_greater_than_frac(post_split_dist, self.min_branch_fraction) < 2:
+            return -math.inf
+
         total_weight = 0.0
         dist_weights = [0.0] * len(post_split_dist)
         for i in range(len(post_split_dist)):
@@ -31,3 +40,18 @@ class GiniSplitCriterion(SplitCriterion):
     @staticmethod
     def range_of_merit(pre_split_dist):
         return 1.0
+
+    @staticmethod
+    def num_subsets_greater_than_frac(distributions, min_frac):
+        total_weight = 0.0
+        dist_sums = [0.0] * len(distributions)
+        for i in range(len(dist_sums)):
+            dist_sums[i] = sum(distributions[i].values())
+            total_weight += dist_sums[i]
+        num_greater = 0
+
+        if total_weight > 0:
+            for d in dist_sums:
+                if (d / total_weight) > min_frac:
+                    num_greater += 1
+        return num_greater

--- a/river/tree/split_criterion/hellinger_distance_criterion.py
+++ b/river/tree/split_criterion/hellinger_distance_criterion.py
@@ -19,14 +19,12 @@ class HellingerDistanceCriterion(SplitCriterion):
     and Knowledge Discovery 24, no. 1 (2012): 136-158.
     """
 
-    def __init__(self, min_branch_frac_option=0.01):
+    def __init__(self, min_branch_fraction):
         super().__init__()
-        self.min_branch_frac_option = min_branch_frac_option
-        self.lowest_entropy = None
-        self.best_idx = 0
+        self.min_branch_fraction = min_branch_fraction
 
     def merit_of_split(self, pre_split_dist, post_split_dist):
-        if self.num_subsets_greater_than_frac(post_split_dist, self.min_branch_frac_option) < 2:
+        if self.num_subsets_greater_than_frac(post_split_dist, self.min_branch_fraction) < 2:
             return -math.inf
         return self.compute_hellinger(post_split_dist)
 

--- a/river/tree/split_criterion/info_gain_split_criterion.py
+++ b/river/tree/split_criterion/info_gain_split_criterion.py
@@ -18,13 +18,12 @@ class InfoGainSplitCriterion(SplitCriterion):
 
     """
 
-    def __init__(self, min_branch_frac_option=0.01):
+    def __init__(self, min_branch_fraction):
         super().__init__()
-        # Minimum fraction of weight required down at least two branches.
-        self.min_branch_frac_option = min_branch_frac_option
+        self.min_branch_fraction = min_branch_fraction
 
     def merit_of_split(self, pre_split_dist, post_split_dist):
-        if self.num_subsets_greater_than_frac(post_split_dist, self.min_branch_frac_option) < 2:
+        if self.num_subsets_greater_than_frac(post_split_dist, self.min_branch_fraction) < 2:
             return -math.inf
         return self.compute_entropy(pre_split_dist) - self.compute_entropy(post_split_dist)
 


### PR DESCRIPTION
Fixes #1169.

I added the `max_share_to_split` parameter, as discussed in the issue. Besides that, I also exposed another parameter that was inherited from MOA. This one prevents splitting when most of the data is concentrated in a single branch (regardless of the class distribution).