### PR TITLE
Fix misspelt section name

### DIFF
--- a/river/bandit/bayes_ucb.py
+++ b/river/bandit/bayes_ucb.py
@@ -53,8 +53,8 @@ class BayesUCB(bandit.base.Policy):
     >>> metric
     Sum: 841.
 
-    Reference
-    ---------
+    References
+    ----------
     [^1]: [Kaufmann, Emilie, Olivier Cappé, and Aurélien Garivier. "On Bayesian upper confidence bounds for bandit problems." Artificial intelligence and statistics. PMLR, 2012.](http://proceedings.mlr.press/v22/kaufmann12/kaufmann12.pdf)
 
     """


### PR DESCRIPTION
The docstring parsing code [expects the section to be named “References”](https://github.com/online-ml/river/blob/be3e48ca901e8606d65774daf66a290048a6fc14/docs/parse/__main__.py#L463-L464). With the final _S_ missing, the references for `BayesUCB` were not included in the documentation.

For future reference, the bottom of BayesUCB's doc page currently looks like this:
![Current doc of BayesUCB](https://github.com/user-attachments/assets/ad64776d-7c2a-4e7a-b99a-0a1f4b86072e)

With the fix, it'll look like that:
![Doc with the fix](https://github.com/user-attachments/assets/235617d0-56bf-4e56-a14a-46469a19fd72)


<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->
