### PR TITLE
fix: Add MANIFEST.in to include Cython + Rust sources

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+# Cython sources
+recursive-include river/ *.pyx *.c
+
+# Rust sources
+recursive-include rust_src/ *.rs
+include Cargo.toml Cargo.lock


### PR DESCRIPTION
The sdist of River 0.24.1 was missing Cython sources, Rust sources, and Rust's cargo configuration. The new `MANIFEST.in` file instructs setuptools to include the missing files in sdists.

See: #1813