### PR TITLE
Sync pre-commit's repo versions with Poetry

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.5.7
+    rev: v0.4.10
     hooks:
       # Run the linter.
       - id: ruff
@@ -19,7 +19,7 @@ repos:
         types_or: [python, pyi, jupyter]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.1.1"
+    rev: v1.13.0
     hooks:
       - id: mypy
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: check-yaml
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
+    # Ruff version, should be the same as in poetry.lock
     rev: v0.4.10
     hooks:
       # Run the linter.
@@ -19,6 +19,7 @@ repos:
         types_or: [python, pyi, jupyter]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
+    # MyPy version, should be the same as in poetry.lock
     rev: v1.13.0
     hooks:
       - id: mypy


### PR DESCRIPTION
The tool versions listed for pre-commit were different from the ones in `poetry.lock`, leading to different behaviour between a local invocation and from pre-commit.

In the case of MyPy, pre-commit's version was severely outdated, causing false positives and false negatives.

When River's dependencies are updated, pre-commit's configuration should be updated to have the same versions.

I realise now that this is one of the causes of #1665; but this PR does not solve the main problem of dependencies between files anyway.

<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->
