### PR TITLE
Add the NoDrift dummy drift detector

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -8,6 +8,10 @@ River's mini-batch methods now support pandas v2. In particular, River conforms 
   - Made `score_one` method of `anomaly.LocalOutlierFactor` stateless
   - Defined default score for uninitialized detector
 
+## covariance
+
+- Added `_from_state` method to `covariance.EmpiricalCovariance` to warm start from previous knowledge.
+
 ## clustering
 
 - Add fixes to `cluster.DBSTREAM` algorithm, including:
@@ -22,13 +26,13 @@ River's mini-batch methods now support pandas v2. In particular, River conforms 
 
 - Added `datasets.WebTraffic`, which is a dataset that counts the occurrences of events on a website. It is a multi-output regression dataset with two outputs.
 
+## drift
+
+- Add `drift.NoDrift` to allow disabling the drift detection capabilities of models. This detector does nothing and always returns `False` when queried whether or not a concept drift was detected.
+
 ## forest
 
 - Simplify inner the structures of `forest.ARFClassifier` and `forest.ARFRegressor` by removing redundant class hierarchy. Simplify how concept drift logging can be accessed in individual trees and in the forest as a whole.
-
-## covariance
-
-- Added `_from_state` method to `covariance.EmpiricalCovariance` to warm start from previous knowledge.
 
 ## proba
 

--- a/river/drift/__init__.py
+++ b/river/drift/__init__.py
@@ -12,6 +12,7 @@ from . import binary, datasets
 from .adwin import ADWIN
 from .dummy import DummyDriftDetector
 from .kswin import KSWIN
+from .no_drift import NoDrift
 from .page_hinkley import PageHinkley
 from .retrain import DriftRetrainingClassifier
 
@@ -22,6 +23,7 @@ __all__ = [
     "DriftRetrainingClassifier",
     "DummyDriftDetector",
     "KSWIN",
+    "NoDrift",
     "PageHinkley",
     "PeriodicTrigger",
 ]

--- a/river/drift/no_drift.py
+++ b/river/drift/no_drift.py
@@ -20,7 +20,7 @@ class NoDrift(base.DriftDetector):
     >>> from river.datasets import synth
 
     >>> dataset = synth.ConceptDriftStream(
-    ...     seed=93,
+    ...     seed=8,
     ...     position=500,
     ...     width=40,
     ... )
@@ -37,10 +37,10 @@ class NoDrift(base.DriftDetector):
     >>> metric = metrics.Accuracy()
 
     >>> evaluate.progressive_val_score(dataset.take(700), model, metric)
-    Accuracy: 69.96%
+    Accuracy: 76.25%
 
     >>> model.n_drifts_detected()
-    1
+    2
 
     >>> model.n_warnings_detected()
     0
@@ -56,7 +56,7 @@ class NoDrift(base.DriftDetector):
     >>> metric = metrics.Accuracy()
 
     >>> evaluate.progressive_val_score(dataset.take(700), stationary_model, metric)
-    Accuracy: 71.10%
+    Accuracy: 76.25%
 
     >>> stationary_model.n_drifts_detected()
     0

--- a/river/drift/no_drift.py
+++ b/river/drift/no_drift.py
@@ -7,8 +7,6 @@ from river.base.drift_detector import DriftDetector
 class NoDrift(base.DriftDetector):
     """Dummy class used to turn off concept drift detection capabilities of adaptive models.
     It always signals that no concept drift was detected.
-
-
     Examples
     --------
     

--- a/river/drift/no_drift.py
+++ b/river/drift/no_drift.py
@@ -6,8 +6,6 @@ from river.base.drift_detector import DriftDetector
 
 class NoDrift(base.DriftDetector):
     """Dummy class used to turn off concept drift detection capabilities of adaptive models.
-
-
     It always signals that no concept drift was detected.
 
 

