### PR TITLE
Add the licence in the project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ readme = "README.md"
 homepage = "https://riverml.xyz/"
 repository = "https://github.com/online-ml/river/"
 authors = ["Max Halford <maxhalford25@gmail.com>"]
+license = "BSD-3-Clause"
 
 include = [
     "**/*.cpp",


### PR DESCRIPTION
<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->
River did not mention its licence in the metadata, causing PyPi to have no information about it.

This new line will enable Poetry to add licence information when building a wheel.