### PR TITLE
Add license to riverml.xyz

### DIFF
--- a/docs/.pages
+++ b/docs/.pages
@@ -6,3 +6,4 @@ nav:
   - faq
   - releases
   - benchmarks
+  - license

--- a/docs/license/.pages
+++ b/docs/license/.pages
@@ -1,0 +1,2 @@
+title: License 📝
+

--- a/docs/license/license.md
+++ b/docs/license/license.md
@@ -1,0 +1,3 @@
+# License
+
+River is free and open-source software licensed under the [3-clause BSD license](https://github.com/online-ml/river/blob/main/LICENSE).


### PR DESCRIPTION
This PR adds a license tab to the River docs. By clearly displaying that River is under the 3-clause BSD license visitors will be able to quickly understand River's licensing terms. 
