### PR TITLE
Move changelog entry to unreleased section (#1700)

### DIFF
--- a/docs/releases/0.22.0.md
+++ b/docs/releases/0.22.0.md
@@ -31,6 +31,3 @@
 ## stream
 
 - `stream.iter_arff` now supports blank values (treated as missing values).
-
-## feature selection
-- `feature_selection.SelectKBest` now supports `use_abs` parameter for the absolute value of the score statistics.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -13,3 +13,7 @@
 ## neighbors
 
 - Remove the `itertools.cycle` usage from the `neighbors.ann.SWINN` search engine, as pickling `cycle` objects will not be supported anymore, starting from Python 3.14. This change has no effect from the user standpoint, as the 'cycle' usage was more of a gimmick than a necessity.
+
+## feature selection
+
+- `feature_selection.SelectKBest` now supports `use_abs` parameter for the absolute value of the score statistics.


### PR DESCRIPTION
- The entry  for `use_abs` parameter to `SelectKBest` was accidentally added to the v0.22.0 notes which are already published. 
- This moves it to the correct 'unreleased' file for the next version.