### PR TITLE
Feature/expected categories

### DIFF
--- a/river/preprocessing/one_hot.py
+++ b/river/preprocessing/one_hot.py
@@ -89,15 +89,6 @@ class OneHotEncoder(base.MiniBatchTransformer):
     This is handy when you want to constrain category encoding space
     to e.g. top 20% most popular category values you've picked in advance.
 
-    X = [
-        {
-            'c1': random.choice(alphabet),
-            'c2': random.choice(alphabet),
-        }
-        for _ in range(4)
-    ]
-    pprint(X)
-
     >>> categories = {'c1': {'a', 'h'}, 'c2': {'x', 'e'}}
     >>> oh = preprocessing.OneHotEncoder(categories=categories)
     >>> # oh = preprocessing.OneHotEncoder()
@@ -116,13 +107,6 @@ class OneHotEncoder(base.MiniBatchTransformer):
     ['a', 'h']
     c2
     ['e', 'x']
-
-
-    oh.values.items()
-    [{'c1': {'a', 'h'}, 'c2': {'e', 'x'}}]
-    [{'c1': {'a', 'h'}, 'c2': {'e', 'x'}}]
-
-    {'c1': {'a', 'h', 'i', 'u'}, 'c2': {'d', 'e', 'h', 'x'}}
 
     A subset of the features can be one-hot encoded by piping a `compose.Select` into the
     `OneHotEncoder`.
@@ -243,19 +227,9 @@ class OneHotEncoder(base.MiniBatchTransformer):
     0     0     0     0     0
     1     1     0     0     1
     2     0     0     0     0
-
-    #     c1_a  c1_i  c1_u  c2_d  c2_h  c2_x
-    # 0     0     0     1     1     0     0
-    # 1     1     0     0     0     0     1
-    # 2     0     1     0     0     1     0
-
-        c1_a  c1_h  c2_e  c2_x
-    0     0     0     0     0
-    1     1     0     0     1
-    2     0     0     0     0
     """
 
-    def __init__(self, categories: str | dict = "auto", drop_zeros=False, drop_first=False):
+    def __init__(self, categories = "auto", drop_zeros=False, drop_first=False):
         self.drop_zeros = drop_zeros
         self.drop_first = drop_first
         self.categories = categories

--- a/river/preprocessing/one_hot.py
+++ b/river/preprocessing/one_hot.py
@@ -46,11 +46,11 @@ class OneHotEncoder(base.MiniBatchTransformer):
     ... ]
     >>> pprint(X)
     [{'c1': 'u', 'c2': 'd'},
-        {'c1': 'a', 'c2': 'x'},
-        {'c1': 'i', 'c2': 'h'},
-        {'c1': 'h', 'c2': 'e'}]
+     {'c1': 'a', 'c2': 'x'},
+     {'c1': 'i', 'c2': 'h'},
+     {'c1': 'h', 'c2': 'e'}]
 
-    e can now apply one-hot encoding. All the provided are one-hot encoded, there is therefore
+    We can now apply one-hot encoding. All the provided are one-hot encoded, there is therefore
     no need to specify which features to encode.
 
     >>> from river import preprocessing
@@ -84,6 +84,45 @@ class OneHotEncoder(base.MiniBatchTransformer):
     {'c2_x': 1}
     {'c2_h': 1}
     {'c2_e': 1}
+
+    Like in `scikit-learn`, you can also specify the expected categories manually.
+    This is handy when you want to constrain category encoding space
+    to e.g. top 20% most popular category values you've picked in advance.
+
+    X = [
+        {
+            'c1': random.choice(alphabet),
+            'c2': random.choice(alphabet),
+        }
+        for _ in range(4)
+    ]
+    pprint(X)
+
+    >>> categories = {'c1': {'a', 'h'}, 'c2': {'x', 'e'}}
+    >>> oh = preprocessing.OneHotEncoder(categories=categories)
+    >>> # oh = preprocessing.OneHotEncoder()
+    >>> for x in X:
+    ...     oh.learn_one(x)
+    ...     pprint(oh.transform_one(x))
+    {'c1_a': 0, 'c1_h': 0, 'c2_e': 0, 'c2_x': 0}
+    {'c1_a': 1, 'c1_h': 0, 'c2_e': 0, 'c2_x': 1}
+    {'c1_a': 0, 'c1_h': 0, 'c2_e': 0, 'c2_x': 0}
+    {'c1_a': 0, 'c1_h': 1, 'c2_e': 1, 'c2_x': 0}
+
+    >>> for key in sorted(oh.values.keys()):
+    ...     print(key)
+    ...     print(sorted(oh.values[key]))
+    c1
+    ['a', 'h']
+    c2
+    ['e', 'x']
+
+
+    oh.values.items()
+    [{'c1': {'a', 'h'}, 'c2': {'e', 'x'}}]
+    [{'c1': {'a', 'h'}, 'c2': {'e', 'x'}}]
+
+    {'c1': {'a', 'h', 'i', 'u'}, 'c2': {'d', 'e', 'h', 'x'}}
 
     A subset of the features can be one-hot encoded by piping a `compose.Select` into the
     `OneHotEncoder`.
@@ -192,23 +231,53 @@ class OneHotEncoder(base.MiniBatchTransformer):
     c2_x          Sparse[uint8, 0]
     dtype: object
 
+    Explicit categories:
+
+    >>> oh = preprocessing.OneHotEncoder(categories=categories)
+
+    # oh = preprocessing.OneHotEncoder()
+    >>> oh.learn_many(X)
+    >>> df = oh.transform_many(X)
+    >>> df.sort_index(axis="columns")
+       c1_a  c1_h  c2_e  c2_x
+    0     0     0     0     0
+    1     1     0     0     1
+    2     0     0     0     0
+
+    #     c1_a  c1_i  c1_u  c2_d  c2_h  c2_x
+    # 0     0     0     1     1     0     0
+    # 1     1     0     0     0     0     1
+    # 2     0     1     0     0     1     0
+
+        c1_a  c1_h  c2_e  c2_x
+    0     0     0     0     0
+    1     1     0     0     1
+    2     0     0     0     0
     """
 
