### PR TITLE
docs: update Python version requirement to ≥3.11 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Of course, this is just a contrived example. We welcome you to check the [introd
 
 ## 🛠 Installation
 
-River is intended to work with **Python 3.10 and above**. Installation can be done with `pip`:
+River is intended to work with **Python 3.11 and above**. Installation can be done with `pip`:
 
 ```sh
 pip install river


### PR DESCRIPTION
Closes: https://github.com/online-ml/river/issues/1820

Updates the README to reflect that Python 3.10 is no longer supported, in line with pyproject.toml and the documentation.

<!--
READ ME!

Thanks for contributing to River!

If you're new to the project, then we encourage you to first [open a discussion](https://github.com/online-ml/river/discussions/new). This helps everyone save time by making sure we're all aligned on the contribution that is being made.

Have a great day.
-->
