### PR TITLE
Fix a Rust panic in the tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ path = "rust_src/lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.16.5", features = ["extension-module"] }
+pyo3 = { version = "0.18.3", features = ["extension-module"] }
 watermill = "0.1.1"
 bincode = "1.3.3"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->

Following #1563, PyO3 is upgraded to resolve a crash in the test suite that appeared after Rust 1.78 was released.
