### PR TITLE
docs: pin mathjax minor version

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,7 +86,7 @@ plugins:
 extra_javascript:
   - javascripts/config.js
   - https://polyfill.io/v3/polyfill.min.js?features=es6
-  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+  - https://cdn.jsdelivr.net/npm/mathjax@3.2/es5/tex-mml-chtml.js
   - https://cdn.jsdelivr.net/npm/vega@5
   - https://cdn.jsdelivr.net/npm/vega-lite@5
   - https://cdn.jsdelivr.net/npm/vega-embed@6


### PR DESCRIPTION
# Description

As I was going through the documentation I noticed something was off in the rendering of the [getting-started/concept-drift-detection](https://riverml.xyz/latest/introduction/getting-started/concept-drift-detection) section.

By opening the source code it was clear that latex is not rendering properly.
The issue gets fixed by pinning the minor version of mathjax.

## Rendering

- **Live** and local with https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js

    ![image](https://github.com/online-ml/river/assets/42817048/0b43eca5-7149-4989-a43c-3abf89031873)

- Local with https://cdn.jsdelivr.net/npm/mathjax@3.2/es5/tex-mml-chtml.js

    ![image](https://github.com/online-ml/river/assets/42817048/05c363c1-e1a0-44c5-9123-6e1af8494429)
