### PR TITLE
Remove script download from polyfill.io

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,7 +85,6 @@ plugins:
 
 extra_javascript:
   - javascripts/config.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3.2/es5/tex-mml-chtml.js
   - https://cdn.jsdelivr.net/npm/vega@5
   - https://cdn.jsdelivr.net/npm/vega-lite@5


### PR DESCRIPTION
The domain polyfill.io was taken over by a malicious actor to download malware.
Polyfill is not needed for modern browsers.

It is recommended to remove references to the website.

Closes: #1589