-    def __init__(self, drop_zeros=False, drop_first=False):
+    def __init__(self, categories: str | dict = "auto", drop_zeros=False, drop_first=False):
         self.drop_zeros = drop_zeros
         self.drop_first = drop_first
-        self.values = collections.defaultdict(set)
+        self.categories = categories
+
+        if self.categories == "auto":
+            self.values = collections.defaultdict(set)
+        else:
+            self.values = self.categories
 
     def learn_one(self, x):
         if self.drop_zeros:
             return
 
-        for i, xi in x.items():
-            if isinstance(xi, list) or isinstance(xi, set):
-                for xj in xi:
-                    self.values[i].add(xj)
-            else:
-                self.values[i].add(xi)
+        # NOTE: assume if category mappings are explicitly provided,
+        # they're intended to be kept fixed.
+        if self.categories == "auto":
+            for i, xi in x.items():
+                if isinstance(xi, list) or isinstance(xi, set):
+                    for xj in xi:
+                        self.values[i].add(xj)
+                else:
+                    self.values[i].add(xi)
 
     def transform_one(self, x, y=None):
         oh = {}
@@ -217,13 +286,25 @@ class OneHotEncoder(base.MiniBatchTransformer):
         if not self.drop_zeros:
             oh = {f"{i}_{v}": 0 for i, values in self.values.items() for v in values}
 
-        # Add 1s
-        for i, xi in x.items():
-            if isinstance(xi, list) or isinstance(xi, set):
-                for xj in xi:
-                    oh[f"{i}_{xj}"] = 1
-            else:
-                oh[f"{i}_{xi}"] = 1
+        # Add 1
+        # NOTE: assume if category mappings are explicitly provided,
+        # no other category values are allowed for output. Aligns with `sklearn` behavior.
+        if self.categories == "auto":
+            for i, xi in x.items():
+                if isinstance(xi, list) or isinstance(xi, set):
+                    for xj in xi:
+                        oh[f"{i}_{xj}"] = 1
+                else:
+                    oh[f"{i}_{xi}"] = 1
+        else:
+            for i, xi in x.items():
+                if isinstance(xi, list) or isinstance(xi, set):
+                    for xj in xi:
+                        if xj in self.values[i]:
+                            oh[f"{i}_{xj}"] = 1
+                else:
+                    if xi in self.values[i]:
+                        oh[f"{i}_{xi}"] = 1
 
         if self.drop_first:
             oh.pop(min(oh.keys()))
