### PR TITLE
Fixes #1248

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -11,10 +11,9 @@ River's mini-batch methods now support pandas v2. In particular, River conforms 
 ## clustering
 
 - Add fixes to `cluster.DBSTREAM` algorithm, including:
-  - Addition of the `-` sign before the `fading_factor` in accordance with the algorithm 2 proposed by Hashler and Bolanos (2016) to allow clusters with low weights to be removed. 
-  - The new `micro_cluster` is added with the key derived from the maximum key of the existing micro clusters. If the set of micro clusters is still empty (`len = 0`), a new micro cluster is added with key 0. 
+  - Addition of the `-` sign before the `fading_factor` in accordance with the algorithm 2 proposed by Hashler and Bolanos (2016) to allow clusters with low weights to be removed.
+  - The new `micro_cluster` is added with the key derived from the maximum key of the existing micro clusters. If the set of micro clusters is still empty (`len = 0`), a new micro cluster is added with key 0.
   - `cluster_is_up_to_date` is set to `True` at the end of the `self._recluster()` function.
-
 
 ## datasets
 
@@ -31,3 +30,7 @@ River's mini-batch methods now support pandas v2. In particular, River conforms 
 ## proba
 
 - Added `_from_state` method to `proba.MultivariateGaussian` to warm start from previous knowledge.
+
+## tree
+
+- Fix a bug in `tree.splitter.NominalSplitterClassif` that generated a mismatch between the number of existing tree branches and the number of tracked branches.

--- a/river/ensemble/streaming_random_patches.py
+++ b/river/ensemble/streaming_random_patches.py
@@ -409,7 +409,7 @@ class SRPClassifier(BaseSRPEnsemble, base.Classifier):
     >>> metric = metrics.Accuracy()
 
     >>> evaluate.progressive_val_score(dataset, model, metric)
-    Accuracy: 72.77%
+    Accuracy: 71.97%
 
     Notes
     -----

--- a/river/tree/extremely_fast_decision_tree.py
+++ b/river/tree/extremely_fast_decision_tree.py
@@ -432,7 +432,7 @@ class ExtremelyFastDecisionTreeClassifier(HoeffdingTreeClassifier):
 
                     # update EFDT
                     if parent is None:
-                        # Root case : replace the root node by a new split node
+                        # Root case : replace the root node by the new node
                         self._root = best_split
                     else:
                         parent.children[branch_index] = best_split


### PR DESCRIPTION
<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->

This was a rather cryptic bug that was really difficult to track down.

Thank you @FedericoMz for providing the reproducible example, I would never find the culprit without that.

In the end, the problem was not in EFDT but in the splitter used in nominal attributes. It previously used `collection.defaultdict` objects in an attempt to simplify and speed up the code. 

However, during prediction actions (such as `predict_proba_one` and `debug_one`) if the `collection.defaultdict` in the splitter was checked for the existence of a previously non-observed branch, the missing value would be inadvertently created.

This created a mismatch between the number of existing and tracked tree branches.

This bug could potentially affect other trees, but was really hard to come by.


