### PR TITLE
DBSTREAM fix (related to issue #1324)

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -6,6 +6,14 @@ River's mini-batch methods now support pandas v2. In particular, River conforms 
 
 - Added `anomaly.LocalOutlierFactor`, which is an online version of the LOF algorithm for anomaly detection that matches the scikit-learn implementation.
 
+## clustering
+
+- Add fixes to `cluster.DBSTREAM` algorithm, including:
+  - Addition of the `-` sign before the `fading_factor` in accordance with the algorithm 2 proposed by Hashler and Bolanos (2016) to allow clusters with low weights to be removed. 
+  - The new `micro_cluster` is added with the key derived from the maximum key of the existing micro clusters. If the set of micro clusters is still empty (`len = 0`), a new micro cluster is added with key 0. 
+  - `cluster_is_up_to_date` is set to `True` at the end of the `self._recluster()` function.
+
+
 ## datasets
 
 - Added `datasets.WebTraffic`, which is a dataset that counts the occurrences of events on a website. It is a multi-output regression dataset with two outputs.

--- a/river/cluster/dbstream.py
+++ b/river/cluster/dbstream.py
@@ -253,7 +253,9 @@ class DBSTREAM(base.Clusterer):
         micro_clusters = copy.deepcopy(self._micro_clusters)
         for i, micro_cluster_i in self._micro_clusters.items():
             try:
-                value = 2 ** (self.fading_factor * (self._time_stamp - micro_cluster_i.last_update))
+                value = 2 ** (
+                    -self.fading_factor * (self._time_stamp - micro_cluster_i.last_update)
+                )
             except OverflowError:
                 continue
 
@@ -266,7 +268,7 @@ class DBSTREAM(base.Clusterer):
         for i in self.s.keys():
             for j in self.s[i].keys():
                 try:
-                    value = 2 ** (self.fading_factor * (self._time_stamp - self.s_t[i][j]))
+                    value = 2 ** (-self.fading_factor * (self._time_stamp - self.s_t[i][j]))
                 except OverflowError:
                     continue
 

--- a/river/cluster/dbstream.py
+++ b/river/cluster/dbstream.py
@@ -182,9 +182,14 @@ class DBSTREAM(base.Clusterer):
 
         if len(neighbor_clusters) < 1:
             # create new micro cluster
-            self._micro_clusters[len(self._micro_clusters)] = DBSTREAMMicroCluster(
-                x=x, last_update=self._time_stamp, weight=1
-            )
+            if len(self._micro_clusters) > 0:
+                self._micro_clusters[max(self._micro_clusters.keys()) + 1] = DBSTREAMMicroCluster(
+                    x=x, last_update=self._time_stamp, weight=1
+                )
+            else:
+                self._micro_clusters[0] = DBSTREAMMicroCluster(
+                    x=x, last_update=self._time_stamp, weight=1
+                )
         else:
             # update existing micro clusters
             current_centers = {}

--- a/river/cluster/dbstream.py
+++ b/river/cluster/dbstream.py
@@ -377,6 +377,8 @@ class DBSTREAM(base.Clusterer):
             self._n_clusters, self._clusters = self._generate_clusters_from_labels(labels)
             self._centers = {i: self._clusters[i].center for i in self._clusters.keys()}
 
+        self.clustering_is_up_to_date = True
+
     def learn_one(self, x, sample_weight=None):
         self._update(x)
 


### PR DESCRIPTION
This PR fixes multiple issues proposed in issue #1324 by @donny741, with the following changes:
- Addition of the `-` sign before the `fading_factor` in accordance with the algorithm 2 proposed by Hashler and Bolanos to allow clusters with low weights to be removed.
- The new `micro_cluster` is added with the key derived from the maximum key of the existing micro clusters. If the set of micro clusters is still empty (`len = 0`), a new micro cluster is added with key `0`.
- `cluster_is_up_to_date` is set to `True` at the end of the `self._recluster()` function.