### PR TITLE
Replace pre-commit in the CI

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -20,5 +20,11 @@ jobs:
           python-version: "3.13"
           build-root: false
 
-      - name: Run pre-commit on all files
-        run: poetry run pre-commit run --all-files
+      - name: MyPy type check
+        run: poetry run mypy
+
+      - name: Ruff code linting
+        run: poetry run ruff check --output-format=github river/
+
+      - name: Ruff code formatting
+        run: poetry run ruff format --check river/

--- a/river/anomaly/pad.py
+++ b/river/anomaly/pad.py
@@ -130,7 +130,7 @@ class PredictiveAnomalyDetection(anomaly.base.SupervisedAnomalyDetector):
             else:
                 self.predictive_model.learn_one(y=y, x=x)
         else:
-            self.predictive_model.learn_one(x=x, y=y)
+            self.predictive_model.learn_one(x=x, y=y)  # type: ignore[union-attr]
 
     def score_one(self, x: dict, y: base.typing.Target):
         # Return the predicted value of x from the predictive model, first by checking whether
@@ -138,7 +138,7 @@ class PredictiveAnomalyDetection(anomaly.base.SupervisedAnomalyDetector):
         if isinstance(self.predictive_model, time_series.base.Forecaster):
             y_pred = self.predictive_model.forecast(self.horizon)[0]
         else:
-            y_pred = self.predictive_model.predict_one(x)
+            y_pred = self.predictive_model.predict_one(x)  # type: ignore[union-attr]
 
         # Calculate the squared error
         squared_error = (y_pred - y) ** 2

--- a/river/preprocessing/scale.py
+++ b/river/preprocessing/scale.py
@@ -237,7 +237,7 @@ class StandardScaler(base.MiniBatchTransformer):
         # Check if the dtype is integer type and convert to corresponding float type
         if np.issubdtype(dtype, np.integer):
             bytes_size = dtype.itemsize
-            dtype = np.dtype(f"float{bytes_size * 8}")
+            dtype = np.dtype(f"float{bytes_size * 8}")  # type: ignore[operator]
 
         means = np.array([self.means[c] for c in X.columns], dtype=dtype)
         Xt = X.values - means

--- a/river/stream/qa.py
+++ b/river/stream/qa.py
@@ -140,10 +140,10 @@ def simulate_qa(
 
     mementos: list[Memento] = []
 
-    kwargs: list
+    kwargs_list: list
 
-    for i, (x, y, *kwargs) in enumerate(dataset):
-        kwargs = kwargs[0] if kwargs else None
+    for i, (x, y, *kwargs_list) in enumerate(dataset):
+        kwargs = kwargs_list[0] if kwargs_list else None
 
         t = get_moment(i, x)
         d = get_delay(x, y)  # type: ignore
@@ -168,7 +168,7 @@ def simulate_qa(
             )
             del mementos[0]
 
-        queue(mementos, Memento(i, x, y, kwargs, t + d))
+        queue(mementos, Memento(i, x, y, kwargs, t + d))  # type: ignore[operator]
         if copy:
             x = deepcopy(x)
         yield (i, x, None, kwargs) if kwargs else (i, x, None)


### PR DESCRIPTION
<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->

Because pre-commit only checks edited files, side effects can cause errors to appear in other files and go unnoticed. On the contrary, the CI's role is to guarantee the soundness of the entire codebase; only checking what changed is insufficient.

This PR replaces pre-commit with an explicit call to the linters (in CI only, pre-commit is still available as a hook).

This process discovered previously silent typing errors.
If anything, we lose pre-commit's interface to select file types: the files must now be given as command arguments.

Closes #1665
