### PR TITLE
Fix for Issues with CluStream clustering

### DIFF
--- a/river/cluster/clustream.py
+++ b/river/cluster/clustream.py
@@ -260,7 +260,7 @@ class CluStream(base.Clusterer):
     def predict_one(self, x):
         index, _ = self._get_closest_mc(x)
         try:
-            return self._kmeans_mc.predict_one(self._mc_centers[index])
+            return self._kmeans_mc.predict_one(self.micro_clusters[index].center)
         except (KeyError, AttributeError):
             return 0
 

--- a/river/cluster/clustream.py
+++ b/river/cluster/clustream.py
@@ -236,12 +236,12 @@ class CluStream(base.Clusterer):
 
         if closest_dist < radius:
             closest_mc.insert(x, w, self._timestamp)
-            return
+        else:
 
-        # If the new point does not fit in the micro-cluster, micro-clusters
-        # whose relevance stamps are less than the threshold are deleted.
-        # Otherwise, closest micro-clusters are merged with each other.
-        self._maintain_micro_clusters(x=x, w=w)
+            # If the new point does not fit in the micro-cluster, micro-clusters
+            # whose relevance stamps are less than the threshold are deleted.
+            # Otherwise, closest micro-clusters are merged with each other.
+            self._maintain_micro_clusters(x=x, w=w)
 
         # Apply incremental K-Means on micro-clusters after each time_gap
         if self._timestamp % self.time_gap == self.time_gap - 1:


### PR DESCRIPTION
Two fixes regarding issues with the clustering procedure of CluStream:
1. fixes mismatch between centers used in distance calculation and cluster assignment that lead to incorrect assignments
2. ensures kMeans clustering at timegap, rather than allowing for skipping when a data point is added to an existing micro-cluster
A more in-depth description can be found here: [https://github.com/online-ml/river/discussions/1633](https://github.com/online-ml/river/discussions/1633)