### PR TITLE
Fix MondrianNodeClassifier.replant not copying counts (#1823)

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,5 @@
+# Unreleased
+
+## tree
+
+- Fixed `MondrianNodeClassifier.replant` not copying the `counts` attribute when promoting a leaf to a branch, leaving the new branch with `n_samples != 0` but empty class counts. The fix mirrors the regressor's `_mean` copy and matches the reference [`onelearn`](https://github.com/onelearn/onelearn) implementation. Addresses [#1823](https://github.com/online-ml/river/issues/1823).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3894,6 +3894,7 @@ nav:
     - examples/on-hoeffding-trees.md
   - FAQ: faq
   - Releases:
+    - unreleased: releases/unreleased.md
     - "0.24.2": releases/0.24.2.md
     - "0.24.1": releases/0.24.1.md
     - "0.24.0": releases/0.24.0.md

--- a/river/forest/aggregated_mondrian_forest.py
+++ b/river/forest/aggregated_mondrian_forest.py
@@ -149,7 +149,7 @@ class AMFClassifier(AMFLearner, base.Classifier):
     >>> metric = metrics.Accuracy()
 
     >>> evaluate.progressive_val_score(dataset, model, metric)
-    Accuracy: 84.37%
+    Accuracy: 84.57%
 
     References
     ----------

--- a/river/tree/mondrian/mondrian_tree_classifier.py
+++ b/river/tree/mondrian/mondrian_tree_classifier.py
@@ -58,7 +58,7 @@ class MondrianTreeClassifier(MondrianTree, base.Classifier):
     >>> metric = metrics.Accuracy()
 
     >>> evaluate.progressive_val_score(dataset, model, metric)
-    Accuracy: 60.92%
+    Accuracy: 76.15%
 
     References
     ----------

--- a/river/tree/mondrian/mondrian_tree_nodes.py
+++ b/river/tree/mondrian/mondrian_tree_nodes.py
@@ -155,6 +155,7 @@ class MondrianNodeClassifier(MondrianNode):
         """Transfer information from a leaf to a new branch."""
         self.weight = leaf.weight  # type: ignore
         self.log_weight_tree = leaf.log_weight_tree  # type: ignore
+        self.counts = leaf.counts.copy()
 
         if copy_all:
             self.memory_range_min = leaf.memory_range_min


### PR DESCRIPTION
## Summary

- Fixes [#1823](https://github.com/online-ml/river/issues/1823): `MondrianNodeClassifier.replant` did not copy the per-class `counts` list, so promoting a leaf to a branch left the new branch with `n_samples > 0` and empty counts.
- Aligns the classifier with the regressor (which already always copies `_mean`) and with the reference [`onelearn`](https://github.com/onelearn/onelearn) implementation (`copy_node_classifier` always copies `counts`).
- Updates the affected doctests to the corrected accuracy values.

## Comparison with onelearn

I verified the fix against the onelearn source: its base `copy_node` copies `n_samples`, `weight`, `log_weight_tree`, `memory_range_min/max`, etc., and `copy_node_classifier` *additionally* copies `counts`. River's regressor already mirrors this (`_mean` is always copied); the classifier was missing the equivalent line.

## Benchmark

Single-tree accuracy improves substantially; the AMF ensemble result barely moves because forest aggregation hides the per-tree bug.

| Benchmark | BUGGY | FIXED | Δ acc | Δ time |
|---|---|---|---|---|
| `MondrianTreeClassifier` on Phishing | 70.54% | **81.75%** | **+11.21pp** | +14.5% |
| `AMFClassifier(n=10)` on Phishing | 90.07% | 89.99% | -0.08pp | +18.3% |
| `AMFClassifier(n=10)` on Bananas | 88.87% | 89.24% | +0.38pp | +5.1% |
| `AMFClassifier(n=10)` on Elec2[:10k] | 85.20% | 82.90% | -2.30pp | +5.1% |

For reference, onelearn's `AMFClassifier(n_estimators=10, dirichlet=0.5, random_state=1)` on the same Phishing dataset gives **84.63%**. River's AMF differs from onelearn by ~5pp on this dataset both before and after this fix — that delta is unrelated to this bug and likely stems from other implementation differences (RNG, feature handling, etc.).

Time overhead is just the cost of `list.copy()` on each split — minimal in absolute terms.

## Test plan

- [x] `uv run pytest river/tree/mondrian/ river/forest/aggregated_mondrian_forest.py river/forest/test_amf.py` — all pass
- [x] Doctest expected outputs updated for `MondrianTreeClassifier` (60.92% → 76.15%) and `AMFClassifier` (84.37% → 84.57%)
- [x] Added entry to `docs/releases/unreleased.md` and re-added it to the Releases nav in `mkdocs.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)