--- a/river/drift/no_drift.py
+++ b/river/drift/no_drift.py
@@ -1,0 +1,75 @@
+from river import base
+from river.base.drift_detector import DriftDetector
+
+
+class NoDrift(base.DriftDetector):
+    """Dummy class used to turn off concept drift detection capabilities of adaptive models.
+
+
+    It always signals that no concept drift was detected.
+
+
+    Examples
+    --------
+    >>> from river import drift
+    >>> from river import evaluate
+    >>> from river import forest
+    >>> from river import metrics
+    >>> from river.datasets import synth
+
+    >>> dataset = synth.ConceptDriftStream(
+    ...     seed=93,
+    ...     position=500,
+    ...     width=40,
+    ... )
+
+    We can turn off the warning detection capabilities of Adaptive Random Forest (ARF) or
+    other similar models. Thus, the base models will reset immediately after identifying a drift,
+    bypassing the background model building phase:
+
+    >>> model = forest.ARFClassifier(
+    ...     leaf_prediction="mc",
+    ...     warning_detector=drift.NoDrift(),
+    ...     seed=8
+    ... )
+    >>> metric = metrics.Accuracy()
+
+    >>> evaluate.progressive_val_score(dataset.take(700), model, metric)
+    Accuracy: 69.96%
+
+    >>> model.n_drifts_detected()
+    1
+
+    >>> model.n_warnings_detected()
+    0
+
+    We can also turn off the concept drift handling capabilities completely:
+
+    >>> stationary_model = forest.ARFClassifier(
+    ...     leaf_prediction="mc",
+    ...     warning_detector=drift.NoDrift(),
+    ...     drift_detector=drift.NoDrift(),
+    ...     seed=8
+    ... )
+    >>> metric = metrics.Accuracy()
+
+    >>> evaluate.progressive_val_score(dataset.take(700), stationary_model, metric)
+    Accuracy: 71.10%
+
+    >>> stationary_model.n_drifts_detected()
+    0
+
+    >>> stationary_model.n_warnings_detected()
+    0
+
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def update(self, x: int | float) -> DriftDetector:
+        return self
+
+    @property
+    def drift_detected(self):
+        return False

--- a/river/drift/no_drift.py
+++ b/river/drift/no_drift.py
@@ -11,6 +11,7 @@ class NoDrift(base.DriftDetector):
 
     Examples
     --------
+    
     >>> from river import drift
     >>> from river import evaluate
     >>> from river import forest

--- a/river/drift/no_drift.py
+++ b/river/drift/no_drift.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from river import base
 from river.base.drift_detector import DriftDetector
 

--- a/river/drift/no_drift.py
+++ b/river/drift/no_drift.py
@@ -9,7 +9,7 @@ class NoDrift(base.DriftDetector):
     It always signals that no concept drift was detected.
     Examples
     --------
-    
+
     >>> from river import drift
     >>> from river import evaluate
     >>> from river import forest
@@ -20,27 +20,17 @@ class NoDrift(base.DriftDetector):
     ...     seed=8,
     ...     position=500,
     ...     width=40,
-    ... )
+    ... ).take(700)
 
     We can turn off the warning detection capabilities of Adaptive Random Forest (ARF) or
     other similar models. Thus, the base models will reset immediately after identifying a drift,
     bypassing the background model building phase:
 
-    >>> model = forest.ARFClassifier(
+    >>> adaptive_model = forest.ARFClassifier(
     ...     leaf_prediction="mc",
     ...     warning_detector=drift.NoDrift(),
     ...     seed=8
     ... )
-    >>> metric = metrics.Accuracy()
-
-    >>> evaluate.progressive_val_score(dataset.take(700), model, metric)
-    Accuracy: 76.25%
-
-    >>> model.n_drifts_detected()
-    2
-
-    >>> model.n_warnings_detected()
-    0
 
     We can also turn off the concept drift handling capabilities completely:
 
@@ -50,10 +40,22 @@ class NoDrift(base.DriftDetector):
     ...     drift_detector=drift.NoDrift(),
     ...     seed=8
     ... )
-    >>> metric = metrics.Accuracy()
 
-    >>> evaluate.progressive_val_score(dataset.take(700), stationary_model, metric)
-    Accuracy: 76.25%
+    Let's put that to test:
+
+    >>> for x, y in dataset:
+    ...     adaptive_model = adaptive_model.learn_one(x, y)
+    ...     stationary_model = stationary_model.learn_one(x, y)
+
+    The adaptive model:
+
+    >>> adaptive_model.n_drifts_detected()
+    2
+
+    >>> adaptive_model.n_warnings_detected()
+    0
+
+    The stationary one:
 
     >>> stationary_model.n_drifts_detected()
     0


### PR DESCRIPTION
<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->

This PR addresses #1332 by adding the `drift.NoDrift` class. This detector does nothing and can be used to bypass the concept drift handling capabilities in ARF.
