### PR TITLE
Full type hints for the module base

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,1 +1,7 @@
 # Unreleased
+
+## base
+
+- The `tags` and `more_tags` properties of `base.Estimator` are now both a set of strings.
+- The `base` module is now fully type-annotated. Some type hints have changed, but this does not impact the behaviour of the code. For instance, the regression target is now indicated as a float instead of a Number.
+- `base.Ensemble`, `base.Wrapper`, and `base.WrapperEnsemble` became generic with regard to the type they encapsulate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,6 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 # Disable strict mode for all non fully-typed modules
 module = [
-    "river.base.*",
     "river.metrics.*",
     "river.utils.*",
     "river.stats.*",

--- a/river/anomaly/pad.py
+++ b/river/anomaly/pad.py
@@ -130,7 +130,7 @@ class PredictiveAnomalyDetection(anomaly.base.SupervisedAnomalyDetector):
             else:
                 self.predictive_model.learn_one(y=y, x=x)
         else:
-            self.predictive_model.learn_one(x=x, y=y)  # type: ignore[union-attr]
+            self.predictive_model.learn_one(x=x, y=y)  # type:ignore[attr-defined]
 
     def score_one(self, x: dict, y: base.typing.Target):
         # Return the predicted value of x from the predictive model, first by checking whether
@@ -138,7 +138,7 @@ class PredictiveAnomalyDetection(anomaly.base.SupervisedAnomalyDetector):
         if isinstance(self.predictive_model, time_series.base.Forecaster):
             y_pred = self.predictive_model.forecast(self.horizon)[0]
         else:
-            y_pred = self.predictive_model.predict_one(x)  # type: ignore[union-attr]
+            y_pred = self.predictive_model.predict_one(x)  # type:ignore[attr-defined]
 
         # Calculate the squared error
         squared_error = (y_pred - y) ** 2

--- a/river/bandit/evaluate.py
+++ b/river/bandit/evaluate.py
@@ -139,7 +139,7 @@ def evaluate(
                 arm = policy_.pull(range(env_.action_space.n))  # type: ignore[attr-defined, arg-type]
                 observation, reward, terminated, truncated, info = env_.step(arm)
                 policy_.update(arm, reward)
-                reward_stat_.update(reward) # type: ignore[arg-type]
+                reward_stat_.update(reward)  # type: ignore[arg-type]
 
                 yield {
                     "episode": episode,

--- a/river/bandit/evaluate.py
+++ b/river/bandit/evaluate.py
@@ -136,10 +136,10 @@ def evaluate(
                 if done[policy_idx]:
                     continue
 
-                arm = policy_.pull(range(env_.action_space.n))  # type: ignore[attr-defined]
+                arm = policy_.pull(range(env_.action_space.n))  # type: ignore[attr-defined, arg-type]
                 observation, reward, terminated, truncated, info = env_.step(arm)
                 policy_.update(arm, reward)
-                reward_stat_.update(reward)
+                reward_stat_.update(reward) # type: ignore[arg-type]
 
                 yield {
                     "episode": episode,

--- a/river/base/__init__.py
+++ b/river/base/__init__.py
@@ -29,6 +29,7 @@ from .estimator import Estimator
 from .multi_output import MultiLabelClassifier, MultiTargetRegressor
 from .regressor import MiniBatchRegressor, Regressor
 from .transformer import (
+    BaseTransformer,
     MiniBatchSupervisedTransformer,
     MiniBatchTransformer,
     SupervisedTransformer,
@@ -38,6 +39,7 @@ from .wrapper import Wrapper
 
 __all__ = [
     "Base",
+    "BaseTransformer",
     "BinaryDriftDetector",
     "BinaryDriftAndWarningDetector",
     "Classifier",

--- a/river/base/base.py
+++ b/river/base/base.py
@@ -31,7 +31,7 @@ class Base:
         return _repr_obj(obj=self)
 
     @classmethod
-    def _unit_test_params(cls) -> typing.Iterator[dict[str, typing.Any]]:
+    def _unit_test_params(cls) -> collections.abc.Iterator[dict[str, typing.Any]]:
         """Instantiates an object with default arguments.
 
         Most parameters of each object have a default value. However, this isn't always the case,

--- a/river/base/base.py
+++ b/river/base/base.py
@@ -73,7 +73,9 @@ class Base:
 
         return params
 
-    def clone(self, new_params: dict[str, typing.Any] | None = None, include_attributes: bool = False) -> typing_extensions.Self:
+    def clone(
+        self, new_params: dict[str, typing.Any] | None = None, include_attributes: bool = False
+    ) -> typing_extensions.Self:
         """Return a fresh estimator with the same parameters.
 
         The clone has the same parameters but has not been updated with any data.
@@ -371,7 +373,7 @@ class Base:
                 buffer.extend([k for k in obj.keys()])
                 buffer.extend([v for v in obj.values()])
             elif hasattr(obj, "__dict__"):  # Save object contents
-                contents= vars(obj)
+                contents = vars(obj)
                 size += sys.getsizeof(contents)
                 buffer.extend([k for k in contents.keys()])
                 buffer.extend([v for v in contents.values()])
@@ -398,7 +400,12 @@ class Base:
         return utils.pretty.humanize_bytes(self._raw_memory_usage)
 
 
-def _log_method_calls(self: typing.Any, name: str, class_condition: typing.Callable[[typing.Any], bool], method_condition: typing.Callable[[typing.Any], bool]) -> typing.Any:
+def _log_method_calls(
+    self: typing.Any,
+    name: str,
+    class_condition: typing.Callable[[typing.Any], bool],
+    method_condition: typing.Callable[[typing.Any], bool],
+) -> typing.Any:
     method = object.__getattribute__(self, name)
     if (
         not name.startswith("_")

--- a/river/base/base.py
+++ b/river/base/base.py
@@ -10,6 +10,8 @@ import sys
 import types
 import typing
 
+import typing_extensions
+
 
 class Base:
     """Base class that is inherited by the majority of classes in River.
@@ -29,7 +31,7 @@ class Base:
         return _repr_obj(obj=self)
 
     @classmethod
-    def _unit_test_params(cls):
+    def _unit_test_params(cls) -> typing.Iterator[dict[str, typing.Any]]:
         """Instantiates an object with default arguments.
 
         Most parameters of each object have a default value. However, this isn't always the case,
@@ -71,7 +73,7 @@ class Base:
 
         return params
 
-    def clone(self, new_params: dict | None = None, include_attributes: bool = False):
+    def clone(self, new_params: dict[str, typing.Any] | None = None, include_attributes: bool = False) -> typing_extensions.Self:
         """Return a fresh estimator with the same parameters.
 
         The clone has the same parameters but has not been updated with any data.
@@ -167,7 +169,7 @@ class Base:
 
         """
 
-        def is_class_param(param):
+        def is_class_param(param) -> bool:
             # See expand_param_grid to understand why this is necessary
             return (
                 isinstance(param, tuple)
@@ -202,10 +204,10 @@ class Base:
         return clone
 
     @property
-    def _mutable_attributes(self) -> set:
+    def _mutable_attributes(self) -> set[str]:
         return set()
 
-    def mutate(self, new_attrs: dict) -> None:
+    def mutate(self, new_attrs: dict[str, typing.Any]) -> None:
         """Modify attributes.
 
         This changes parameters inplace. Although you can change attributes yourself, this is the
@@ -296,8 +298,8 @@ class Base:
 
         """
 
-        def _mutate(obj, new_attrs):
-            def is_class_attr(name: str, attr):
+        def _mutate(obj, new_attrs) -> None:
+            def is_class_attr(name: str, attr) -> bool:
                 return hasattr(getattr(obj, name), "mutate") and isinstance(attr, dict)
 
             for name, attr in new_attrs.items():
@@ -318,7 +320,7 @@ class Base:
         _mutate(obj=self, new_attrs=new_attrs)
 
     @property
-    def _is_stochastic(self):
+    def _is_stochastic(self) -> bool:
         """Indicates if the model contains an unset seed parameter.
 
         The convention in River is to control randomness by exposing a seed parameter. This seed
@@ -329,14 +331,14 @@ class Base:
 
         """
 
-        def is_class_param(param):
+        def is_class_param(param) -> bool:
             return (
                 isinstance(param, tuple)
                 and inspect.isclass(param[0])
                 and isinstance(param[1], dict)
             )
 
-        def find(params) -> bool:
+        def find(params: dict[str, typing.Any]) -> bool:
             if not isinstance(params, dict):
                 return False
             for name, param in params.items():
@@ -354,7 +356,7 @@ class Base:
 
         import numpy as np
 
-        buffer = collections.deque([self])
+        buffer: collections.deque[typing.Any] = collections.deque([self])
         seen = set()
         size = 0
         while len(buffer) > 0:
@@ -369,7 +371,7 @@ class Base:
                 buffer.extend([k for k in obj.keys()])
                 buffer.extend([v for v in obj.values()])
             elif hasattr(obj, "__dict__"):  # Save object contents
-                contents: dict = vars(obj)
+                contents= vars(obj)
                 size += sys.getsizeof(contents)
                 buffer.extend([k for k in contents.keys()])
                 buffer.extend([v for v in contents.values()])

--- a/river/base/base.py
+++ b/river/base/base.py
@@ -169,7 +169,7 @@ class Base:
 
         """
 
-        def is_class_param(param) -> bool:
+        def is_class_param(param: typing.Any) -> bool:
             # See expand_param_grid to understand why this is necessary
             return (
                 isinstance(param, tuple)
@@ -298,8 +298,8 @@ class Base:
 
         """
 
-        def _mutate(obj, new_attrs) -> None:
-            def is_class_attr(name: str, attr) -> bool:
+        def _mutate(obj: typing.Any, new_attrs: dict[str, typing.Any]) -> None:
+            def is_class_attr(name: str, attr: typing.Any) -> bool:
                 return hasattr(getattr(obj, name), "mutate") and isinstance(attr, dict)
 
             for name, attr in new_attrs.items():
@@ -331,7 +331,7 @@ class Base:
 
         """
 
-        def is_class_param(param) -> bool:
+        def is_class_param(param: typing.Any) -> bool:
             return (
                 isinstance(param, tuple)
                 and inspect.isclass(param[0])
@@ -398,7 +398,7 @@ class Base:
         return utils.pretty.humanize_bytes(self._raw_memory_usage)
 
 
-def _log_method_calls(self, name: str, class_condition, method_condition):
+def _log_method_calls(self: typing.Any, name: str, class_condition: typing.Callable[[typing.Any], bool], method_condition: typing.Callable[[typing.Any], bool]) -> typing.Any:
     method = object.__getattribute__(self, name)
     if (
         not name.startswith("_")
@@ -414,7 +414,7 @@ def _log_method_calls(self, name: str, class_condition, method_condition):
 def log_method_calls(
     class_condition: typing.Callable[[typing.Any], bool] | None = None,
     method_condition: typing.Callable[[typing.Any], bool] | None = None,
-):
+) -> collections.abc.Iterator[None]:
     """A context manager to log method calls.
 
     All method calls will be logged by default. This behavior can be overridden by passing filtering
@@ -479,7 +479,7 @@ def log_method_calls(
         Base.__getattribute__ = old  # type: ignore
 
 
-def _repr_obj(obj, show_modules: bool = False, depth: int = 0) -> str:
+def _repr_obj(obj: typing.Any, show_modules: bool = False, depth: int = 0) -> str:
     """Return a pretty representation of an object."""
 
     rep = f"{obj.__class__.__name__} ("

--- a/river/base/base.py
+++ b/river/base/base.py
@@ -22,10 +22,10 @@ class Base:
 
     """
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.__class__.__name__
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return _repr_obj(obj=self)
 
     @classmethod
@@ -71,7 +71,7 @@ class Base:
 
         return params
 
-    def clone(self, new_params: dict | None = None, include_attributes=False):
+    def clone(self, new_params: dict | None = None, include_attributes: bool = False):
         """Return a fresh estimator with the same parameters.
 
         The clone has the same parameters but has not been updated with any data.
@@ -205,7 +205,7 @@ class Base:
     def _mutable_attributes(self) -> set:
         return set()
 
-    def mutate(self, new_attrs: dict):
+    def mutate(self, new_attrs: dict) -> None:
         """Modify attributes.
 
         This changes parameters inplace. Although you can change attributes yourself, this is the
@@ -297,7 +297,7 @@ class Base:
         """
 
         def _mutate(obj, new_attrs):
-            def is_class_attr(name, attr):
+            def is_class_attr(name: str, attr):
                 return hasattr(getattr(obj, name), "mutate") and isinstance(attr, dict)
 
             for name, attr in new_attrs.items():
@@ -336,7 +336,7 @@ class Base:
                 and isinstance(param[1], dict)
             )
 
-        def find(params):
+        def find(params) -> bool:
             if not isinstance(params, dict):
                 return False
             for name, param in params.items():
@@ -396,7 +396,7 @@ class Base:
         return utils.pretty.humanize_bytes(self._raw_memory_usage)
 
 
-def _log_method_calls(self, name, class_condition, method_condition):
+def _log_method_calls(self, name: str, class_condition, method_condition):
     method = object.__getattribute__(self, name)
     if (
         not name.startswith("_")

--- a/river/base/base.py
+++ b/river/base/base.py
@@ -384,7 +384,7 @@ class Base:
             elif hasattr(obj, "__iter__") and not (
                 isinstance(obj, str) or isinstance(obj, bytes) or isinstance(obj, bytearray)
             ):
-                buffer.extend([i for i in obj])  # type: ignore
+                buffer.extend([i for i in obj])
 
         return size
 
@@ -487,7 +487,7 @@ def _repr_obj(obj, show_modules: bool = False, depth: int = 0) -> str:
 
     params = {
         name: getattr(obj, name)
-        for name, param in inspect.signature(obj.__init__).parameters.items()  # type: ignore
+        for name, param in inspect.signature(obj.__init__).parameters.items()
         if not (
             param.name == "args"
             and param.kind == param.VAR_POSITIONAL

--- a/river/base/classifier.py
+++ b/river/base/classifier.py
@@ -69,11 +69,11 @@ class Classifier(estimator.Estimator):
         return None
 
     @property
-    def _multiclass(self):
+    def _multiclass(self) -> bool:
         return False
 
     @property
-    def _supervised(self):
+    def _supervised(self) -> bool:
         return True
 
 

--- a/river/base/classifier.py
+++ b/river/base/classifier.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import typing
+from typing import Any
 
 from river import base
 
@@ -15,7 +16,7 @@ class Classifier(estimator.Estimator):
     """A classifier."""
 
     @abc.abstractmethod
-    def learn_one(self, x: dict, y: base.typing.ClfTarget) -> None:
+    def learn_one(self, x: dict[base.typing.FeatureName, Any], y: base.typing.ClfTarget) -> None:
         """Update the model with a set of features `x` and a label `y`.
 
         Parameters
@@ -27,7 +28,7 @@ class Classifier(estimator.Estimator):
 
         """
 
-    def predict_proba_one(self, x: dict) -> dict[base.typing.ClfTarget, float]:
+    def predict_proba_one(self, x: dict[base.typing.FeatureName, Any]) -> dict[base.typing.ClfTarget, float]:
         """Predict the probability of each label for a dictionary of features `x`.
 
         Parameters
@@ -47,7 +48,7 @@ class Classifier(estimator.Estimator):
         # that a classifier does not support predict_proba_one.
         raise NotImplementedError
 
-    def predict_one(self, x: dict, **kwargs) -> base.typing.ClfTarget | None:
+    def predict_one(self, x: dict[base.typing.FeatureName, Any], **kwargs) -> base.typing.ClfTarget | None:
         """Predict the label of a set of features `x`.
 
         Parameters

--- a/river/base/classifier.py
+++ b/river/base/classifier.py
@@ -28,7 +28,9 @@ class Classifier(estimator.Estimator):
 
         """
 
-    def predict_proba_one(self, x: dict[base.typing.FeatureName, Any], **kwargs: Any) -> dict[base.typing.ClfTarget, float]:
+    def predict_proba_one(
+        self, x: dict[base.typing.FeatureName, Any], **kwargs: Any
+    ) -> dict[base.typing.ClfTarget, float]:
         """Predict the probability of each label for a dictionary of features `x`.
 
         Parameters
@@ -48,7 +50,9 @@ class Classifier(estimator.Estimator):
         # that a classifier does not support predict_proba_one.
         raise NotImplementedError
 
-    def predict_one(self, x: dict[base.typing.FeatureName, Any], **kwargs: Any) -> base.typing.ClfTarget | None:
+    def predict_one(
+        self, x: dict[base.typing.FeatureName, Any], **kwargs: Any
+    ) -> base.typing.ClfTarget | None:
         """Predict the label of a set of features `x`.
 
         Parameters

--- a/river/base/classifier.py
+++ b/river/base/classifier.py
@@ -28,7 +28,7 @@ class Classifier(estimator.Estimator):
 
         """
 
-    def predict_proba_one(self, x: dict[base.typing.FeatureName, Any]) -> dict[base.typing.ClfTarget, float]:
+    def predict_proba_one(self, x: dict[base.typing.FeatureName, Any], **kwargs: Any) -> dict[base.typing.ClfTarget, float]:
         """Predict the probability of each label for a dictionary of features `x`.
 
         Parameters
@@ -48,7 +48,7 @@ class Classifier(estimator.Estimator):
         # that a classifier does not support predict_proba_one.
         raise NotImplementedError
 
-    def predict_one(self, x: dict[base.typing.FeatureName, Any], **kwargs) -> base.typing.ClfTarget | None:
+    def predict_one(self, x: dict[base.typing.FeatureName, Any], **kwargs: Any) -> base.typing.ClfTarget | None:
         """Predict the label of a set of features `x`.
 
         Parameters

--- a/river/base/clusterer.py
+++ b/river/base/clusterer.py
@@ -9,7 +9,7 @@ class Clusterer(estimator.Estimator):
     """A clustering model."""
 
     @property
-    def _supervised(self):
+    def _supervised(self) -> bool:
         return False
 
     @abc.abstractmethod

--- a/river/base/clusterer.py
+++ b/river/base/clusterer.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import abc
+from typing import Any
 
-from . import estimator
+from . import estimator, typing
 
 
 class Clusterer(estimator.Estimator):
@@ -13,7 +14,7 @@ class Clusterer(estimator.Estimator):
         return False
 
     @abc.abstractmethod
-    def learn_one(self, x: dict) -> None:
+    def learn_one(self, x: dict[typing.FeatureName, Any]) -> None:
         """Update the model with a set of features `x`.
 
         Parameters
@@ -24,7 +25,7 @@ class Clusterer(estimator.Estimator):
         """
 
     @abc.abstractmethod
-    def predict_one(self, x: dict) -> int:
+    def predict_one(self, x: dict[typing.FeatureName, Any]) -> int:
         """Predicts the cluster number for a set of features `x`.
 
         Parameters

--- a/river/base/drift_detector.py
+++ b/river/base/drift_detector.py
@@ -20,7 +20,7 @@ class _BaseDriftDetector(base.Base):
 
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._drift_detected = False
 
     def _reset(self) -> None:
@@ -40,11 +40,11 @@ class _BaseDriftAndWarningDetector(_BaseDriftDetector):
 
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self._warning_detected = False
 
-    def _reset(self):
+    def _reset(self) -> None:
         super()._reset()
         self._warning_detected = False
 

--- a/river/base/drift_detector.py
+++ b/river/base/drift_detector.py
@@ -49,7 +49,7 @@ class _BaseDriftAndWarningDetector(_BaseDriftDetector):
         self._warning_detected = False
 
     @property
-    def warning_detected(self):
+    def warning_detected(self) -> bool:
         """Whether or not a drift is detected following the last update."""
         return self._warning_detected
 

--- a/river/base/ensemble.py
+++ b/river/base/ensemble.py
@@ -8,7 +8,7 @@ from .estimator import Estimator
 from .wrapper import Wrapper
 
 
-class Ensemble(UserList):
+class Ensemble(UserList[Estimator]):
     """An ensemble is a model which is composed of a list of models.
 
     Parameters
@@ -31,7 +31,7 @@ class Ensemble(UserList):
         return 2
 
     @property
-    def models(self) -> list:
+    def models(self) -> list[Estimator]:
         return self.data
 
 

--- a/river/base/ensemble.py
+++ b/river/base/ensemble.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 from collections import UserList
 from collections.abc import Iterator
 from random import Random
+from typing import TypeVar
 
 from .estimator import Estimator
 from .wrapper import Wrapper
 
+T = TypeVar("T", bound=Estimator)
 
-class Ensemble(UserList[Estimator]):
+
+class Ensemble(UserList[T]):
     """An ensemble is a model which is composed of a list of models.
 
     Parameters
@@ -17,7 +20,7 @@ class Ensemble(UserList[Estimator]):
 
     """
 
-    def __init__(self, models: Iterator[Estimator]) -> None:
+    def __init__(self, models: Iterator[T]) -> None:
         super().__init__(models)
 
         if len(self) < self._min_number_of_models:
@@ -31,11 +34,11 @@ class Ensemble(UserList[Estimator]):
         return 2
 
     @property
-    def models(self) -> list[Estimator]:
+    def models(self) -> list[T]:
         return self.data
 
 
-class WrapperEnsemble(Ensemble, Wrapper):
+class WrapperEnsemble(Ensemble[T], Wrapper[T]):
     """A wrapper ensemble is an ensemble composed of multiple copies of the same model.
 
     Parameters
@@ -49,7 +52,7 @@ class WrapperEnsemble(Ensemble, Wrapper):
 
     """
 
-    def __init__(self, model: Estimator, n_models: int, seed: int | None) -> None:
+    def __init__(self, model: T, n_models: int, seed: int | None) -> None:
         super().__init__(model.clone() for _ in range(n_models))
         self.model = model
         self.n_models = n_models
@@ -57,5 +60,5 @@ class WrapperEnsemble(Ensemble, Wrapper):
         self._rng = Random(seed)
 
     @property
-    def _wrapped_model(self) -> Estimator:
+    def _wrapped_model(self) -> T:
         return self.model

--- a/river/base/ensemble.py
+++ b/river/base/ensemble.py
@@ -17,7 +17,7 @@ class Ensemble(UserList):
 
     """
 
-    def __init__(self, models: Iterator[Estimator]):
+    def __init__(self, models: Iterator[Estimator]) -> None:
         super().__init__(models)
 
         if len(self) < self._min_number_of_models:
@@ -27,7 +27,7 @@ class Ensemble(UserList):
             )
 
     @property
-    def _min_number_of_models(self):
+    def _min_number_of_models(self) -> int:
         return 2
 
     @property
@@ -49,7 +49,7 @@ class WrapperEnsemble(Ensemble, Wrapper):
 
     """
 
-    def __init__(self, model, n_models, seed):
+    def __init__(self, model, n_models: int, seed: int) -> None:
         super().__init__(model.clone() for _ in range(n_models))
         self.model = model
         self.n_models = n_models

--- a/river/base/ensemble.py
+++ b/river/base/ensemble.py
@@ -31,7 +31,7 @@ class Ensemble(UserList):
         return 2
 
     @property
-    def models(self):
+    def models(self) -> list:
         return self.data
 
 
@@ -49,7 +49,7 @@ class WrapperEnsemble(Ensemble, Wrapper):
 
     """
 
-    def __init__(self, model, n_models: int, seed: int) -> None:
+    def __init__(self, model: Estimator, n_models: int, seed: int | None) -> None:
         super().__init__(model.clone() for _ in range(n_models))
         self.model = model
         self.n_models = n_models
@@ -57,5 +57,5 @@ class WrapperEnsemble(Ensemble, Wrapper):
         self._rng = Random(seed)
 
     @property
-    def _wrapped_model(self):
+    def _wrapped_model(self) -> Estimator:
         return self.model

--- a/river/base/estimator.py
+++ b/river/base/estimator.py
@@ -9,7 +9,7 @@ class Estimator(base.Base, abc.ABC):
     """An estimator."""
 
     @property
-    def _supervised(self):
+    def _supervised(self) -> bool:
         """Indicates whether or not the estimator is supervised or not.
 
         This is useful internally for determining if an estimator expects to be provided with a `y`
@@ -35,7 +35,7 @@ class Estimator(base.Base, abc.ABC):
             return other.__or__(self)
         return compose.Pipeline(other, self)
 
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
         from xml.etree import ElementTree as ET
 
         from river.base import viz

--- a/river/base/estimator.py
+++ b/river/base/estimator.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import abc
+from typing import Any
+from collections.abc import Iterator
 
 from . import base
+from river import compose
 
 
 class Estimator(base.Base, abc.ABC):
@@ -19,7 +22,7 @@ class Estimator(base.Base, abc.ABC):
         """
         return True
 
-    def __or__(self, other):
+    def __or__(self, other: Estimator | compose.Pipeline) -> compose.Pipeline:
         """Merge with another Transformer into a Pipeline."""
         from river import compose
 
@@ -27,7 +30,7 @@ class Estimator(base.Base, abc.ABC):
             return other.__ror__(self)
         return compose.Pipeline(self, other)
 
-    def __ror__(self, other):
+    def __ror__(self, other: Estimator | compose.Pipeline) -> compose.Pipeline:
         """Merge with another Transformer into a Pipeline."""
         from river import compose
 
@@ -71,7 +74,7 @@ class Estimator(base.Base, abc.ABC):
         return tags
 
     @classmethod
-    def _unit_test_params(self):
+    def _unit_test_params(self) -> Iterator[dict[str, Any]]:
         """Indicates which parameters to use during unit testing.
 
         Most estimators have a default value for each of their parameters. However, in some cases,
@@ -84,7 +87,7 @@ class Estimator(base.Base, abc.ABC):
         """
         yield {}
 
-    def _unit_test_skips(self):
+    def _unit_test_skips(self) -> set[str]:
         """Indicates which checks to skip during unit testing.
 
         Most estimators pass the full test suite. However, in some cases, some estimators might not

--- a/river/base/estimator.py
+++ b/river/base/estimator.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import abc
-from typing import Any
+from typing import Any, TYPE_CHECKING
 from collections.abc import Iterator
 
 from . import base
-from river import compose
+
+if TYPE_CHECKING:
+    from river import compose
 
 
 class Estimator(base.Base, abc.ABC):

--- a/river/base/estimator.py
+++ b/river/base/estimator.py
@@ -47,11 +47,11 @@ class Estimator(base.Base, abc.ABC):
         div_str = ET.tostring(div, encoding="unicode")
         return f"<div>{div_str}<style scoped>{viz.CSS}</style></div>"
 
-    def _more_tags(self):
+    def _more_tags(self) -> set[str]:
         return set()
 
     @property
-    def _tags(self) -> dict[str, bool]:
+    def _tags(self) -> set[str]:
         """Return the estimator's tags.
 
         Tags can be used to specify what kind of inputs an estimator is able to process. For
@@ -67,7 +67,7 @@ class Estimator(base.Base, abc.ABC):
 
         for parent in self.__class__.__mro__:
             try:
-                tags |= parent._more_tags(self)  # type: ignore
+                tags |= parent._more_tags(self)  # type: ignore[attr-defined]
             except AttributeError:
                 pass
 

--- a/river/base/estimator.py
+++ b/river/base/estimator.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import abc
-from typing import Any, TYPE_CHECKING
 from collections.abc import Iterator
-
-from . import base
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from river import compose
+
+from . import base
 
 
 class Estimator(base.Base, abc.ABC):

--- a/river/base/multi_output.py
+++ b/river/base/multi_output.py
@@ -23,7 +23,9 @@ class MultiLabelClassifier(Estimator, abc.ABC):
 
         """
 
-    def predict_proba_one(self, x: dict[FeatureName, typing.Any], **kwargs: typing.Any) -> dict[FeatureName, dict[bool, float]]:
+    def predict_proba_one(
+        self, x: dict[FeatureName, typing.Any], **kwargs: typing.Any
+    ) -> dict[FeatureName, dict[bool, float]]:
         """Predict the probability of each label appearing given dictionary of features `x`.
 
         Parameters
@@ -40,7 +42,9 @@ class MultiLabelClassifier(Estimator, abc.ABC):
         # In case the multi-label classifier does not support probabilities
         raise NotImplementedError
 
-    def predict_one(self, x: dict[FeatureName, typing.Any], **kwargs: typing.Any) -> dict[FeatureName, bool]:
+    def predict_one(
+        self, x: dict[FeatureName, typing.Any], **kwargs: typing.Any
+    ) -> dict[FeatureName, bool]:
         """Predict the labels of a set of features `x`.
 
         Parameters
@@ -69,7 +73,12 @@ class MultiTargetRegressor(Estimator, abc.ABC):
     """Multi-target regressor."""
 
     @abc.abstractmethod
-    def learn_one(self, x: dict[FeatureName, typing.Any], y: dict[FeatureName, RegTarget], **kwargs: typing.Any) -> None:
+    def learn_one(
+        self,
+        x: dict[FeatureName, typing.Any],
+        y: dict[FeatureName, RegTarget],
+        **kwargs: typing.Any,
+    ) -> None:
         """Fits to a set of features `x` and a real-valued target `y`.
 
         Parameters

--- a/river/base/multi_output.py
+++ b/river/base/multi_output.py
@@ -23,7 +23,7 @@ class MultiLabelClassifier(Estimator, abc.ABC):
 
         """
 
-    def predict_proba_one(self, x: dict[FeatureName, typing.Any], **kwargs) -> dict[FeatureName, dict[bool, float]]:
+    def predict_proba_one(self, x: dict[FeatureName, typing.Any], **kwargs: typing.Any) -> dict[FeatureName, dict[bool, float]]:
         """Predict the probability of each label appearing given dictionary of features `x`.
 
         Parameters
@@ -40,7 +40,7 @@ class MultiLabelClassifier(Estimator, abc.ABC):
         # In case the multi-label classifier does not support probabilities
         raise NotImplementedError
 
-    def predict_one(self, x: dict[FeatureName, typing.Any], **kwargs) -> dict[FeatureName, bool]:
+    def predict_one(self, x: dict[FeatureName, typing.Any], **kwargs: typing.Any) -> dict[FeatureName, bool]:
         """Predict the labels of a set of features `x`.
 
         Parameters
@@ -69,7 +69,7 @@ class MultiTargetRegressor(Estimator, abc.ABC):
     """Multi-target regressor."""
 
     @abc.abstractmethod
-    def learn_one(self, x: dict[FeatureName, typing.Any], y: dict[FeatureName, RegTarget], **kwargs) -> None:
+    def learn_one(self, x: dict[FeatureName, typing.Any], y: dict[FeatureName, RegTarget], **kwargs: typing.Any) -> None:
         """Fits to a set of features `x` and a real-valued target `y`.
 
         Parameters

--- a/river/base/multi_output.py
+++ b/river/base/multi_output.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import abc
+import typing
 
 from .estimator import Estimator
 from .typing import FeatureName, RegTarget
@@ -10,7 +11,7 @@ class MultiLabelClassifier(Estimator, abc.ABC):
     """Multi-label classifier."""
 
     @abc.abstractmethod
-    def learn_one(self, x: dict, y: dict[FeatureName, bool]) -> None:
+    def learn_one(self, x: dict[FeatureName, typing.Any], y: dict[FeatureName, bool]) -> None:
         """Update the model with a set of features `x` and the labels `y`.
 
         Parameters
@@ -22,7 +23,7 @@ class MultiLabelClassifier(Estimator, abc.ABC):
 
         """
 
-    def predict_proba_one(self, x: dict, **kwargs) -> dict[FeatureName, dict[bool, float]]:
+    def predict_proba_one(self, x: dict[FeatureName, typing.Any], **kwargs) -> dict[FeatureName, dict[bool, float]]:
         """Predict the probability of each label appearing given dictionary of features `x`.
 
         Parameters
@@ -39,7 +40,7 @@ class MultiLabelClassifier(Estimator, abc.ABC):
         # In case the multi-label classifier does not support probabilities
         raise NotImplementedError
 
-    def predict_one(self, x: dict, **kwargs) -> dict[FeatureName, bool]:
+    def predict_one(self, x: dict[FeatureName, typing.Any], **kwargs) -> dict[FeatureName, bool]:
         """Predict the labels of a set of features `x`.
 
         Parameters
@@ -68,7 +69,7 @@ class MultiTargetRegressor(Estimator, abc.ABC):
     """Multi-target regressor."""
 
     @abc.abstractmethod
-    def learn_one(self, x: dict, y: dict[FeatureName, RegTarget], **kwargs) -> None:
+    def learn_one(self, x: dict[FeatureName, typing.Any], y: dict[FeatureName, RegTarget], **kwargs) -> None:
         """Fits to a set of features `x` and a real-valued target `y`.
 
         Parameters
@@ -81,7 +82,7 @@ class MultiTargetRegressor(Estimator, abc.ABC):
         """
 
     @abc.abstractmethod
-    def predict_one(self, x: dict) -> dict[FeatureName, RegTarget]:
+    def predict_one(self, x: dict[FeatureName, typing.Any]) -> dict[FeatureName, RegTarget]:
         """Predict the outputs of features `x`.
 
         Parameters

--- a/river/base/regressor.py
+++ b/river/base/regressor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import typing
+from typing import Any
 
 from river import base
 
@@ -15,7 +16,7 @@ class Regressor(estimator.Estimator):
     """A regressor."""
 
     @abc.abstractmethod
-    def learn_one(self, x: dict, y: base.typing.RegTarget) -> None:
+    def learn_one(self, x: dict[base.typing.FeatureName, Any], y: base.typing.RegTarget) -> None:
         """Fits to a set of features `x` and a real-valued target `y`.
 
         Parameters
@@ -28,7 +29,7 @@ class Regressor(estimator.Estimator):
         """
 
     @abc.abstractmethod
-    def predict_one(self, x: dict) -> base.typing.RegTarget:
+    def predict_one(self, x: dict[base.typing.FeatureName, Any]) -> base.typing.RegTarget:
         """Predict the output of features `x`.
 
         Parameters

--- a/river/base/test_base.py
+++ b/river/base/test_base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from river import compose, datasets, linear_model, optim, preprocessing, stats, time_series
 
 
-def test_clone_estimator():
+def test_clone_estimator() -> None:
     obj = linear_model.LinearRegression(l2=42)
     obj.learn_one({"x": 3}, 6)
 
@@ -14,7 +14,7 @@ def test_clone_estimator():
     assert new.weights != obj.weights
 
 
-def test_clone_include_attributes():
+def test_clone_include_attributes() -> None:
     var = stats.Var()
     var.update(1)
     var.update(2)
@@ -25,7 +25,7 @@ def test_clone_include_attributes():
     assert var.clone(include_attributes=True)._S == 2
 
 
-def test_clone_pipeline():
+def test_clone_pipeline() -> None:
     obj = preprocessing.StandardScaler() | linear_model.LinearRegression(l2=42)
     obj.learn_one({"x": 3}, 6)
 
@@ -37,7 +37,7 @@ def test_clone_pipeline():
     assert new["LinearRegression"].weights != obj["LinearRegression"].weights
 
 
-def test_clone_idempotent():
+def test_clone_idempotent() -> None:
     model = preprocessing.StandardScaler() | linear_model.LogisticRegression(
         optimizer=optim.Adam(), l2=0.1
     )
@@ -53,7 +53,7 @@ def test_clone_idempotent():
         clone.learn_one(x, y)
 
 
-def test_memory_usage():
+def test_memory_usage() -> None:
     model = preprocessing.StandardScaler() | linear_model.LogisticRegression()
 
     # We can't test the exact value because it depends on the platform and the Python version
@@ -61,7 +61,7 @@ def test_memory_usage():
     assert isinstance(model._memory_usage, str)
 
 
-def test_mutate():
+def test_mutate() -> None:
     """
 
     >>> from river import datasets, linear_model, optim, preprocessing
@@ -114,13 +114,13 @@ def test_mutate():
     """
 
 
-def test_clone_positional_args():
+def test_clone_positional_args() -> None:
     assert compose.Select(1, 2, 3).clone().keys == {1, 2, 3}
     assert compose.Discard("a", "b", "c").clone().keys == {"a", "b", "c"}
     assert compose.SelectType(float, int).clone().types == (float, int)
 
 
-def test_clone_nested_pipeline():
+def test_clone_nested_pipeline() -> None:
     model = time_series.SNARIMAX(
         p=2,
         d=1,

--- a/river/base/test_base.py
+++ b/river/base/test_base.py
@@ -8,6 +8,7 @@ def test_clone_estimator() -> None:
     obj.learn_one({"x": 3}, 6)
 
     new = obj.clone({"l2": 21})
+    assert type(new) is type(obj)
     assert new.l2 == 21
     assert obj.l2 == 42
     assert new.weights == {}

--- a/river/base/transformer.py
+++ b/river/base/transformer.py
@@ -25,10 +25,10 @@ class BaseTransformer:
     def __mul__(self, other):
         from river import compose
 
-        if isinstance(other, Transformer) or isinstance(other, compose.Pipeline):
+        if isinstance(other, BaseTransformer) or isinstance(other, compose.Pipeline):
             return compose.TransformerProduct(self, other)
 
-        return compose.Grouper(transformer=self, by=other)
+        return compose.Grouper(transformer=self, by=other) # type: ignore[arg-type]
 
     def __rmul__(self, other):
         """Creates a Grouper."""

--- a/river/base/transformer.py
+++ b/river/base/transformer.py
@@ -4,10 +4,11 @@ import abc
 import typing
 from typing import Any
 
-from river import base, compose
+from river import base
 
 if typing.TYPE_CHECKING:
     import pandas as pd
+    from river import compose
 
 
 class BaseTransformer:

--- a/river/base/transformer.py
+++ b/river/base/transformer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import typing
+from typing import Any
 
 from river import base, compose
 
@@ -35,7 +36,7 @@ class BaseTransformer:
         return self * other
 
     @abc.abstractmethod
-    def transform_one(self, x: dict) -> dict:
+    def transform_one(self, x: dict[base.typing.FeatureName, Any]) -> dict[base.typing.FeatureName, Any]:
         """Transform a set of features `x`.
 
         Parameters
@@ -57,7 +58,7 @@ class Transformer(base.Estimator, BaseTransformer):
     def _supervised(self) -> bool:
         return False
 
-    def learn_one(self, x: dict) -> None:
+    def learn_one(self, x: dict[base.typing.FeatureName, Any]) -> None:
         """Update with a set of features `x`.
 
         A lot of transformers don't actually have to do anything during the `learn_one` step
@@ -81,7 +82,7 @@ class SupervisedTransformer(base.Estimator, BaseTransformer):
     def _supervised(self) -> bool:
         return True
 
-    def learn_one(self, x: dict, y: base.typing.Target) -> None:
+    def learn_one(self, x: dict[base.typing.FeatureName, Any], y: base.typing.Target) -> None:
         """Update with a set of features `x` and a target `y`.
 
         Parameters

--- a/river/base/transformer.py
+++ b/river/base/transformer.py
@@ -54,7 +54,7 @@ class Transformer(base.Estimator, BaseTransformer):
     """A transformer."""
 
     @property
-    def _supervised(self):
+    def _supervised(self) -> bool:
         return False
 
     def learn_one(self, x: dict) -> None:
@@ -78,7 +78,7 @@ class SupervisedTransformer(base.Estimator, BaseTransformer):
     """A supervised transformer."""
 
     @property
-    def _supervised(self):
+    def _supervised(self) -> bool:
         return True
 
     def learn_one(self, x: dict, y: base.typing.Target) -> None:
@@ -134,7 +134,7 @@ class MiniBatchSupervisedTransformer(Transformer):
     """A supervised transformer that can operate on mini-batches."""
 
     @property
-    def _supervised(self):
+    def _supervised(self) -> bool:
         return True
 
     @abc.abstractmethod

--- a/river/base/transformer.py
+++ b/river/base/transformer.py
@@ -8,6 +8,7 @@ from river import base
 
 if typing.TYPE_CHECKING:
     import pandas as pd
+
     from river import compose
 
 
@@ -24,20 +25,34 @@ class BaseTransformer:
 
         return compose.TransformerUnion(other, self)
 
-    def __mul__(self, other: BaseTransformer | compose.Pipeline | base.typing.FeatureName | list[base.typing.FeatureName]) -> compose.Grouper | compose.TransformerProduct:
+    def __mul__(
+        self,
+        other: BaseTransformer
+        | compose.Pipeline
+        | base.typing.FeatureName
+        | list[base.typing.FeatureName],
+    ) -> compose.Grouper | compose.TransformerProduct:
         from river import compose
 
         if isinstance(other, BaseTransformer) or isinstance(other, compose.Pipeline):
             return compose.TransformerProduct(self, other)
 
-        return compose.Grouper(transformer=self, by=other) # type: ignore[arg-type]
+        return compose.Grouper(transformer=self, by=other)
 
-    def __rmul__(self, other: BaseTransformer | compose.Pipeline | base.typing.FeatureName | list[base.typing.FeatureName]) -> compose.Grouper | compose.TransformerProduct:
+    def __rmul__(
+        self,
+        other: BaseTransformer
+        | compose.Pipeline
+        | base.typing.FeatureName
+        | list[base.typing.FeatureName],
+    ) -> compose.Grouper | compose.TransformerProduct:
         """Creates a Grouper."""
         return self * other
 
     @abc.abstractmethod
-    def transform_one(self, x: dict[base.typing.FeatureName, Any]) -> dict[base.typing.FeatureName, Any]:
+    def transform_one(
+        self, x: dict[base.typing.FeatureName, Any]
+    ) -> dict[base.typing.FeatureName, Any]:
         """Transform a set of features `x`.
 
         Parameters

--- a/river/base/transformer.py
+++ b/river/base/transformer.py
@@ -3,26 +3,26 @@ from __future__ import annotations
 import abc
 import typing
 
-from river import base
+from river import base, compose
 
 if typing.TYPE_CHECKING:
     import pandas as pd
 
 
 class BaseTransformer:
-    def __add__(self, other):
+    def __add__(self, other: BaseTransformer) -> compose.TransformerUnion:
         """Fuses with another Transformer into a TransformerUnion."""
         from river import compose
 
         return compose.TransformerUnion(self, other)
 
-    def __radd__(self, other):
+    def __radd__(self, other: BaseTransformer) -> compose.TransformerUnion:
         """Fuses with another Transformer into a TransformerUnion."""
         from river import compose
 
         return compose.TransformerUnion(other, self)
 
-    def __mul__(self, other):
+    def __mul__(self, other: BaseTransformer | compose.Pipeline | base.typing.FeatureName | list[base.typing.FeatureName]) -> compose.Grouper | compose.TransformerProduct:
         from river import compose
 
         if isinstance(other, BaseTransformer) or isinstance(other, compose.Pipeline):
@@ -30,7 +30,7 @@ class BaseTransformer:
 
         return compose.Grouper(transformer=self, by=other) # type: ignore[arg-type]
 
-    def __rmul__(self, other):
+    def __rmul__(self, other: BaseTransformer | compose.Pipeline | base.typing.FeatureName | list[base.typing.FeatureName]) -> compose.Grouper | compose.TransformerProduct:
         """Creates a Grouper."""
         return self * other
 

--- a/river/base/typing.py
+++ b/river/base/typing.py
@@ -7,5 +7,5 @@ FeatureName = typing.Hashable
 RegTarget = numbers.Number
 ClfTarget = typing.Union[bool, str, int]  # noqa: UP007
 Target = typing.Union[ClfTarget, RegTarget]  # noqa: UP007
-Dataset = typing.Iterable[typing.Tuple[dict, typing.Any]]  # noqa: UP006
-Stream = typing.Iterator[typing.Tuple[dict, typing.Any]]  # noqa: UP006
+Dataset = typing.Iterable[typing.Tuple[dict[FeatureName, typing.Any], typing.Any]]  # noqa: UP006
+Stream = typing.Iterator[typing.Tuple[dict[FeatureName, typing.Any], typing.Any]]  # noqa: UP006

--- a/river/base/typing.py
+++ b/river/base/typing.py
@@ -8,3 +8,13 @@ ClfTarget = typing.Union[bool, str, int]  # noqa: UP007
 Target = typing.Union[ClfTarget, RegTarget]  # noqa: UP007
 Dataset = typing.Iterable[typing.Tuple[dict[FeatureName, typing.Any], typing.Any]]  # noqa: UP006
 Stream = typing.Iterator[typing.Tuple[dict[FeatureName, typing.Any], typing.Any]]  # noqa: UP006
+
+
+# These classes aim to provide the first blocks towards using protocols.
+# They should be modified if needed.
+class Learner(typing.Protocol):
+    def learn_one(self, x: dict[FeatureName, typing.Any], y: Target) -> None: ...
+
+
+class Predictor(Learner, typing.Protocol):
+    def predict_one(self, x: dict[FeatureName, typing.Any]) -> Target: ...

--- a/river/base/typing.py
+++ b/river/base/typing.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import numbers
 import typing
 
 FeatureName = typing.Hashable
-RegTarget = numbers.Number
+RegTarget = float
 ClfTarget = typing.Union[bool, str, int]  # noqa: UP007
 Target = typing.Union[ClfTarget, RegTarget]  # noqa: UP007
 Dataset = typing.Iterable[typing.Tuple[dict[FeatureName, typing.Any], typing.Any]]  # noqa: UP006

--- a/river/base/viz.py
+++ b/river/base/viz.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-# This import is not cyclic because 'viz' is not exported by 'base'
-from river import base, compose
-
 import inspect
 import textwrap
 from xml.etree import ElementTree as ET
+
+# This import is not cyclic because 'viz' is not exported by 'base'
+from river import base, compose
 
 
 def to_html(obj: base.Estimator) -> ET.Element:

--- a/river/base/viz.py
+++ b/river/base/viz.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
+# This import is not cyclic because 'viz' is not exported by 'base'
+from river import base, compose
+
 import inspect
 import textwrap
 from xml.etree import ElementTree as ET
 
 
-def to_html(obj) -> ET.Element:
-    from river import base, compose
-
+def to_html(obj: base.Estimator) -> ET.Element:
     if isinstance(obj, compose.Pipeline):
         return pipeline_to_html(obj)
     if isinstance(obj, compose.TransformerUnion):
@@ -17,9 +18,7 @@ def to_html(obj) -> ET.Element:
     return estimator_to_html(obj)
 
 
-def estimator_to_html(estimator) -> ET.Element:
-    from river import compose
-
+def estimator_to_html(estimator: base.Estimator) -> ET.Element:
     details = ET.Element("details", attrib={"class": "river-component river-estimator"})
 
     summary = ET.Element("summary", attrib={"class": "river-summary"})
@@ -45,7 +44,7 @@ def estimator_to_html(estimator) -> ET.Element:
     return details
 
 
-def pipeline_to_html(pipeline) -> ET.Element:
+def pipeline_to_html(pipeline: compose.Pipeline) -> ET.Element:
     div = ET.Element("div", attrib={"class": "river-component river-pipeline"})
 
     for step in pipeline.steps.values():
@@ -54,7 +53,7 @@ def pipeline_to_html(pipeline) -> ET.Element:
     return div
 
 
-def union_to_html(union) -> ET.Element:
+def union_to_html(union: compose.TransformerUnion) -> ET.Element:
     div = ET.Element("div", attrib={"class": "river-component river-union"})
 
     for transformer in union.transformers.values():
@@ -63,7 +62,7 @@ def union_to_html(union) -> ET.Element:
     return div
 
 
-def wrapper_to_html(wrapper) -> ET.Element:
+def wrapper_to_html(wrapper: base.Wrapper) -> ET.Element:
     div = ET.Element("div", attrib={"class": "river-component river-wrapper"})
 
     details = ET.Element("details", attrib={"class": "river-details"})

--- a/river/base/viz.py
+++ b/river/base/viz.py
@@ -62,7 +62,7 @@ def union_to_html(union: compose.TransformerUnion) -> ET.Element:
     return div
 
 
-def wrapper_to_html(wrapper: base.Wrapper) -> ET.Element:
+def wrapper_to_html(wrapper: base.Wrapper[base.Estimator]) -> ET.Element:
     div = ET.Element("div", attrib={"class": "river-component river-wrapper"})
 
     details = ET.Element("details", attrib={"class": "river-details"})

--- a/river/base/wrapper.py
+++ b/river/base/wrapper.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from river import base
 
 
 class Wrapper(ABC):
@@ -8,7 +9,7 @@ class Wrapper(ABC):
 
     @property
     @abstractmethod
-    def _wrapped_model(self):
+    def _wrapped_model(self) -> base.Estimator:
         """Provides access to the wrapped model."""
 
     @property
@@ -19,13 +20,13 @@ class Wrapper(ABC):
     def __str__(self) -> str:
         return f"{type(self).__name__}({self._wrapped_model})"
 
-    def _more_tags(self):
+    def _more_tags(self) -> set[str]:
         return self._wrapped_model._tags
 
     @property
-    def _supervised(self):
+    def _supervised(self) -> bool:
         return self._wrapped_model._supervised
 
     @property
-    def _multiclass(self):
+    def _multiclass(self) -> bool:
         return self._wrapped_model._multiclass

--- a/river/base/wrapper.py
+++ b/river/base/wrapper.py
@@ -12,11 +12,11 @@ class Wrapper(ABC):
         """Provides access to the wrapped model."""
 
     @property
-    def _labelloc(self):
+    def _labelloc(self) -> str:
         """Indicates location of the wrapper name when drawing pipelines."""
         return "t"  # for top
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{type(self).__name__}({self._wrapped_model})"
 
     def _more_tags(self):

--- a/river/base/wrapper.py
+++ b/river/base/wrapper.py
@@ -1,15 +1,21 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Generic, TypeVar
+
 from river import base
 
+from .estimator import Estimator  # Prevent a circular import of module base
 
-class Wrapper(ABC):
+T = TypeVar("T", bound=Estimator)
+
+
+class Wrapper(ABC, Generic[T]):
     """A wrapper model."""
 
     @property
     @abstractmethod
-    def _wrapped_model(self) -> base.Estimator:
+    def _wrapped_model(self) -> T:
         """Provides access to the wrapped model."""
 
     @property

--- a/river/base/wrapper.py
+++ b/river/base/wrapper.py
@@ -29,4 +29,4 @@ class Wrapper(ABC):
 
     @property
     def _multiclass(self) -> bool:
-        return self._wrapped_model._multiclass
+        return isinstance(self._wrapped_model, base.Classifier) and self._wrapped_model._multiclass

--- a/river/compose/grouper.py
+++ b/river/compose/grouper.py
@@ -28,7 +28,7 @@ class Grouper(base.Transformer):
 
     def __init__(
         self,
-        transformer: base.Transformer,
+        transformer: base.BaseTransformer,
         by: base.typing.FeatureName | list[base.typing.FeatureName],
     ):
         self.transformer = transformer

--- a/river/compose/pipeline.py
+++ b/river/compose/pipeline.py
@@ -274,7 +274,7 @@ class Pipeline(base.Estimator):
 
     _LEARN_UNSUPERVISED_DURING_PREDICT = False
 
-    def __init__(self, *steps):
+    def __init__(self, *steps) -> None:
         self.steps = collections.OrderedDict()
         for step in steps:
             self |= step
@@ -289,12 +289,12 @@ class Pipeline(base.Estimator):
         """Just for convenience."""
         return len(self.steps)
 
-    def __or__(self, other):
+    def __or__(self, other) -> Pipeline:
         """Insert a step at the end of the pipeline."""
         self._add_step(other, at_start=False)
         return self
 
-    def __ror__(self, other):
+    def __ror__(self, other) -> Pipeline:
         """Insert a step at the start of the pipeline."""
         self._add_step(other, at_start=True)
         return self

--- a/river/compose/pipeline.py
+++ b/river/compose/pipeline.py
@@ -275,7 +275,7 @@ class Pipeline(base.Estimator):
     _LEARN_UNSUPERVISED_DURING_PREDICT = False
 
     def __init__(self, *steps) -> None:
-        self.steps = collections.OrderedDict()
+        self.steps: collections.OrderedDict = collections.OrderedDict()
         for step in steps:
             self |= step
 

--- a/river/compose/select.py
+++ b/river/compose/select.py
@@ -42,7 +42,7 @@ class Discard(base.Transformer):
 
     """
 
-    def __init__(self, *keys: tuple[base.typing.FeatureName]):
+    def __init__(self, *keys: base.typing.FeatureName):
         self.keys = set(keys)
 
     def transform_one(self, x):
@@ -124,7 +124,7 @@ class Select(base.MiniBatchTransformer):
 
     """
 
-    def __init__(self, *keys: tuple[base.typing.FeatureName]):
+    def __init__(self, *keys: base.typing.FeatureName):
         self.keys = set(keys)
 
     def transform_one(self, x):
@@ -173,7 +173,7 @@ class SelectType(base.Transformer):
 
     """
 
-    def __init__(self, *types: tuple[type]):
+    def __init__(self, *types: type):
         self.types = types
 
     def transform_one(self, x):

--- a/river/compose/union.py
+++ b/river/compose/union.py
@@ -156,7 +156,7 @@ class TransformerUnion(base.MiniBatchTransformer):
 
     """
 
-    def __init__(self, *transformers):
+    def __init__(self, *transformers) -> None:
         self.transformers = {}
         for transformer in transformers:
             if transformer.__class__ == self.__class__:

--- a/river/compose/union.py
+++ b/river/compose/union.py
@@ -157,7 +157,7 @@ class TransformerUnion(base.MiniBatchTransformer):
     """
 
     def __init__(self, *transformers) -> None:
-        self.transformers = {}
+        self.transformers: dict = {}
         for transformer in transformers:
             if transformer.__class__ == self.__class__:
                 for t in transformer:

--- a/river/datasets/phishing.py
+++ b/river/datasets/phishing.py
@@ -16,7 +16,7 @@ class Phishing(base.FileDataset):
 
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             n_samples=1_250,
             n_features=9,

--- a/river/ensemble/streaming_random_patches.py
+++ b/river/ensemble/streaming_random_patches.py
@@ -543,7 +543,7 @@ class BaseSRPClassifier(BaseSRPEstimator):
 
         # TODO Find a way to verify if the model natively supports sample_weight (w)
         for _ in range(int(w)):
-            self.model.learn_one(x=x_subset, y=y, **kwargs)
+            self.model.learn_one(x=x_subset, y=y, **kwargs)  # type: ignore[attr-defined]
 
         if self._background_learner:
             # Train the background learner
@@ -557,7 +557,7 @@ class BaseSRPClassifier(BaseSRPEstimator):
             )
 
         if not self.disable_drift_detector and not self.is_background_learner:
-            correctly_classifies = self.model.predict_one(x_subset) == y
+            correctly_classifies = self.model.predict_one(x_subset) == y  # type: ignore[attr-defined]
             # Check for warnings only if the background learner is active
             if not self.disable_background_learner:
                 # Update the warning detection method
@@ -845,10 +845,10 @@ class BaseSRPRegressor(BaseSRPEstimator):
 
         # TODO Find a way to verify if the model natively supports sample_weight (w)
         for _ in range(int(w)):
-            self.model.learn_one(x=x_subset, y=y, **kwargs)
+            self.model.learn_one(x=x_subset, y=y, **kwargs)  # type: ignore[attr-defined]
 
         # Drift detection input
-        y_pred = self.model.predict_one(x_subset)
+        y_pred = self.model.predict_one(x_subset)  # type: ignore[attr-defined]
         if self.drift_detection_criteria == "error":
             # Track absolute error
             drift_detector_input = abs(y_pred - y)

--- a/river/forest/adaptive_random_forest.py
+++ b/river/forest/adaptive_random_forest.py
@@ -159,7 +159,7 @@ class BaseForest(base.Ensemble):
 
             # Update performance evaluator
             self._metrics[i].update(
-                y_true=y,
+                y_true=y,  # type:ignore[arg-type]
                 y_pred=(
                     model.predict_proba_one(x)
                     if isinstance(self.metric, metrics.base.ClassificationMetric)

--- a/river/forest/adaptive_random_forest.py
+++ b/river/forest/adaptive_random_forest.py
@@ -663,7 +663,9 @@ class ARFClassifier(BaseForest, base.Classifier):
     def _multiclass(self):
         return True
 
-    def predict_proba_one(self, x: dict, **kwargs: typing.Any) -> dict[base.typing.ClfTarget, float]:
+    def predict_proba_one(
+        self, x: dict, **kwargs: typing.Any
+    ) -> dict[base.typing.ClfTarget, float]:
         y_pred: typing.Counter = collections.Counter()
 
         if len(self) == 0:

--- a/river/forest/adaptive_random_forest.py
+++ b/river/forest/adaptive_random_forest.py
@@ -663,7 +663,7 @@ class ARFClassifier(BaseForest, base.Classifier):
     def _multiclass(self):
         return True
 
-    def predict_proba_one(self, x: dict) -> dict[base.typing.ClfTarget, float]:
+    def predict_proba_one(self, x: dict, **kwargs: typing.Any) -> dict[base.typing.ClfTarget, float]:
         y_pred: typing.Counter = collections.Counter()
 
         if len(self) == 0:

--- a/river/metrics/base.py
+++ b/river/metrics/base.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import abc
 import collections
-import numbers
 import operator
 
 from river import base, stats, utils
@@ -190,11 +189,11 @@ class RegressionMetric(Metric):
     _fmt = ",.6f"  # use commas to separate big numbers and show 6 decimals
 
     @abc.abstractmethod
-    def update(self, y_true: numbers.Number, y_pred: numbers.Number) -> None:
+    def update(self, y_true: float, y_pred: float) -> None:
         """Update the metric."""
 
     @abc.abstractmethod
-    def revert(self, y_true: numbers.Number, y_pred: numbers.Number) -> None:
+    def revert(self, y_true: float, y_pred: float) -> None:
         """Revert the metric."""
 
     @property

--- a/river/multioutput/chain.py
+++ b/river/multioutput/chain.py
@@ -34,7 +34,7 @@ class BaseChain(base.Wrapper, collections.UserDict):
             return self[key]
 
 
-class ClassifierChain(BaseChain, base.MultiLabelClassifier):
+class ClassifierChain(BaseChain, base.MultiLabelClassifier):  # type:ignore[misc]
     """A multi-output model that arranges classifiers into a chain.
 
     This will create one model per output. The prediction of the first output will be used as a
@@ -165,7 +165,7 @@ class ClassifierChain(BaseChain, base.MultiLabelClassifier):
         return y_pred
 
 
-class RegressorChain(BaseChain, base.MultiTargetRegressor):
+class RegressorChain(BaseChain, base.MultiTargetRegressor):  # type:ignore[misc]
     """A multi-output model that arranges regressors into a chain.
 
     This will create one model per output. The prediction of the first output will be used as a

--- a/river/optim/adam.py
+++ b/river/optim/adam.py
@@ -51,7 +51,7 @@ class Adam(optim.base.Optimizer):
 
     """
 
-    def __init__(self, lr=0.1, beta_1=0.9, beta_2=0.999, eps=1e-8):
+    def __init__(self, lr=0.1, beta_1=0.9, beta_2=0.999, eps=1e-8) -> None:
         super().__init__(lr)
         self.beta_1 = beta_1
         self.beta_2 = beta_2

--- a/river/optim/sgd.py
+++ b/river/optim/sgd.py
@@ -39,7 +39,7 @@ class SGD(optim.base.Optimizer):
 
     """
 
-    def __init__(self, lr=0.01):
+    def __init__(self, lr=0.01) -> None:
         super().__init__(lr)
 
     def _step_with_dict(self, w, g):

--- a/river/preprocessing/scale.py
+++ b/river/preprocessing/scale.py
@@ -154,9 +154,9 @@ class StandardScaler(base.MiniBatchTransformer):
 
     def __init__(self, with_std=True) -> None:
         self.with_std = with_std
-        self.counts = collections.Counter()
-        self.means = collections.defaultdict(float)
-        self.vars = collections.defaultdict(float)
+        self.counts: collections.Counter = collections.Counter()
+        self.means: collections.defaultdict = collections.defaultdict(float)
+        self.vars: collections.defaultdict = collections.defaultdict(float)
 
     def learn_one(self, x):
         for i, xi in x.items():

--- a/river/preprocessing/scale.py
+++ b/river/preprocessing/scale.py
@@ -152,7 +152,7 @@ class StandardScaler(base.MiniBatchTransformer):
 
     """
 
-    def __init__(self, with_std=True):
+    def __init__(self, with_std=True) -> None:
         self.with_std = with_std
         self.counts = collections.Counter()
         self.means = collections.defaultdict(float)

--- a/river/rules/amrules.py
+++ b/river/rules/amrules.py
@@ -334,6 +334,7 @@ class AMRules(base.Regressor):
         return self._n_drifts_detected
 
     def _new_rule(self) -> RegRule:
+        predictor: base.Regressor
         if self.pred_type == self._PRED_MEAN:
             predictor = MeanRegressor()
         elif self.pred_type == self._PRED_MODEL:

--- a/river/stats/var.py
+++ b/river/stats/var.py
@@ -70,7 +70,7 @@ class Var(stats.base.Univariate):
 
     """
 
-    def __init__(self, ddof=1):
+    def __init__(self, ddof=1) -> None:
         self.ddof = ddof
         self.mean = stats.Mean()
         self._S = 0
@@ -79,7 +79,7 @@ class Var(stats.base.Univariate):
     def n(self):
         return self.mean.n
 
-    def update(self, x, w=1.0):
+    def update(self, x, w=1.0) -> None:
         mean_old = self.mean.get()
         self.mean.update(x, w)
         mean_new = self.mean.get()

--- a/river/stream/iter_sql.py
+++ b/river/stream/iter_sql.py
@@ -102,4 +102,4 @@ def iter_sql(
     for row in result_proxy:
         x = dict(row._mapping.items())
         y = x.pop(target_name)
-        yield x, y # type: ignore[misc]
+        yield x, y  # type: ignore[misc]

--- a/river/stream/iter_sql.py
+++ b/river/stream/iter_sql.py
@@ -102,4 +102,4 @@ def iter_sql(
     for row in result_proxy:
         x = dict(row._mapping.items())
         y = x.pop(target_name)
-        yield x, y
+        yield x, y # type: ignore[misc]

--- a/river/time_series/snarimax.py
+++ b/river/time_series/snarimax.py
@@ -4,7 +4,7 @@ import collections
 import itertools
 import math
 
-from river import base, linear_model, preprocessing, time_series
+from river import base, linear_model, preprocessing, time_series, compose
 
 __all__ = ["SNARIMAX"]
 
@@ -280,7 +280,7 @@ class SNARIMAX(time_series.base.Forecaster):
         sp: int = 0,
         sd: int = 0,
         sq: int = 0,
-        regressor: base.Regressor | None = None,
+        regressor: base.Regressor | compose.Pipeline | None = None,
     ):
         self.p = p
         self.d = d

--- a/river/time_series/snarimax.py
+++ b/river/time_series/snarimax.py
@@ -4,7 +4,7 @@ import collections
 import itertools
 import math
 
-from river import base, linear_model, preprocessing, time_series, compose
+from river import base, compose, linear_model, preprocessing, time_series
 
 __all__ = ["SNARIMAX"]
 

--- a/river/tree/stochastic_gradient_tree.py
+++ b/river/tree/stochastic_gradient_tree.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import sys
+from typing import Any
 
 from scipy.stats import f as f_dist
 
@@ -291,7 +292,7 @@ class SGTClassifier(StochasticGradientTree, base.Classifier):
     def _target_transform(self, y):
         return float(y)
 
-    def predict_proba_one(self, x: dict) -> dict[base.typing.ClfTarget, float]:
+    def predict_proba_one(self, x: dict, **kwargs: Any) -> dict[base.typing.ClfTarget, float]:
         if isinstance(self._root, DTBranch):
             leaf = self._root.traverse(x, until_leaf=True)
         else:

--- a/river/utils/pretty.py
+++ b/river/utils/pretty.py
@@ -56,7 +56,7 @@ def print_table(
     return table
 
 
-def humanize_bytes(n_bytes: int):
+def humanize_bytes(n_bytes: int) -> str:
     """Returns a human-friendly byte size.
 
     Parameters


### PR DESCRIPTION
<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->

Continuing #1592, this PR adds type hints for the `base`module.

I am not entirely familiar with the code, so we may have things to adjust. Hence, I start with a draft.

Because the PR is quite big, I tried to have clean commits, you can use them to help the review.

Notable changes:
- I changed the regression target to float, because Python's type pyramid recommends not to use the `numbers` module for type annotations. And MyPy doesn't support it anyway.
   Also, `numers.Number` also includes complex numbers, but I am confident saying all the code expects floats. Integers are converted automatically to floats if needed.
- Where transformers are used, the annotation is now `BaseTransformer` to allow all transformers, not just the supervised ones.

~~A few things I would like to discuss before leaving the "draft" status:~~ (These items are addressed now.)
- [x] ~~The Estimator Problem: many functions expect a generic model that has the `predict_*` and `learn_*` methods, but there is no single type representing this capability.~~
   ~~I tagged them as requiring an `Estimator`, but this is not satisfactory.~~
   ~~Should we:~~
    - ~~Enumerate all possible types every time (`Classifier`, `Regressor`, `Clusterer`, `Pipeline`)~~
    - ~~Create a Protocol (a Python interface) for models that can learn, predict, and do both~~
    - ~~Create a new abstract class that introduces `learn_*` and `predict_*`~~
- [X] ~~The `Ensemble` class inherits from `UserList`. Because it is an implementation of the list type, it is mutable, leading it to be type-invariant. Since `Ensemble` is now typed with `Estimator`, all models are bare estimators. An ensemble of Hoeffding trees would not be able to access the HT-specific methods (even things like `learn_one`!) without violating the typing -- runtime behaviour is not impacted, Python is dynamic.~~

