### PR TITLE
Remove rich, ipython, and ipykernel from dev dependencies Issue #1803

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -28,11 +28,6 @@ jobs:
         run: |
           uv pip install en_core_web_sm@https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
 
-      - name: Use Rich in notebooks
-        run: |
-          uv run ipython profile create
-          echo "%load_ext rich" > ~/.ipython/profile_default/startup/00_rich.ipy
-
       - name: Execute notebooks
         run: uv run make execute-notebooks
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,9 +38,6 @@ dev = [
     "sqlalchemy>=2.0.22,<3",
     "sympy>=1.12.1,<2",
     "pytest-xdist[psutil]>=3.3.1,<4",
-    "ipykernel>=6.26.0,<7",
-    "ipython>=8.17.2,<9",
-    "rich>=13.6.0,<14",
     "jupyter>=1.0.0,<2",
     "mike @ git+https://github.com/squidfunk/mike.git",
     "polars>=1.1.0,<2",
@@ -52,7 +49,6 @@ compat = [
 docs = [
     "dominate",
     "flask",
-    "ipykernel",
     "jupyter-client",
     "mike @ git+https://github.com/squidfunk/mike.git",
     "pygments<2.20",
@@ -95,9 +91,6 @@ scikit-learn = "^1.5.1"
 sqlalchemy = "^2.0.22"
 sympy = "^1.12.1"
 pytest-xdist = { extras = ["psutil"], version = "^3.3.1" }
-ipykernel = "^6.26.0"
-ipython = "^8.17.2"
-rich = "^13.6.0"
 jupyter = "^1.0.0"
 mike = { git = "https://github.com/squidfunk/mike.git" }
 polars = "^1.1.0"
@@ -115,7 +108,6 @@ optional = true
 [tool.poetry.group.docs.dependencies]
 "dominate" = "*"
 "flask" = "*"
-"ipykernel" = "*"
 "jupyter-client" = "*"
 "jupyter-contrib-nbextensions" = "^0.7.0"
 "mike" = { git = "https://github.com/squidfunk/mike.git" }
@@ -131,8 +123,6 @@ optional = true
 
 [tool.poetry.group.benchmark]
 optional = true
-
-
 
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -3213,8 +3213,6 @@ compat = [
 dev = [
     { name = "graphviz" },
     { name = "gymnasium" },
-    { name = "ipykernel" },
-    { name = "ipython" },
     { name = "jupyter" },
     { name = "matplotlib" },
     { name = "mike" },
@@ -3223,7 +3221,6 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-xdist", extra = ["psutil"] },
-    { name = "rich" },
     { name = "ruff" },
     { name = "scikit-learn" },
     { name = "sqlalchemy" },
@@ -3232,7 +3229,6 @@ dev = [
 docs = [
     { name = "dominate" },
     { name = "flask" },
-    { name = "ipykernel" },
     { name = "jupyter-client" },
     { name = "jupyter-contrib-nbextensions" },
     { name = "mike" },
@@ -3268,8 +3264,6 @@ compat = [
 dev = [
     { name = "graphviz", specifier = ">=0.20.1,<0.21" },
     { name = "gymnasium", specifier = ">=0.29.0,<0.30" },
-    { name = "ipykernel", specifier = ">=6.26.0,<7" },
-    { name = "ipython", specifier = ">=8.17.2,<9" },
     { name = "jupyter", specifier = ">=1.0.0,<2" },
     { name = "matplotlib", specifier = ">=3.8.4,<4" },
     { name = "mike", git = "https://github.com/squidfunk/mike.git" },
@@ -3278,7 +3272,6 @@ dev = [
     { name = "pre-commit", specifier = ">=3.5.0,<4" },
     { name = "pytest", specifier = ">=7.4.2,<8" },
     { name = "pytest-xdist", extras = ["psutil"], specifier = ">=3.3.1,<4" },
-    { name = "rich", specifier = ">=13.6.0,<14" },
     { name = "ruff", specifier = "~=0.15.8" },
     { name = "scikit-learn", specifier = ">=1.5.1,<2" },
     { name = "sqlalchemy", specifier = ">=2.0.22,<3" },
@@ -3287,7 +3280,6 @@ dev = [
 docs = [
     { name = "dominate" },
     { name = "flask" },
-    { name = "ipykernel" },
     { name = "jupyter-client" },
     { name = "jupyter-contrib-nbextensions", specifier = ">=0.7.0,<0.8" },
     { name = "mike", git = "https://github.com/squidfunk/mike.git" },


### PR DESCRIPTION
Hey 

Removed rich, ipython, and ipykernel from the development dependency groups in pyproject.toml. Regenerated uv.lock. 
Ran the full test suite locally: 3757 passed 44 skipped 54 deselected