### PR TITLE
Make mini-batch TF-IDF raise an exception

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -14,6 +14,10 @@
 
 - Make `drift.ADWIN` comply with the reference MOA implementation.
 
+## feature extraction
+
+- The mini-batch methods for `feature_extraction.TFIDF` now systematically raise an exception, as they are not implemented.
+
 ## stats
 
 - Removed the unexported class `stats.CentralMoments`.

--- a/river/feature_extraction/vectorize.py
+++ b/river/feature_extraction/vectorize.py
@@ -489,3 +489,12 @@ class TFIDF(BagOfWords):
             norm = math.sqrt(sum(tfidf**2 for tfidf in tfidfs.values()))
             return {term: tfidf / norm for term, tfidf in tfidfs.items()}
         return tfidfs
+
+    # Mini-batch methods should be done well™ and not just be a loop over the *_one equivalent.
+    def learn_many(self, X):
+        "Not available, will raise an exception."
+        raise NotImplementedError
+
+    def transform_many(self, X):
+        "Not available, will raise an exception."
+        raise NotImplementedError

--- a/river/feature_extraction/vectorize.py
+++ b/river/feature_extraction/vectorize.py
@@ -451,6 +451,8 @@ class TFIDF(BagOfWords):
         strip_accents=True,
         lowercase=True,
         preprocessor: typing.Callable | None = None,
+        stop_words: set[str] | None = None,
+        tokenizer_pattern=r"(?u)\b\w[\w\-]+\b",
         tokenizer: typing.Callable | None = None,
         ngram_range=(1, 1),
     ):
@@ -459,6 +461,8 @@ class TFIDF(BagOfWords):
             strip_accents=strip_accents,
             lowercase=lowercase,
             preprocessor=preprocessor,
+            stop_words=stop_words,
+            tokenizer_pattern=tokenizer_pattern,
             tokenizer=tokenizer,
             ngram_range=ngram_range,
         )


### PR DESCRIPTION
<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->

`feature _extraction.TFIDF` has no explicit implementation of the mini-batch methods `learn_many` and `transform_many`, meaning that Python will fall back on the ones provided by its parent `feature _extraction.BagOfWords`. This causes TF-IDF to have a different behaviour in single-instance and in mini-batch mode.

This PR is a band-aid that adds the methods for TF-IDF to make it explicit they are not supported. Both will raise an exception when called.

A true mini-batch version could be added at a later point.

Fixes #1629
