### PR TITLE
Add WASM wheels build

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -97,10 +97,59 @@ jobs:
           name: cibw-sdist
           path: dist/*.tar.gz
 
+  build_pyodide_wheels:
+    name: Build Python ${{ matrix.python-version }} ~ pyodide
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # CPython 3.13 -> Pyodide 0.29.x (pyemscripten_2025_0). Pyodide pins a
+          # Rust nightly there, and the stock Emscripten target std is built
+          # without the emscripten-wasm-eh ABI, so std is rebuilt from source
+          # with -Zbuild-std (needs the rust-src component).
+          - python-version: "313"
+            rust_toolchain: "nightly-2025-02-01"
+            rust_component: "--component rust-src"
+            cargo_build_std: "panic_abort,std"
+            cibw_enable: ""
+          # CPython 3.14 -> Pyodide 314.x (pyemscripten_2026_0). Builds on stable
+          # Rust, where emscripten-wasm-eh is the default and the stock std is
+          # usable as-is, so no -Zbuild-std is needed.
+          - python-version: "314"
+            rust_toolchain: "1.93.0"
+            rust_component: ""
+            cargo_build_std: ""
+            cibw_enable: "pyodide-prerelease"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Install Rust ${{ matrix.rust_toolchain }} with the Emscripten target
+        run: |
+          rustup toolchain install "${{ matrix.rust_toolchain }}" \
+            --profile minimal --target wasm32-unknown-emscripten ${{ matrix.rust_component }}
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v4.1.0
+        timeout-minutes: 720
+        env:
+          CIBW_PLATFORM: pyodide
+          CIBW_BUILD: "cp${{ matrix.python-version }}-*"
+          CIBW_ENABLE: ${{ matrix.cibw_enable }}
+          # Override the stable pin in rust-toolchain.toml with the wasm-capable
+          # toolchain installed above. CARGO_UNSTABLE_BUILD_STD is ignored on the
+          # stable (3.14) toolchain, so the same env block works for both.
+          RUSTUP_TOOLCHAIN: ${{ matrix.rust_toolchain }}
+          CARGO_UNSTABLE_BUILD_STD: ${{ matrix.cargo_build_std }}
+      - uses: actions/upload-artifact@v5
+        with:
+          name: cibw-wheels-pyodide-${{ matrix.python-version }}
+          path: ./wheelhouse/*.whl
+
   upload_to_pypi:
     name: Upload all wheels to PyPI
     runs-on: ubuntu-latest
-    needs: [build_linux_wheels, build_macos_wheels, build_windows_wheels, build_sdist]
+    needs: [build_linux_wheels, build_macos_wheels, build_windows_wheels, build_sdist, build_pyodide_wheels]
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/test-for-pyodide.yml
+++ b/.github/workflows/test-for-pyodide.yml
@@ -1,0 +1,54 @@
+name: test-for-pyodide
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build Python ${{ matrix.python-version }} ~ pyodide
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # CPython 3.13 -> Pyodide 0.29.x (pyemscripten_2025_0). Pyodide pins a
+          # Rust nightly there, and the stock Emscripten target std is built
+          # without the emscripten-wasm-eh ABI, so std is rebuilt from source
+          # with -Zbuild-std (needs the rust-src component).
+          - python-version: "313"
+            rust_toolchain: "nightly-2025-02-01"
+            rust_component: "--component rust-src"
+            cargo_build_std: "panic_abort,std"
+            cibw_enable: ""
+          # CPython 3.14 -> Pyodide 314.x (pyemscripten_2026_0). Builds on stable
+          # Rust, where emscripten-wasm-eh is the default and the stock std is
+          # usable as-is, so no -Zbuild-std is needed.
+          - python-version: "314"
+            rust_toolchain: "1.93.0"
+            rust_component: ""
+            cargo_build_std: ""
+            cibw_enable: "pyodide-prerelease"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Install Rust ${{ matrix.rust_toolchain }} with the Emscripten target
+        run: |
+          rustup toolchain install "${{ matrix.rust_toolchain }}" \
+            --profile minimal --target wasm32-unknown-emscripten ${{ matrix.rust_component }}
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v4.1.0
+        timeout-minutes: 720
+        env:
+          CIBW_PLATFORM: pyodide
+          CIBW_BUILD: "cp${{ matrix.python-version }}-*"
+          CIBW_ENABLE: ${{ matrix.cibw_enable }}
+          RUSTUP_TOOLCHAIN: ${{ matrix.rust_toolchain }}
+          CARGO_UNSTABLE_BUILD_STD: ${{ matrix.cargo_build_std }}
+      - uses: actions/upload-artifact@v5
+        with:
+          name: pyodide-wheel-${{ matrix.python-version }}
+          path: ./wheelhouse/*.whl

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -2,6 +2,7 @@
 
 * Add `ppc64le` architecture to Linux wheel builds.
 * Dropped `altair` from River's runtime dependencies. It was never imported by the package itself (it is only used to draw plots in the documentation notebooks), so it has been moved to the `docs`/`dev` dependency groups. Installing River no longer pulls in `altair` and its transitive dependencies.
+* Publish Pyodide/WebAssembly wheels (CPython 3.13 and 3.14) so River can be installed in the browser, e.g. via [JupyterLite](https://jupyterlite.readthedocs.io/) or `micropip`. The minimum `numpy` and `scipy` versions were lowered to `2.2.5` and `1.14.1` to match the versions bundled with Pyodide.
 
 ## covariance
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,8 @@ requires-python = ">=3.11"
 readme = "README.md"
 license = "BSD-3-Clause"
 dependencies = [
-    "scipy>=1.16,<2",
-    "numpy>=2.3.4,<3",
+    "scipy>=1.14.1,<2",
+    "numpy>=2.2.5,<3",
     "narwhals>=2.0.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2911,9 +2911,9 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "narwhals", specifier = ">=2.0.0" },
-    { name = "numpy", specifier = ">=2.3.4,<3" },
+    { name = "numpy", specifier = ">=2.2.5,<3" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.2,<3" },
-    { name = "scipy", specifier = ">=1.16,<2" },
+    { name = "scipy", specifier = ">=1.14.1,<2" },
 ]
 provides-extras = ["pandas"]
 


### PR DESCRIPTION
Let's first test the build of the WASM wheels in an independant workflow so that it is easier to iterate and make sure it works before adding the logic to the pypi workflow.

See #1649 thread for more context.

Current blocker is a conflict between River `pandas<3.0.0,>=2.2.3` requirement and Pyodide pandas version (`2.2.0`) (see [run error](https://github.com/online-ml/river/actions/runs/12062931204/job/33637361981?pr=1653)).