### PR TITLE
Simplify Adaptive Random Forest

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -5,3 +5,7 @@ River's mini-batch methods now support pandas v2. In particular, River conforms 
 ## anomaly
 
 - Added `anomaly.LocalOutlierFactor`, which is an online version of the LOF algorithm for anomaly detection that matches the scikit-learn implementation.
+
+## forest
+
+- Simplify inner the structures of `forest.ARFClassifier` and `forest.ARFRegressor` by removing redundant class hierarchy. Simplify how concept drift logging can be accessed in individual trees and in the forest as a whole.

--- a/river/base/drift_detector.py
+++ b/river/base/drift_detector.py
@@ -8,7 +8,6 @@ purposes. The properties are not meant to be modified by the user.
 from __future__ import annotations
 
 import abc
-import numbers
 
 from . import base
 
@@ -58,7 +57,7 @@ class DriftDetector(_BaseDriftDetector):
     """A drift detector."""
 
     @abc.abstractmethod
-    def update(self, x: numbers.Number) -> DriftDetector:
+    def update(self, x: int | float) -> DriftDetector:
         """Update the detector with a single data point.
 
         Parameters

--- a/river/forest/adaptive_random_forest.py
+++ b/river/forest/adaptive_random_forest.py
@@ -104,7 +104,7 @@ class BaseForest(base.Ensemble):
         raise NotImplementedError
 
     def n_warnings_detected(self, tree_id: int | None = None) -> int | None:
-        """ "Get the total number of concept drift warnings detected, or the number on an individual
+        """Get the total number of concept drift warnings detected, or the number on an individual
         tree basis (optionally).
 
         If warning detection is disabled, will return `None`.
@@ -130,7 +130,7 @@ class BaseForest(base.Ensemble):
         return self._warning_tracker[tree_id]
 
     def n_drifts_detected(self, tree_id: int | None = None) -> int | None:
-        """ "Get the total number of concept drifts detected, or such number on an individual
+        """Get the total number of concept drifts detected, or such number on an individual
         tree basis (optionally).
 
         If drift detection is disabled, will return `None`.
@@ -576,15 +576,15 @@ class ARFClassifier(BaseForest, base.Classifier):
     >>> evaluate.progressive_val_score(dataset, model, metric)
     Accuracy: 71.17%
 
-    # The total number of warnings and drifts detected, respectively
+    The total number of warnings and drifts detected, respectively
     >>> model.n_warnings_detected(), model.n_drifts_detected()
     (2, 1)
 
-    # The number of warnings detected by tree number 2
+    The number of warnings detected by tree number 2
     >>> model.n_warnings_detected(2)
     1
 
-    # And the corresponding number of actual concept drift detected
+    And the corresponding number of actual concept drift detected
     >>> model.n_drifts_detected(2)
     1
 

--- a/river/forest/adaptive_random_forest.py
+++ b/river/forest/adaptive_random_forest.py
@@ -79,8 +79,6 @@ class BaseForest(base.Ensemble):
             collections.defaultdict(int) if self.drift_detector is not None else None  # type: ignore
         )
 
-        self._aux = 0
-
     @property
     def _min_number_of_models(self):
         return 0
@@ -194,8 +192,6 @@ class BaseForest(base.Ensemble):
 
                         # Update warning tracker
                         self._warning_tracker[i] += 1
-
-                        self._aux += 1
 
                 if self.drift_detector is not None:
                     drift_input = (

--- a/river/forest/adaptive_random_forest.py
+++ b/river/forest/adaptive_random_forest.py
@@ -63,10 +63,23 @@ class BaseForest(base.Ensemble):
             else [self.drift_detector.clone() for _ in range(self.n_models)]
         )
 
+        # The background models
         self._background: list[BaseTreeClassifier | BaseTreeRegressor | None] = (
             None if self.warning_detector is None else [None] * self.n_models  # type: ignore
         )
+
+        # Performance metrics used for weighted voting/aggregation
         self._metrics = [self.metric.clone() for _ in range(self.n_models)]
+
+        # Drift and warning logging
+        self._warning_tracker: dict = (
+            collections.defaultdict(int) if self.warning_detector is not None else None  # type: ignore
+        )
+        self._drift_tracker: dict = (
+            collections.defaultdict(int) if self.drift_detector is not None else None  # type: ignore
+        )
+
+        self._aux = 0
 
     @property
     def _min_number_of_models(self):
@@ -91,6 +104,58 @@ class BaseForest(base.Ensemble):
     @abc.abstractmethod
     def _new_base_model(self) -> BaseTreeClassifier | BaseTreeRegressor:
         raise NotImplementedError
+
+    def n_warnings_detected(self, tree_id: int | None = None) -> int | None:
+        """ "Get the total number of concept drift warnings detected, or the number on an individual
+        tree basis (optionally).
+
+        If warning detection is disabled, will return `None`.
+
+        Parameters
+        ----------
+        tree_id
+            The number of the base learner in the ensemble: `[0, self.n_models - 1]. If `None`,
+            the total number of warnings is returned instead.
+
+        Returns
+        -------
+            The number of concept drift warnings detected.
+
+        """
+
+        if self.warning_detector is None:
+            return None
+
+        if tree_id is None:
+            return sum(self._warning_tracker.values())
+
+        return self._warning_tracker[tree_id]
+
+    def n_drifts_detected(self, tree_id: int | None = None) -> int | None:
+        """ "Get the total number of concept drifts detected, or such number on an individual
+        tree basis (optionally).
+
+        If drift detection is disabled, will return `None`.
+
+        Parameters
+        ----------
+        tree_id
+            The number of the base learner in the ensemble: `[0, self.n_models - 1]. If `None`,
+            the total number of warnings is returned instead.
+
+        Returns
+        -------
+            The number of concept drifts detected.
+
+        """
+
+        if self.drift_detector is None:
+            return None
+
+        if tree_id is None:
+            return sum(self._drift_tracker.values())
+
+        return self._drift_tracker[tree_id]
 
     def learn_one(self, x: dict, y: base.typing.Target, **kwargs):
         self._n_samples_seen += 1
@@ -127,6 +192,11 @@ class BaseForest(base.Ensemble):
                         # Reset the warning detector for the current object
                         self._warning_detectors[i] = self.warning_detector.clone()
 
+                        # Update warning tracker
+                        self._warning_tracker[i] += 1
+
+                        self._aux += 1
+
                 if self.drift_detector is not None:
                     drift_input = (
                         drift_input
@@ -146,6 +216,9 @@ class BaseForest(base.Ensemble):
                             self.data[i] = self._new_base_model()
                             self._drift_detectors[i] = self.drift_detector.clone()
                             self._metrics[i] = self.metric.clone()
+
+                        # Update warning tracker
+                        self._drift_tracker[i] += 1
 
         return self
 
@@ -505,7 +578,19 @@ class ARFClassifier(BaseForest, base.Classifier):
     >>> metric = metrics.Accuracy()
 
     >>> evaluate.progressive_val_score(dataset, model, metric)
-    Accuracy: 71.07%
+    Accuracy: 71.17%
+
+    # The total number of warnings and drifts detected, respectively
+    >>> model.n_warnings_detected(), model.n_drifts_detected()
+    (2, 1)
+
+    # The number of warnings detected by tree number 2
+    >>> model.n_warnings_detected(2)
+    1
+
+    # And the corresponding number of actual concept drift detected
+    >>> model.n_drifts_detected(2)
+    1
 
     References
     ----------
@@ -777,7 +862,7 @@ class ARFRegressor(BaseForest, base.Regressor):
     >>> metric = metrics.MAE()
 
     >>> evaluate.progressive_val_score(dataset, model, metric)
-    MAE: 0.800378
+    MAE: 0.788619
 
     """
 

