### PR TITLE
DBSTREAM: fix density graph timestamps

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -14,6 +14,7 @@ River's mini-batch methods now support pandas v2. In particular, River conforms 
   - Addition of the `-` sign before the `fading_factor` in accordance with the algorithm 2 proposed by Hashler and Bolanos (2016) to allow clusters with low weights to be removed.
   - The new `micro_cluster` is added with the key derived from the maximum key of the existing micro clusters. If the set of micro clusters is still empty (`len = 0`), a new micro cluster is added with key 0.
   - `cluster_is_up_to_date` is set to `True` at the end of the `self._recluster()` function.
+  - shared density graph update timestamps are initialized with the current timestamp value
 
 ## datasets
 

--- a/river/cluster/dbstream.py
+++ b/river/cluster/dbstream.py
@@ -228,10 +228,10 @@ class DBSTREAM(base.Clusterer):
                         except KeyError:
                             try:
                                 self.s[i][j] = 0
-                                self.s_t[i][j] = 0
+                                self.s_t[i][j] = self._time_stamp
                             except KeyError:
                                 self.s[i] = {j: 0}
-                                self.s_t[i] = {j: 0}
+                                self.s_t[i] = {j: self._time_stamp}
 
             # prevent collapsing clusters
             for i in neighbor_clusters.keys():


### PR DESCRIPTION
When the timestamp is set to 0 it may result in the immediate removal of the density graph entry because during cleanup 0 will be used as a current timestamp and the fading value will be incorrect ([here](https://github.com/online-ml/river/blob/main/river/cluster/dbstream.py#L276))