### PR TITLE
Add _from_state methods to MultivariateGaussian and EmpiricalCovariance

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -9,3 +9,11 @@ River's mini-batch methods now support pandas v2. In particular, River conforms 
 ## forest
 
 - Simplify inner the structures of `forest.ARFClassifier` and `forest.ARFRegressor` by removing redundant class hierarchy. Simplify how concept drift logging can be accessed in individual trees and in the forest as a whole.
+
+## covariance
+
+- Added `_from_state` method to `covariance.EmpiricalCovariance` to warm start from previous knowledge
+
+## proba
+
+- Added `_from_state` method to `proba.MultivariateGaussian` to warm start from previous knowledge

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -12,8 +12,8 @@ River's mini-batch methods now support pandas v2. In particular, River conforms 
 
 ## covariance
 
-- Added `_from_state` method to `covariance.EmpiricalCovariance` to warm start from previous knowledge
+- Added `_from_state` method to `covariance.EmpiricalCovariance` to warm start from previous knowledge.
 
 ## proba
 
-- Added `_from_state` method to `proba.MultivariateGaussian` to warm start from previous knowledge
+- Added `_from_state` method to `proba.MultivariateGaussian` to warm start from previous knowledge.

--- a/river/covariance/emp.py
+++ b/river/covariance/emp.py
@@ -190,7 +190,30 @@ class EmpiricalCovariance(SymmetricMatrix):
         return self
 
     @classmethod
-    def _from_state(cls, n, mean, cov, *, ddof=1):
+    def _from_state(cls, n: int, mean: dict, cov: dict, *, ddof=1):
+        """Create a new instance from state information.
+
+        Parameters
+        ----------
+        cls (type)
+            The class type.
+        n (int)
+            The number of data points.
+        mean (dict)
+            A dictionary of variable means.
+        cov (dict)
+            A dictionary of covariance or variance values.
+        ddof (int, optional)
+            Degrees of freedom for covariance calculation. Defaults to 1.
+
+        Returns
+        ----------
+            cls: A new instance of the class with updated covariance matrix.
+
+        Raises
+        ----------
+            KeyError: If an element in `mean` or `cov` is missing.
+        """
         new = cls(ddof=ddof)
         for i, j in itertools.combinations(sorted(mean.keys()), r=2):
             try:

--- a/river/covariance/emp.py
+++ b/river/covariance/emp.py
@@ -108,6 +108,22 @@ class EmpiricalCovariance(SymmetricMatrix):
     >>> cov["blue", "blue"]
     Var: 0.076119
 
+    Start from a state:
+    n = 8
+    mean = {'red': 0.416, 'green': 0.387, 'blue': 0.518}
+    cov_ = {('red', 'red'): 0.079,
+    ...     ('red', 'green'): -0.053,
+    ...     ('red', 'blue'): -0.010,
+    ...     ('green', 'green'): 0.113,
+    ...     ('green', 'blue'): 0.020,
+    ...     ('blue', 'blue'): 0.076}
+    cov = covariance.EmpiricalCovariance._from_state(
+    ...    n=n, mean=mean, cov=cov_, ddof=1)
+    >>> cov
+            blue     green    red
+     blue    0.076    0.020   -0.010
+    green    0.020    0.113   -0.053
+      red   -0.010   -0.053    0.079
     """
 
     def __init__(self, ddof=1):
@@ -368,3 +384,8 @@ class EmpiricalPrecision(SymmetricMatrix):
                 self._inv_cov[min((fi, fj), (fj, fi))] = row[j]
 
         return self
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()

--- a/river/covariance/emp.py
+++ b/river/covariance/emp.py
@@ -109,15 +109,15 @@ class EmpiricalCovariance(SymmetricMatrix):
     Var: 0.076119
 
     Start from a state:
-    n = 8
-    mean = {'red': 0.416, 'green': 0.387, 'blue': 0.518}
-    cov_ = {('red', 'red'): 0.079,
+    >>> n = 8
+    >>> mean = {'red': 0.416, 'green': 0.387, 'blue': 0.518}
+    >>> cov_ = {('red', 'red'): 0.079,
     ...     ('red', 'green'): -0.053,
     ...     ('red', 'blue'): -0.010,
     ...     ('green', 'green'): 0.113,
     ...     ('green', 'blue'): 0.020,
     ...     ('blue', 'blue'): 0.076}
-    cov = covariance.EmpiricalCovariance._from_state(
+    >>> cov = covariance.EmpiricalCovariance._from_state(
     ...    n=n, mean=mean, cov=cov_, ddof=1)
     >>> cov
             blue     green    red
@@ -211,15 +211,15 @@ class EmpiricalCovariance(SymmetricMatrix):
 
         Parameters
         ----------
-        cls (type)
+        cls
             The class type.
-        n (int)
+        n
             The number of data points.
-        mean (dict)
+        mean
             A dictionary of variable means.
-        cov (dict)
+        cov
             A dictionary of covariance or variance values.
-        ddof (int, optional)
+        ddof
             Degrees of freedom for covariance calculation. Defaults to 1.
 
         Returns
@@ -231,7 +231,7 @@ class EmpiricalCovariance(SymmetricMatrix):
             KeyError: If an element in `mean` or `cov` is missing.
         """
         new = cls(ddof=ddof)
