### PR TITLE
Add a stricter test for feature elimination

### DIFF
--- a/river/checks/__init__.py
+++ b/river/checks/__init__.py
@@ -145,6 +145,7 @@ def yield_checks(model: Estimator) -> typing.Iterator[typing.Callable]:
         common.check_shuffle_features_no_impact,
         common.check_emerging_features,
         common.check_disappearing_features,
+        common.check_radically_disappearing_features,
     ]
 
     if hasattr(model, "debug_one"):

--- a/river/checks/common.py
+++ b/river/checks/common.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import inspect
+import itertools
 import pickle
 import random
 
@@ -105,6 +106,32 @@ def check_disappearing_features(model, dataset):
         else:
             model.predict_one({i: x[i] for i in features[:-3]})
             model.learn_one(x, y)
+
+
+def check_radically_disappearing_features(model, dataset):
+    """The model should work fine when nearly all features disappear."""
+
+    from river import utils
+
+    # First give all the data to prime the model
+    for x, y in itertools.islice(dataset, 20):
+        if utils.inspect.isanomalydetector(model):
+            model.score_one(x)
+            model.learn_one(x)
+        else:
+            model.predict_one(x)
+            model.learn_one(x, y)
+
+    # And suddenly remove almost everything
+    for x, y in itertools.islice(dataset, 10, None):
+        features = list(x.keys())
+        feat = random.choice(list(features))  # keep only 1 feature, at random
+        if utils.inspect.isanomalydetector(model):
+            model.score_one({feat: x[feat]})
+            model.learn_one({feat: x[feat]})
+        else:
+            model.predict_one({feat: x[feat]})
+            model.learn_one({feat: x[feat]}, y)
 
 
 def check_debug_one(model, dataset):

--- a/river/compat/sklearn_to_river.py
+++ b/river/compat/sklearn_to_river.py
@@ -63,6 +63,7 @@ class SKL2RiverBase:
         return {
             "check_emerging_features",
             "check_disappearing_features",
+            "check_radically_disappearing_features",
         }
 
 

--- a/river/ensemble/streaming_random_patches.py
+++ b/river/ensemble/streaming_random_patches.py
@@ -317,7 +317,9 @@ class BaseSRPEstimator:
 
 
 def random_subspace(all_features: list, k: int, rng: random.Random):
-    """Utility function to generate a random feature subspace of length k
+    """Utility function to generate a random feature subspace of length k.
+
+    If the number of features is smaller than k , the result is a shuffled version of the input list.
 
     Parameters
     ----------
@@ -328,7 +330,8 @@ def random_subspace(all_features: list, k: int, rng: random.Random):
     rng
         Random number generator (initialized).
     """
-    return rng.sample(all_features, k=k)
+    corrected_k = min(len(all_features), k)
+    return rng.sample(all_features, k=corrected_k)
 
 
 class SRPClassifier(BaseSRPEnsemble, base.Classifier):


### PR DESCRIPTION
<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->

This new test is similar to [the existing](https://github.com/online-ml/river/blob/d59f78881116180a788eee69c7a51e4fc91df6f7/river/checks/common.py#L94) `check_disappearing_features`, but tests the case where only one feature is left.

Such a situation can happen when one uses aggressive feature reduction preprocessing.

It tests for the case encountered in #1560, and discovered a similar problem in SRPClassifier (fixed in the PR).