### PR TITLE
Fixed `AttributeError` in metrics/roc_auc.py.

### DIFF
--- a/river/metrics/roc_auc.py
+++ b/river/metrics/roc_auc.py
@@ -100,4 +100,10 @@ class ROCAUC(metrics.base.BinaryMetric):
             tprs[i] = safe_div(a=tp, b=tp + fn)
             fprs[i] = safe_div(a=fp, b=fp + tn)
 
-        return -integrate.trapz(x=fprs, y=tprs)
+        trapezoid = (
+            integrate.trapz  # For older/outdated versions of SciPy.
+            if hasattr(integrate, "trapz")
+            else integrate.trapezoid
+        )
+
+        return -trapezoid(x=fprs, y=tprs)

--- a/river/metrics/roc_auc.py
+++ b/river/metrics/roc_auc.py
@@ -100,10 +100,4 @@ class ROCAUC(metrics.base.BinaryMetric):
             tprs[i] = safe_div(a=tp, b=tp + fn)
             fprs[i] = safe_div(a=fp, b=fp + tn)
 
-        trapezoid = (
-            integrate.trapz  # For older/outdated versions of SciPy.
-            if hasattr(integrate, "trapz")
-            else integrate.trapezoid
-        )
-
-        return -trapezoid(x=fprs, y=tprs)
+        return -integrate.trapezoid(x=fprs, y=tprs)


### PR DESCRIPTION
SciPy deprecated `scipy.integrate.trapz` long ago and it had instead
been renamed to `scipy.integrate.trapezoid`. The `ROCAUC()` class uses
the former instead of the latter (causing an `AttributeError`), with
the latter being included from the start of SciPy version 1.6.0 (start
of 2021). This is a small fix: I've added a simple `hasattr()` check for 
compatibility with versions that still have `scipy.integrate.trapz` and
to use it if it's there over `scipy.integrate.trapezoid`, but it might be
unnecessary, since those versions are outdated.

https://docs.scipy.org/doc/scipy/release/1.6.0-notes.html#scipy-integrate-improvements