### PR TITLE
New MyPy configuration for per-module type completeness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ required-imports = ["from __future__ import annotations"]
 
 [tool.mypy]
 files = "river"
+strict = true
 
 [[tool.mypy.overrides]]
 module = [
@@ -144,3 +145,63 @@ module = [
     "requests.*"
 ]
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# Disable strict mode for all non fully-typed modules
+module = [
+    "river.base.*",
+    "river.metrics.*",
+    "river.utils.*",
+    "river.stats.*",
+    "river.optim.*",
+    "river.datasets.*",
+    "river.tree.*",
+    "river.preprocessing.*",
+    "river.stream.*",
+    "river.linear_model.*",
+    "river.evaluate.*",
+    "river.drift.*",
+    "river.compose.*",
+    "river.bandit.*",
+    "river.cluster.*",
+    "river.anomaly.*",
+    "river.time_series.*",
+    "river.feature_extraction.*",
+    "river.ensemble.*",
+    "river.proba.*",
+    "river.multioutput.*",
+    "river.naive_bayes.*",
+    "river.checks.*",
+    "river.rules.*",
+    "river.model_selection.*",
+    "river.forest.*",
+    "river.neighbors.*",
+    "river.sketch.*",
+    "river.facto.*",
+    "river.covariance.*",
+    "river.compat.*",
+    "river.multiclass.*",
+    "river.reco.*",
+    "river.imblearn.*",
+    "river.feature_selection.*",
+    "river.misc.*",
+    "river.active.*",
+    "river.conf.*",
+    "river.neural_net.*",
+    "river.test_estimators",
+    "river.dummy",
+]
+# The strict option is global, the checks must be disabled one by one
+warn_unused_ignores = false
+strict_equality = false
+strict_concatenate = false
+check_untyped_defs = false
+allow_subclassing_any = true
+allow_untyped_decorators = true
+allow_any_generics = true
+allow_untyped_calls = true
+allow_incomplete_defs = true
+allow_untyped_defs = true
+implicit_reexport = true
+warn_return_any = false
+extra_checks = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,15 +193,11 @@ module = [
 ]
 # The strict option is global, the checks must be disabled one by one
 warn_unused_ignores = false
-strict_equality = false
-strict_concatenate = false
 check_untyped_defs = false
 allow_subclassing_any = true
-allow_untyped_decorators = true
 allow_any_generics = true
 allow_untyped_calls = true
 allow_incomplete_defs = true
 allow_untyped_defs = true
 implicit_reexport = true
 warn_return_any = false
-extra_checks = false

--- a/river/bandit/envs/__init__.py
+++ b/river/bandit/envs/__init__.py
@@ -15,13 +15,13 @@ if GYM_INSTALLED:
 
     RIVER_NAMESPACE = "river_bandits"
 
-    if (env_id := f"{RIVER_NAMESPACE}/CandyCaneContest-v0") not in gym.envs.registry:
+    if (env_id := f"{RIVER_NAMESPACE}/CandyCaneContest-v0") not in gym.envs.registration.registry:
         gym.envs.registration.register(
             id=env_id,
             entry_point="river.bandit.envs:CandyCaneContest",
             max_episode_steps=CandyCaneContest.n_steps,
         )
-    if (env_id := f"{RIVER_NAMESPACE}/KArmedTestbed-v0") not in gym.envs.registry:
+    if (env_id := f"{RIVER_NAMESPACE}/KArmedTestbed-v0") not in gym.envs.registration.registry:
         gym.envs.registration.register(
             id=env_id,
             entry_point="river.bandit.envs:KArmedTestbed",


### PR DESCRIPTION
As discussed in #1592, this PR enables MyPy's strict mode by default for the repository.
Since none of the modules are fully annotated yet, they have an override to disable the extra rules.

Because MyPy has [a configuration bug](https://github.com/python/mypy/issues/11401), the settings enabled by the strict mode need to be disabled individually.

Only the options that raised new errors are disabled in the override : this means that MyPy will now perform more checks over the code.