--- a/river/forest/adaptive_random_forest.py
+++ b/river/forest/adaptive_random_forest.py
@@ -50,8 +50,6 @@ class BaseForest(base.Ensemble):
 
         self._rng = random.Random(self.seed)
 
-        # Internal parameters
-        self._n_samples_seen = 0
         self._warning_detectors: list[base.DriftDetector] = (
             None  # type: ignore
             if self.warning_detector is None
@@ -156,8 +154,6 @@ class BaseForest(base.Ensemble):
         return self._drift_tracker[tree_id]
 
     def learn_one(self, x: dict, y: base.typing.Target, **kwargs):
-        self._n_samples_seen += 1
-
         if len(self) == 0:
             self._init_ensemble(sorted(x.keys()))
 

--- a/river/forest/online_extra_trees.py
+++ b/river/forest/online_extra_trees.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import abc
 import collections
 import math
-import numbers
 import random
 import sys
 
@@ -221,7 +220,7 @@ class ExtraTrees(base.Ensemble, metaclass=abc.ABCMeta):
     def _detection_mode_all(
         drift_detector: base.DriftDetector,
         warning_detector: base.DriftDetector,
-        detector_input: numbers.Number,
+        detector_input: int | float,
     ) -> tuple[bool, bool]:
         in_warning = warning_detector.update(detector_input).drift_detected
         in_drift = drift_detector.update(detector_input).drift_detected
@@ -232,7 +231,7 @@ class ExtraTrees(base.Ensemble, metaclass=abc.ABCMeta):
     def _detection_mode_drop(
         drift_detector: base.DriftDetector,
         warning_detector: base.DriftDetector,
-        detector_input: numbers.Number,
+        detector_input: int | float,
     ) -> tuple[bool, bool]:
         in_drift = drift_detector.update(detector_input).drift_detected
 
@@ -242,7 +241,7 @@ class ExtraTrees(base.Ensemble, metaclass=abc.ABCMeta):
     def _detection_mode_off(
         drift_detector: base.DriftDetector,
         warning_detector: base.DriftDetector,
-        detector_input: numbers.Number,
+        detector_input: int | float,
     ) -> tuple[bool, bool]:
         return False, False
 


### PR DESCRIPTION
<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->

While reviewing #1309 I realized that the proposed changes would make the existing code problematic due to the existing class hierarchy. For instance, MSTS is intended for classification tasks, but the ARFRegressor ended up being affected to some extent.

Thus, I decided to first simplify the existing code. Next, we need to think about how to better integrate MSTS.

Suggestions:

- Create a new base Class intended to select subsets of classifiers/regressors in forest-based ensembles to generate the responses. This should become a single new parameter to ARF rather than multiple ones (ARF after #1309 would have over 30 parameters!). Such implementation must be generic and work separately from the main ARF logic (or any other target ensemble algorithm).
   - In such case, such selector would be passed very much in the same fashion as the attribute splitters.
   - If the selector is supplied, it produces a list with the classifiers/regressors to use when computing the responses.
   - The selector will be updated during `learning_one` (thus the need for a carefully planned API) and queried in `predict_one`.
- Alternatively, we can try and find a way to apply MSTS while only affecting ARFClassifier.