### PR TITLE
dbstream: fix adjacency matrix building

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -16,7 +16,7 @@ River's mini-batch methods now support pandas v2. In particular, River conforms 
   - `cluster_is_up_to_date` is set to `True` at the end of the `self._recluster()` function.
   - Shared density graph update timestamps are initialized with the current timestamp value
   - `neighbour_neighbours` are appended correctly to the `seed_set` when generating cluster labels
-  - When building weighted adjacency matrix the alhorithm accounts for possibly orphaned entries in shared density graph
+  - When building weighted adjacency matrix the algorithm accounts for possibly orphaned entries in shared density graph
 
 ## datasets
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -16,6 +16,7 @@ River's mini-batch methods now support pandas v2. In particular, River conforms 
   - `cluster_is_up_to_date` is set to `True` at the end of the `self._recluster()` function.
   - Shared density graph update timestamps are initialized with the current timestamp value
   - `neighbour_neighbours` are appended correctly to the `seed_set` when generating cluster labels
+  - When building weighted adjacency matrix the alhorithm accounts for possibly orphaned entries in shared density graph
 
 ## datasets
 

--- a/river/cluster/dbstream.py
+++ b/river/cluster/dbstream.py
@@ -287,18 +287,23 @@ class DBSTREAM(base.Clusterer):
         weighted_adjacency_matrix = {}
         for i in list(self.s.keys()):
             for j in list(self.s[i].keys()):
-                if (
-                    self._micro_clusters[i].weight >= self.minimum_weight
-                    and self._micro_clusters[j].weight >= self.minimum_weight
-                ):
-                    value = self.s[i][j] / (
-                        (self._micro_clusters[i].weight + self._micro_clusters[j].weight) / 2
-                    )
-                    if value > self.intersection_factor:
-                        try:
-                            weighted_adjacency_matrix[i][j] = value
-                        except KeyError:
-                            weighted_adjacency_matrix[i] = {j: value}
+                try:
+                    if (
+                        self._micro_clusters[i].weight <= self.minimum_weight
+                        or self._micro_clusters[j].weight <= self.minimum_weight
+                    ):
+                        continue
+                except KeyError:
+                    continue
+
+                value = self.s[i][j] / (
+                    (self._micro_clusters[i].weight + self._micro_clusters[j].weight) / 2
+                )
+                if value > self.intersection_factor:
+                    try:
+                        weighted_adjacency_matrix[i][j] = value
+                    except KeyError:
+                        weighted_adjacency_matrix[i] = {j: value}
 
         return weighted_adjacency_matrix
 


### PR DESCRIPTION
It is possible for the microcluster (`mc`) to be removed, but for the shared density graph entry (`Sij`) associated with that microcluster to remain because:
- The threshold for removing `Sij` is `α` (a.k.a. `intersection_factor`) times lower than the threshold for removing a `mc`;
- and no mechanism would ensure the removal of associated `Sij` when `mc` is removed.

This introduces a `KeyError` during the `weighted_adjacency_matrix` building step when looking up removed `mc`. Adding a `try` block to account for that