### PR TITLE
Fix tests warnings

### DIFF
--- a/river/bandit/bayes_ucb.py
+++ b/river/bandit/bayes_ucb.py
@@ -79,7 +79,7 @@ class BayesUCB(bandit.base.Policy):
         """the p-th quantile of the beta distribution for the arm"""
         p = 1 - 1 / (self._n + 1)
         posterior = self._posteriors[arm_id]
-        return scipy.special.btdtri(posterior.alpha, posterior.beta, p)
+        return scipy.special.betaincinv(posterior.alpha, posterior.beta, p)
 
     def update(self, arm_id, *reward_args, **reward_kwargs):
         """Rewrite update function"""

--- a/river/covariance/test_emp.py
+++ b/river/covariance/test_emp.py
@@ -95,7 +95,7 @@ def test_covariance_update_sampled():
 def test_covariance_update_many(ddof):
     cov = covariance.EmpiricalCovariance(ddof=ddof)
     p = 5
-    X_all = pd.DataFrame(columns=range(p))
+    X_all = None
 
     for _ in range(p):
         n = np.random.randint(1, 31)
@@ -123,7 +123,7 @@ def test_covariance_update_many(ddof):
 def test_covariance_update_many_shuffled(ddof):
     cov = covariance.EmpiricalCovariance(ddof=ddof)
     p = 5
-    X_all = pd.DataFrame(columns=range(p))
+    X_all = None
 
     for _ in range(p):
         n = np.random.randint(5, 31)
@@ -143,7 +143,7 @@ def test_covariance_update_many_sampled():
     ddof = 1
     cov = covariance.EmpiricalCovariance(ddof=ddof)
     p = 5
-    X_all = pd.DataFrame(columns=range(p))
+    X_all = None
 
     for _ in range(p):
         n = np.random.randint(5, 31)

--- a/river/utils/test_rolling.py
+++ b/river/utils/test_rolling.py
@@ -47,6 +47,6 @@ def test_issue_1343():
 
     """
     rmean = utils.TimeRolling(proba.MultivariateGaussian(), period=dt.timedelta(microseconds=1))
-    t = dt.datetime.utcnow()
+    t = dt.datetime.now()
     rmean.update({"a": 0}, t=t)
     rmean.update({"a": 1}, t=t)


### PR DESCRIPTION
<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->

River's test suite raises an important quantity of warnings, and their number may hide defects in new code. Most warnings are created by a few pieces of code run many times. This PR aims to greatly reduce the number of warnings in the tests.

Before: 209139 warnings
After : 17 warnings

Most warnings left are caused by libraries like NumPy and Scikit-learn.

Four of the remaining warnings are a deprecation : `pickle`, `copy`, and `deepcopy` support will be removed from `itertools` in Python 3.14. *This may warrant an action.*

This PR also fixes a semi-bug: 
In [`naives_bayes.BernoulliNB.joint_log_likelihood_many()`](https://github.com/online-ml/river/blob/main/river/naive_bayes/bernoulli.py#L266), the `if hasattr(X, "sparse")` path was never used (at least in the tests) because sparse dataframes were completed with non-sparse values, becoming non-sparse.

Thankfully, both types of dataframes have the same behaviour so nothing bad happened and only a warning was issued by Pandas.
In removing the warning, I restored the intended behaviour (or the one I believe was intended).