@@ -234,11 +315,21 @@ class OneHotEncoder(base.MiniBatchTransformer):
         if self.drop_zeros:
             return
 
-        for col in X.columns:
-            self.values[col].update(X[col].unique())
+        # NOTE: assume if category mappings are explicitly provided,
+        # they're intended to be kept fixed.
+        if self.categories == "auto":
+            for col in X.columns:
+                self.values[col].update(X[col].unique())
 
     def transform_many(self, X):
         oh = pd.get_dummies(X, columns=X.columns, sparse=True, dtype="uint8")
+
+        # NOTE: assume if category mappings are explicitly provided,
+        # no other category values are allowed for output. Aligns with `sklearn` behavior.
+        if self.categories != "auto":
+            seen_in_the_past = {f"{col}_{val}" for col, vals in self.values.items() for val in vals}
+            to_remove = set(oh.columns) - seen_in_the_past
+            oh.drop(columns=list(to_remove), inplace=True)
 
         if not self.drop_zeros:
             seen_in_the_past = {f"{col}_{val}" for col, vals in self.values.items() for val in vals}

--- a/river/preprocessing/ordinal.py
+++ b/river/preprocessing/ordinal.py
@@ -82,7 +82,7 @@ class OrdinalEncoder(base.MiniBatchTransformer):
     {'country': 0, 'place': 3}
     {'country': 0, 'place': 0}
     {'country': -1, 'place': -1}
-    
+
     >>> import pandas as pd
     >>> xb1 = pd.DataFrame(X[0:4], index=[0, 1, 2, 3])
     >>> xb2 = pd.DataFrame(X[4:8], index=[4, 5, 6, 7])
@@ -107,13 +107,14 @@ class OrdinalEncoder(base.MiniBatchTransformer):
 
     def __init__(
         self,
-        categories: str | dict = "auto",
+        categories = "auto",
         unknown_value: int | None = 0,
         none_value: int = -1,
     ):
         self.unknown_value = unknown_value
         self.none_value = none_value
         self.categories = categories
+        self.values: collections.defaultdict | dict | None = None
 
         if self.categories == "auto":
             # We're going to have one auto-incrementing counter per feature. This counter will generate
@@ -124,9 +125,9 @@ class OrdinalEncoder(base.MiniBatchTransformer):
 
             # We're going to store the categories in a dict of dicts. The outer dict will map each
             # feature to its inner dict. The inner dict will map each category to its code.
-            self.values: collections.defaultdict = collections.defaultdict(dict)
+            self.values = collections.defaultdict(dict)
         else:
-            self.values: dict = self.categories 
+            self.values = self.categories
 
 
     def transform_one(self, x):


### PR DESCRIPTION
<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->

Add support for processing only explicitly expected categories for `preprocessing.OneHotEncoder`, `preprocessing.OrdinalEncoder`, akin to `sklearn` api for respective encoders.

All doctests pass (i've added some).

Rationale:
`sklearn` has this neat feature where you can explicitly pass category values you want to see in the encoder state, other values are filtered out. See `categories` parameter: [OneHotEncoder](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.OneHotEncoder.html), [OrdinalEncoder](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.OrdinalEncoder.html)

This is convenient when you work with high cardinality category spaces where some values are rare and you want to regularize your model. E.g. I've had a practical problem where constraining only to pre-selected top 20% frequent categories in 1 000 000 cardinality space can give you a 10%+ latency boost with no significant loss in metrics, and also make a model lighter on RAM.

This implementation is hackable so if user wants to modify lists of expected categories between training steps, they can do so by direct attribute access. E.g. can glue with modules like [TargetAgg](https://riverml.xyz/latest/api/feature-extraction/TargetAgg/) for some cool dynamic reevaluation of expected category lists. 


P.S. Pls bump Ruff, my LSP config compains coz api changes. Also MyPy complained a lot about about `str | dict | defaultdict` type hints for `category` parameter, I just had to give up on them, maybe someone has better ideas how to  handle them.