### PR TITLE
Remove mention of former compat modules

### DIFF
--- a/river/conftest.py
+++ b/river/conftest.py
@@ -5,7 +5,6 @@ collect_ignore = []
 try:
     import sklearn  # noqa: F401
 except ImportError:
-    collect_ignore.append("compat/sklearn.py")
     collect_ignore.append("compat/test_sklearn.py")
 
 try:
@@ -13,11 +12,6 @@ try:
 except ImportError:
     collect_ignore.append("stream/iter_sql.py")
     collect_ignore.append("stream/test_sql.py")
-
-try:
-    import torch  # noqa: F401
-except ImportError:
-    collect_ignore.append("compat/pytorch.py")
 
 try:
     import vaex  # noqa: F401

--- a/river/test_estimators.py
+++ b/river/test_estimators.py
@@ -5,6 +5,7 @@ import importlib
 import inspect
 
 import pytest
+from sklearn import linear_model as sk_linear_model
 
 from river import (
     anomaly,
@@ -24,9 +25,6 @@ from river import (
     preprocessing,
     time_series,
 )
-
-from sklearn import linear_model as sk_linear_model
-
 from river.compat.river_to_sklearn import River2SKLBase
 from river.compat.sklearn_to_river import SKL2RiverBase
 

--- a/river/test_estimators.py
+++ b/river/test_estimators.py
@@ -25,12 +25,6 @@ from river import (
     time_series,
 )
 
-try:
-    from river.compat.pytorch import PyTorch2RiverBase
-
-    PYTORCH_INSTALLED = True
-except ImportError:
-    PYTORCH_INSTALLED = False
 from sklearn import linear_model as sk_linear_model
 
 from river.compat.river_to_sklearn import River2SKLBase
@@ -83,9 +77,6 @@ def iter_estimators_which_can_be_tested():
         preprocessing.StatImputer,
         time_series.base.Forecaster,
     )
-
-    if PYTORCH_INSTALLED:
-        ignored = (*ignored, PyTorch2RiverBase)
 
     def can_be_tested(estimator):
         return not inspect.isabstract(estimator) and not issubclass(estimator, ignored)


### PR DESCRIPTION
<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->
There were still lingering references to deleted modules from `river/compat`.

Closes #1587
