### PR TITLE
Fix Mondrian Tree bounding box loss during branch splits

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -85,6 +85,8 @@ The `dummy` module is now fully type-annotated.
 
 ## tree
 
+- Fixed Mondrian Tree branch nodes losing bounding box ranges during splits. When a branch was split, the new child branch did not inherit `memory_range_min`/`memory_range_max`, causing incorrect range extension calculations. This affected both `MondrianTreeClassifier` and `MondrianTreeRegressor`, as well as their forest variants (`AMFClassifier`, `AMFRegressor`). Fixes [#1801](https://github.com/online-ml/river/issues/1801).
+- Changed the default `step` parameter for `MondrianTreeClassifier` and `MondrianTreeRegressor` from `0.1` to `1.0`, matching the onelearn reference implementation and the existing default in `AMFClassifier`/`AMFRegressor`.
 - Added `cond_log_proba` to `GaussianSplitter` and optimized `do_naive_bayes_prediction` to use direct log-probabilities, avoiding the `exp`/`log` round-trip.
 - Added handling for division by zero in `tree.hoeffding_tree` for leaf size estimation.
 - Optimized Mondrian trees and AMF (Aggregated Mondrian Forest): replaced dict-based node storage with list-indexed storage, added feature/class-to-index mappings, inlined all hot-path methods, and moved the core traversal loops (`_go_downwards`, `update_downwards`, `predict_proba` upward walk) to Cython. AMFClassifier is **3.2x faster**, AMFRegressor is **2.9x faster**.

--- a/river/forest/aggregated_mondrian_forest.py
+++ b/river/forest/aggregated_mondrian_forest.py
@@ -149,7 +149,7 @@ class AMFClassifier(AMFLearner, base.Classifier):
     >>> metric = metrics.Accuracy()
 
     >>> evaluate.progressive_val_score(dataset, model, metric)
-    Accuracy: 85.37%
+    Accuracy: 84.37%
 
     References
     ----------
@@ -278,7 +278,7 @@ class AMFRegressor(AMFLearner, base.Regressor):
     >>> metric = metrics.MAE()
 
     >>> evaluate.progressive_val_score(dataset, model, metric)
-    MAE: 0.2805
+    MAE: 0.279747
 
     References
     ----------

--- a/river/tree/mondrian/mondrian_tree.py
+++ b/river/tree/mondrian/mondrian_tree.py
@@ -33,7 +33,7 @@ class MondrianTree(abc.ABC):
 
     def __init__(
         self,
-        step: float = 0.1,
+        step: float = 1.0,
         loss: str = "log",
         use_aggregation: bool = True,
         iteration: int = 0,

--- a/river/tree/mondrian/mondrian_tree_classifier.py
+++ b/river/tree/mondrian/mondrian_tree_classifier.py
@@ -58,7 +58,7 @@ class MondrianTreeClassifier(MondrianTree, base.Classifier):
     >>> metric = metrics.Accuracy()
 
     >>> evaluate.progressive_val_score(dataset, model, metric)
-    Accuracy: 58.52%
+    Accuracy: 60.92%
 
     References
     ----------
@@ -69,7 +69,7 @@ class MondrianTreeClassifier(MondrianTree, base.Classifier):
 
     def __init__(
         self,
-        step: float = 0.1,
+        step: float = 1.0,
         use_aggregation: bool = True,
         dirichlet: float = 0.5,
         split_pure: bool = False,
@@ -160,7 +160,7 @@ class MondrianTreeClassifier(MondrianTree, base.Classifier):
                     node, split_time, new_depth, node.feature, node.threshold
                 )
                 right = MondrianLeafClassifier(node, split_time, new_depth)
-                left.replant(node)
+                left.replant(node, True)
 
                 old_left.parent = left
                 old_right.parent = left
@@ -171,7 +171,7 @@ class MondrianTreeClassifier(MondrianTree, base.Classifier):
                     node, split_time, new_depth, node.feature, node.threshold
                 )
                 left = MondrianLeafClassifier(node, split_time, new_depth)
-                right.replant(node)
+                right.replant(node, True)
 
                 old_left.parent = right
                 old_right.parent = right

--- a/river/tree/mondrian/mondrian_tree_regressor.py
+++ b/river/tree/mondrian/mondrian_tree_regressor.py
@@ -45,7 +45,7 @@ class MondrianTreeRegressor(MondrianTree, base.Regressor):
 
     def __init__(
         self,
-        step: float = 0.1,
+        step: float = 1.0,
         use_aggregation: bool = True,
         iteration: int = 0,
         max_nodes: int | None = None,
@@ -127,7 +127,7 @@ class MondrianTreeRegressor(MondrianTree, base.Regressor):
                     node, split_time, new_depth, node.feature, node.threshold
                 )
                 right = MondrianLeafRegressor(node, split_time, new_depth)
-                left.replant(node)
+                left.replant(node, True)
 
                 old_left.parent = left
                 old_right.parent = left
@@ -138,7 +138,7 @@ class MondrianTreeRegressor(MondrianTree, base.Regressor):
                     node, split_time, new_depth, node.feature, node.threshold
                 )
                 left = MondrianLeafRegressor(node, split_time, new_depth)
-                right.replant(node)
+                right.replant(node, True)
 
                 old_left.parent = right
                 old_right.parent = right


### PR DESCRIPTION
## Summary
- **Fix missing `copy_all=True`** in `replant()` calls when splitting branch nodes in both `MondrianTreeClassifier` and `MondrianTreeRegressor`. Without this, new child branches lost their `memory_range_min`/`memory_range_max`, causing `range_extension()` to compute against `defaultdict(int)` zeros instead of actual data bounds.
- **Change default `step` from 0.1 to 1.0** for `MondrianTreeClassifier` and `MondrianTreeRegressor`, matching the [onelearn reference implementation](https://github.com/onelearn/onelearn) and the existing `AMFClassifier`/`AMFRegressor` defaults.

Fixes #1801

## Verification

Confirmed the bug by tracing `replant()` calls — branch-to-branch splits were not copying ranges. Cross-referenced with [onelearn's `copy_node`](https://github.com/onelearn/onelearn), which explicitly copies `memory_range_min`/`memory_range_max` in the equivalent code path.