### PR TITLE
Fix publishing to PyPI

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-14, macos-15]
+        os: [macos-15]
         python-version: ["311", "312", "313"]
     steps:
       - uses: actions/checkout@v4
@@ -78,7 +78,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-2022, windows-2025]
+        os: [windows-2025]
         python-version: ["311", "312", "313"]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->

I noticed that version 0.23 did not get pushed to PyPI, and that the `pypi` job kept failing because of a ZIP corruption issue (“zipfile.BadZipFile: Bad magic number for central directory”).

I believe the error encountered in the job is related to these bugs: https://github.com/pypa/gh-action-pypi-publish/issues/215 and https://github.com/actions/download-artifact/issues/298.

The bug is activated when two wheels with the same name are produced, creating conflicts and corrupting the files during the upload.
The workaround they propose is only use one version of the operating systems that cause duplicate wheels (macOS and Windows). Indeed, in River's case, two different versions of both macOS and Windows were used.

I verified the change on my side, and the upload to PyPI is now functional.

This PR also includes changes for the `cibuildwheel` frontend because `cibuildwheel` got upgraded to version 3 (commits 3aae1ff and a495b00), with breaking changes. Its default frontend changed from `pip` to `build`, and the latter fails to build River. Falling back to the previous default restore the ability to build.