### PR TITLE
Fix the build in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,7 @@ requires = [
     "setuptools>=70.1.0",
     "setuptools-rust",
 ]
-build-backend = "setuptools.build_meta"
-
-[tool.setuptools]
-packages = ["river"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "river"


### PR DESCRIPTION
This reverts commit 6984c5c0e7663e919d60a5c17e35e4351d00df16.

Commit 6984c5c changed the build system to Setuptools instead of Poetry's own `poetry-core`.
Unfortunately, this change prevents River from being built and breaks CI 🙁.

River, with its C++ and Rust extensions, needs an external compilation step and is currently configured for poetry-core.
Using Setuptools could certainly be done, but it requires more configuration change than swapping the build system 😄.

I propose to restore the ability to build River with Poetry for the time being, and if the transition to Setuptools is wanted, that a follow-up PR can bring a more complete transition.

<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->