-        for i, j in itertools.combinations(sorted(mean.keys()), r=2):
+        for i, j in itertools.combinations(mean.keys(), r=2):
             try:
                 new[i, j]
             except KeyError:
@@ -244,7 +244,7 @@ class EmpiricalCovariance(SymmetricMatrix):
                 ddof=new.ddof,
             )
 
-        for i in sorted(mean.keys()):
+        for i in mean.keys():
             try:
                 new[i, i]
             except KeyError:

--- a/river/covariance/emp.py
+++ b/river/covariance/emp.py
@@ -384,8 +384,3 @@ class EmpiricalPrecision(SymmetricMatrix):
                 self._inv_cov[min((fi, fj), (fj, fi))] = row[j]
 
         return self
-
-if __name__ == "__main__":
-    import doctest
-
-    doctest.testmod()

--- a/river/proba/gaussian.py
+++ b/river/proba/gaussian.py
@@ -215,7 +215,11 @@ class MultivariateGaussian(base.MultivariateContinuousDistribution):
         super().__init__(seed)
         self._var = covariance.EmpiricalCovariance(ddof=1)
 
-    # TODO: add method _from_state to initialize model (for warm starting)
+    @classmethod
+    def _from_state(cls, n, mean, cov, ddof):
+        new = cls()
+        new._var = covariance.EmpiricalCovariance._from_state(n, mean, cov, ddof=ddof)
+        return new
 
     @property
     def n_samples(self) -> float:

--- a/river/proba/gaussian.py
+++ b/river/proba/gaussian.py
@@ -215,8 +215,8 @@ class MultivariateGaussian(base.MultivariateContinuousDistribution):
         self._var = covariance.EmpiricalCovariance(ddof=1)
 
     @classmethod
-    def _from_state(cls, n, mean, cov, ddof):
-        new = cls()
+    def _from_state(cls, n, mean, cov, ddof, seed=None):
+        new = cls(seed)
         new._var = covariance.EmpiricalCovariance._from_state(n, mean, cov, ddof=ddof)
         return new
 


### PR DESCRIPTION
Hey there 👋

I was thinking about adding _from_state method to [MultivariateGaussian](https://github.com/online-ml/river/commit/e767f26692ac8bf4cae9d38bfacfa97080cf5f49) and [EmpiricalCovariance](https://github.com/online-ml/river/commit/be0b3257b579dc7401608d5dda1106e1bdf92cc2). 

I believe it might aid the versatility of the classes usage. Nevertheless, I must admit that it might be little tricky for some users to retrieve covariance as dictionary of correct form.

Here is a pull request with proposed changes! (Did not open discussion as I considered this quite minor, sorry for inconvenience)

Please let me know what you think.

Thank you 🙏

