### PR TITLE
Update the contributing guidelines for docstrings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,6 @@ To build the documentation, you need to install some extra dependencies:
 
 ```sh
 poetry install --with docs
-pip install git+https://github.com/MaxHalford/yamp
 ```
 
 From the root of the repository, you can then run the `make livedoc` command to take a look at the documentation in your browser. This will run a custom script which parses all the docstrings and generate MarkDown files that [MkDocs](https://www.mkdocs.org/) can render.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ model = linear_model.LinearRegression()
 
 ## Documenting your change
 
-If you're adding a class or a function, then you'll need to add a docstring. We follow the [Google docstring convention](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html), so please do too.
+If you're adding a class or a function, then you'll need to add a docstring. We follow the [Numpy docstring convention](https://numpydoc.readthedocs.io/en/latest/format.html), so please do too.
 
 To build the documentation, you need to install some extra dependencies:
 


### PR DESCRIPTION
<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->

As @gbolmier indicated (https://github.com/online-ml/river/discussions/1699#discussioncomment-13812311), River now uses the NumPy-style docstrings everywhere, but the guidelines were still referencing the former convention.

This PR also removes mention of yamp: installing it is not necessary any more to build the docs, as the Markdown parser is now shipped with River (standalone yamp is deprecated).