### PR TITLE
Remove max from the Kuiper statistic

### DIFF
--- a/river/stats/kolmogorov_smirnov.py
+++ b/river/stats/kolmogorov_smirnov.py
@@ -270,7 +270,7 @@ class KolmogorovSmirnov(stats.base.Bivariate):
         if self.statistic == "ks":
             return max(self.treap.max_value, -self.treap.min_value) / self.n_samples
         elif self.statistic == "kuiper":
-            return max(self.treap.max_value - self.treap.min_value) / self.n_samples
+            return (self.treap.max_value - self.treap.min_value) / self.n_samples
         else:
             raise ValueError(f"Unknown statistic {self.statistic}, expected one of: ks, kuiper")
 


### PR DESCRIPTION
The Kolmogorov-Smirnov implementation in River is based on [the code for a paper](https://github.com/denismr/incremental-ks), cited in the documentation.

This reference implementation of uses max() only for the Kolmogorov-Smirnov statistic; the [Kuiper statistic is the difference between the maximum and the minimum values](https://github.com/denismr/incremental-ks/blob/c6bc98833db67d9dc90a0f997a11877860966337/IncrementalKS/Pure%20Python/IKS.py#L55
).

In River (as of now), the Kuiper statistic [uses the maximum of the difference](https://github.com/online-ml/river/blob/9e2ceca900ba53f0ee710a6e69f972b05f74d43a/river/stats/kolmogorov_smirnov.py#L273), which doesn't make much sense (how do you take the maximum of a number?).

It looks like a copy-paste gone wrong.

This PR changes how the Kuiper statistic is computed to follow the reference implementation.

<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->
