### PR TITLE
stats: add ChiSquared statistic

### DIFF
--- a/river/stats/__init__.py
+++ b/river/stats/__init__.py
@@ -6,6 +6,7 @@ from . import base
 from .auto_corr import AutoCorr
 from .count import Count
 from .cov import Cov
+from .chi_squared import ChiSquared
 from .entropy import Entropy
 from .ewmean import EWMean
 from .ewvar import EWVar
@@ -34,6 +35,7 @@ __all__ = [
     "BayesianMean",
     "Count",
     "Cov",
+    "ChiSquared",
     "Entropy",
     "EWMean",
     "EWVar",

--- a/river/stats/__init__.py
+++ b/river/stats/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from . import base
 from .auto_corr import AutoCorr
-from .chi_squared import ChiSquared
+from .chi_squared import ChiSquared, RollingChiSquared
 from .count import Count
 from .cov import Cov
 from .entropy import Entropy
@@ -36,6 +36,7 @@ __all__ = [
     "Count",
     "Cov",
     "ChiSquared",
+    "RollingChiSquared",
     "Entropy",
     "EWMean",
     "EWVar",

--- a/river/stats/__init__.py
+++ b/river/stats/__init__.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from . import base
 from .auto_corr import AutoCorr
+from .chi_squared import ChiSquared
 from .count import Count
 from .cov import Cov
-from .chi_squared import ChiSquared
 from .entropy import Entropy
 from .ewmean import EWMean
 from .ewvar import EWVar

--- a/river/stats/base.py
+++ b/river/stats/base.py
@@ -70,3 +70,16 @@ class Bivariate(Statistic):
     @abc.abstractmethod
     def update(self, x, y) -> None:
         """Update the called instance."""
+
+
+class RollingBivariate(Bivariate):
+    """A rolling bivariate statistic measures a relationship between two variables over a window."""
+
+    @property
+    @abc.abstractmethod
+    def window_size(self):
+        pass
+
+    @property
+    def name(self):
+        return f"{self.__class__.__name__.lower()}_{self.window_size}"

--- a/river/stats/chi_squared.py
+++ b/river/stats/chi_squared.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import collections
+import math
+
+from river import stats
+
+
+class ChiSquared(stats.base.Bivariate):
+    """Streaming Chi-squared statistic.
+
+    Maintains a contingency table between feature values (x) and classes (y)
+    and computes the Chi-squared statistic incrementally.
+
+    This can be used to measure the dependency between a categorical feature
+    and a target variable in a streaming setting.
+
+    Examples
+    --------
+    >>> from river import stats
+
+    >>> chi = stats.ChiSquared()
+
+    >>> data = [
+    ...     ("A", 0),
+    ...     ("A", 0),
+    ...     ("B", 1),
+    ...     ("B", 1),
+    ... ]
+
+    >>> for x, y in data:
+    ...     chi.update(x, y)
+
+    >>> round(chi.get(), 3)
+    4.0
+    """
+
+    def __init__(self):
+        # counts[value][class] = frequency
+        self.counts = collections.defaultdict(collections.Counter)
+
+        # total counts per class
+        self.class_totals = collections.Counter()
+
+        # total counts per feature value
+        self.value_totals = collections.Counter()
+
+        # total observations
+        self.n = 0
+
+    @property
+    def name(self):
+        return "chi_squared"
+
+    def update(self, x, y):
+        """Update the statistic with a new observation.
+
+        Parameters
+        ----------
+        x
+            Feature value (categorical).
+        y
+            Target class.
+        """
+        self.counts[x][y] += 1
+        self.class_totals[y] += 1
+        self.value_totals[x] += 1
+        self.n += 1
+
+    def get(self):
+        """Return the current Chi-squared statistic."""
+        if self.n == 0:
+            return 0.0
+
+        chi2 = 0.0
+
+        # Iterate over contingency table
+        for x in self.counts:
+            for y in self.class_totals:
+
+                observed = self.counts[x].get(y, 0)
+
+                expected = (
+                    self.value_totals[x] * self.class_totals[y]
+                ) / self.n
+
+                if expected > 0:
+                    chi2 += (observed - expected) ** 2 / expected
+
+        return chi2
+
+    

--- a/river/stats/chi_squared.py
+++ b/river/stats/chi_squared.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import collections
+import typing
 
 from river import stats, utils
 
@@ -41,24 +42,26 @@ class ChiSquared(stats.base.Bivariate):
 
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         # counts[value][class] = frequency
-        self.counts = collections.defaultdict(collections.Counter)
+        self.counts: collections.defaultdict[typing.Any, collections.Counter] = (
+            collections.defaultdict(collections.Counter)
+        )
 
         # total counts per class
-        self.class_totals = collections.Counter()
+        self.class_totals: collections.Counter = collections.Counter()
 
         # total counts per feature value
-        self.value_totals = collections.Counter()
+        self.value_totals: collections.Counter = collections.Counter()
 
         # total observations
         self.n = 0
 
     @property
-    def name(self):
+    def name(self) -> str:
         return "chi_squared"
 
-    def update(self, x, y):
+    def update(self, x: typing.Any, y: typing.Any) -> None:
         """Update the statistic with a new observation.
 
         Parameters
@@ -73,7 +76,7 @@ class ChiSquared(stats.base.Bivariate):
         self.value_totals[x] += 1
         self.n += 1
 
-    def revert(self, x, y):
+    def revert(self, x: typing.Any, y: typing.Any) -> None:
         """Revert the statistic with a new observation.
 
         Parameters
@@ -100,7 +103,7 @@ class ChiSquared(stats.base.Bivariate):
         self.n -= 1
 
     @property
-    def degrees_of_freedom(self):
+    def degrees_of_freedom(self) -> int:
         """Return the degrees of freedom of the contingency table."""
         r = len(self.value_totals)
         c = len(self.class_totals)
@@ -109,7 +112,7 @@ class ChiSquared(stats.base.Bivariate):
         return (r - 1) * (c - 1)
 
     @property
-    def p_value(self):
+    def p_value(self) -> float:
         """Return the p-value associated with the Chi-squared statistic."""
         import scipy.stats
 
@@ -118,11 +121,11 @@ class ChiSquared(stats.base.Bivariate):
             return 1.0
         return float(scipy.stats.chi2.sf(self.get(), df))
 
-    def is_significant(self, alpha=0.05):
+    def is_significant(self, alpha: float = 0.05) -> bool:
         """Return whether the test is significant at a given alpha level."""
         return bool(self.p_value < alpha)
 
-    def get(self):
+    def get(self) -> float:
         """Return the current Chi-squared statistic."""
         if self.n == 0:
             return 0.0
@@ -177,26 +180,26 @@ class RollingChiSquared(stats.base.RollingBivariate, utils.Rolling):
 
     """
 
-    def __init__(self, window_size: int):
+    def __init__(self, window_size: int) -> None:
         utils.Rolling.__init__(self, obj=ChiSquared(), window_size=window_size)
 
-    def update(self, x, y):
+    def update(self, x: typing.Any, y: typing.Any) -> None:
         utils.Rolling.update(self, x, y)
 
-    def get(self):
-        return self.obj.get()
+    def get(self) -> float:
+        return typing.cast(ChiSquared, self.obj).get()
 
     @property
-    def window_size(self):
+    def window_size(self) -> int:
         return self._window_size
 
     @property
-    def p_value(self):
-        return self.obj.p_value
+    def p_value(self) -> float:
+        return typing.cast(ChiSquared, self.obj).p_value
 
     @property
-    def degrees_of_freedom(self):
-        return self.obj.degrees_of_freedom
+    def degrees_of_freedom(self) -> int:
+        return typing.cast(ChiSquared, self.obj).degrees_of_freedom
 
-    def is_significant(self, alpha=0.05):
-        return self.obj.is_significant(alpha)
+    def is_significant(self, alpha: float = 0.05) -> bool:
+        return typing.cast(ChiSquared, self.obj).is_significant(alpha)

--- a/river/stats/chi_squared.py
+++ b/river/stats/chi_squared.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import collections
-import math
+# import math
 
 from river import stats
 

--- a/river/stats/chi_squared.py
+++ b/river/stats/chi_squared.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import collections
 
-# import math
-from river import stats
+from river import stats, utils
 
 
 class ChiSquared(stats.base.Bivariate):
@@ -33,6 +32,13 @@ class ChiSquared(stats.base.Bivariate):
 
     >>> round(chi.get(), 3)
     4.0
+
+    >>> print(round(chi.p_value, 3))
+    0.046
+
+    >>> chi.is_significant(alpha=0.05)
+    True
+
     """
 
     def __init__(self):
@@ -67,6 +73,55 @@ class ChiSquared(stats.base.Bivariate):
         self.value_totals[x] += 1
         self.n += 1
 
+    def revert(self, x, y):
+        """Revert the statistic with a new observation.
+
+        Parameters
+        ----------
+        x
+            Feature value (categorical).
+        y
+            Target class.
+        """
+        self.counts[x][y] -= 1
+        if self.counts[x][y] <= 0:
+            del self.counts[x][y]
+        if not self.counts[x]:
+            del self.counts[x]
+
+        self.class_totals[y] -= 1
+        if self.class_totals[y] <= 0:
+            del self.class_totals[y]
+
+        self.value_totals[x] -= 1
+        if self.value_totals[x] <= 0:
+            del self.value_totals[x]
+
+        self.n -= 1
+
+    @property
+    def degrees_of_freedom(self):
+        """Return the degrees of freedom of the contingency table."""
+        r = len(self.value_totals)
+        c = len(self.class_totals)
+        if r <= 1 or c <= 1:
+            return 0
+        return (r - 1) * (c - 1)
+
+    @property
+    def p_value(self):
+        """Return the p-value associated with the Chi-squared statistic."""
+        import scipy.stats
+
+        df = self.degrees_of_freedom
+        if df <= 0:
+            return 1.0
+        return float(scipy.stats.chi2.sf(self.get(), df))
+
+    def is_significant(self, alpha=0.05):
+        """Return whether the test is significant at a given alpha level."""
+        return bool(self.p_value < alpha)
+
     def get(self):
         """Return the current Chi-squared statistic."""
         if self.n == 0:
@@ -78,10 +133,70 @@ class ChiSquared(stats.base.Bivariate):
         for x in self.counts:
             for y in self.class_totals:
                 observed = self.counts[x].get(y, 0)
-
                 expected = (self.value_totals[x] * self.class_totals[y]) / self.n
-
                 if expected > 0:
                     chi2 += (observed - expected) ** 2 / expected
 
         return chi2
+
+
+class RollingChiSquared(stats.base.RollingBivariate, utils.Rolling):
+    """Running Chi-squared statistic over a window.
+
+    Maintains a contingency table between feature values (x) and classes (y)
+    over a window of size `window_size` and computes the Chi-squared statistic.
+
+    Parameters
+    ----------
+    window_size
+        Size of the rolling window.
+
+    Examples
+    --------
+    >>> from river import stats
+
+    >>> data = [
+    ...     ("A", 0),
+    ...     ("A", 0),
+    ...     ("B", 1),
+    ...     ("B", 1),
+    ...     ("C", 0),
+    ... ]
+
+    >>> rchi = stats.RollingChiSquared(window_size=4)
+
+    >>> for x, y in data[:4]:
+    ...     rchi.update(x, y)
+
+    >>> round(rchi.get(), 3)
+    4.0
+
+    >>> rchi.update(*data[4])
+    >>> round(rchi.get(), 3)
+    4.0
+
+    """
+
+    def __init__(self, window_size: int):
+        utils.Rolling.__init__(self, obj=ChiSquared(), window_size=window_size)
+
+    def update(self, x, y):
+        super().update(x, y)
+
+    def get(self):
+        return super().get()
+
+    @property
+    def window_size(self):
+        return self._window_size
+
+    @property
+    def p_value(self):
+        return self.obj.p_value
+
+    @property
+    def degrees_of_freedom(self):
+        return self.obj.degrees_of_freedom
+
+    def is_significant(self, alpha=0.05):
+        return self.obj.is_significant(alpha)

--- a/river/stats/chi_squared.py
+++ b/river/stats/chi_squared.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import collections
-# import math
 
+# import math
 from river import stats
 
 
@@ -77,16 +77,11 @@ class ChiSquared(stats.base.Bivariate):
         # Iterate over contingency table
         for x in self.counts:
             for y in self.class_totals:
-
                 observed = self.counts[x].get(y, 0)
 
-                expected = (
-                    self.value_totals[x] * self.class_totals[y]
-                ) / self.n
+                expected = (self.value_totals[x] * self.class_totals[y]) / self.n
 
                 if expected > 0:
                     chi2 += (observed - expected) ** 2 / expected
 
         return chi2
-
-    

--- a/river/stats/chi_squared.py
+++ b/river/stats/chi_squared.py
@@ -181,10 +181,10 @@ class RollingChiSquared(stats.base.RollingBivariate, utils.Rolling):
         utils.Rolling.__init__(self, obj=ChiSquared(), window_size=window_size)
 
     def update(self, x, y):
-        super().update(x, y)
+        utils.Rolling.update(self, x, y)
 
     def get(self):
-        return super().get()
+        return self.obj.get()
 
     @property
     def window_size(self):

--- a/river/stats/test_chi_squared.py
+++ b/river/stats/test_chi_squared.py
@@ -63,31 +63,6 @@ def test_chi_squared_exact_value():
     # Known correct value
     assert abs(chi.get() - 4.0) < 1e-6
 
-# (SciPy validation)
-def test_chi_squared_against_scipy():
-    import numpy as np
-    from scipy.stats import chi2_contingency
-
-    chi = stats.ChiSquared()
-
-    data = [
-        ("A", 0),
-        ("A", 0),
-        ("B", 1),
-        ("B", 1),
-    ]
-
-    for x, y in data:
-        chi.update(x, y)
-
-    table = np.array([
-        [2, 0],
-        [0, 2]
-    ])
-
-    expected, _, _, _ = chi2_contingency(table, correction=False)
-
-    assert abs(chi.get() - expected) < 1e-6
 
 
 # MULTIPLE CATEGORY TEST
@@ -107,3 +82,7 @@ def test_chi_squared_multiple_categories():
         chi.update(x, y)
 
     assert chi.get() >= 0
+
+def test_chi_squared_empty():
+    chi = stats.ChiSquared()
+    assert chi.get() == 0.0

--- a/river/stats/test_chi_squared.py
+++ b/river/stats/test_chi_squared.py
@@ -1,0 +1,46 @@
+from river import stats
+
+
+def test_chi_squared_basic():
+    chi = stats.ChiSquared()
+
+    data = [
+        ("A", 0),
+        ("A", 0),
+        ("B", 1),
+        ("B", 1),
+    ]
+
+    for x, y in data:
+        chi.update(x, y)
+
+    assert chi.get() > 0
+
+
+def test_chi_squared_zero_case():
+    chi = stats.ChiSquared()
+
+    # same class only → no dependency
+    data = [
+        ("A", 0),
+        ("B", 0),
+        ("C", 0),
+    ]
+
+    for x, y in data:
+        chi.update(x, y)
+
+    assert chi.get() == 0.0
+
+
+def test_chi_squared_incremental():
+    chi = stats.ChiSquared()
+
+    chi.update("A", 0)
+    first = chi.get()
+
+    chi.update("A", 1)
+    second = chi.get()
+
+    assert second >= 0
+    assert first >= 0

--- a/river/stats/test_chi_squared.py
+++ b/river/stats/test_chi_squared.py
@@ -20,7 +20,7 @@ def test_chi_squared_basic():
 def test_chi_squared_zero_case():
     chi = stats.ChiSquared()
 
-    # same class only → no dependency
+    # No dependency: all belong to same class
     data = [
         ("A", 0),
         ("B", 0),
@@ -42,5 +42,68 @@ def test_chi_squared_incremental():
     chi.update("A", 1)
     second = chi.get()
 
-    assert second >= 0
     assert first >= 0
+    assert second >= 0
+
+
+
+def test_chi_squared_exact_value():
+    chi = stats.ChiSquared()
+
+    data = [
+        ("A", 0),
+        ("A", 0),
+        ("B", 1),
+        ("B", 1),
+    ]
+
+    for x, y in data:
+        chi.update(x, y)
+
+    # Known correct value
+    assert abs(chi.get() - 4.0) < 1e-6
+
+# (SciPy validation)
+def test_chi_squared_against_scipy():
+    import numpy as np
+    from scipy.stats import chi2_contingency
+
+    chi = stats.ChiSquared()
+
+    data = [
+        ("A", 0),
+        ("A", 0),
+        ("B", 1),
+        ("B", 1),
+    ]
+
+    for x, y in data:
+        chi.update(x, y)
+
+    table = np.array([
+        [2, 0],
+        [0, 2]
+    ])
+
+    expected, _, _, _ = chi2_contingency(table, correction=False)
+
+    assert abs(chi.get() - expected) < 1e-6
+
+
+# MULTIPLE CATEGORY TEST
+def test_chi_squared_multiple_categories():
+    chi = stats.ChiSquared()
+
+    data = [
+        ("A", 0),
+        ("B", 1),
+        ("C", 0),
+        ("A", 1),
+        ("B", 0),
+        ("C", 1),
+    ]
+
+    for x, y in data:
+        chi.update(x, y)
+
+    assert chi.get() >= 0

--- a/river/stats/test_chi_squared.py
+++ b/river/stats/test_chi_squared.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from river import stats
 
 
@@ -46,7 +48,6 @@ def test_chi_squared_incremental():
     assert second >= 0
 
 
-
 def test_chi_squared_exact_value():
     chi = stats.ChiSquared()
 
@@ -62,7 +63,6 @@ def test_chi_squared_exact_value():
 
     # Known correct value
     assert abs(chi.get() - 4.0) < 1e-6
-
 
 
 # MULTIPLE CATEGORY TEST
@@ -82,6 +82,7 @@ def test_chi_squared_multiple_categories():
         chi.update(x, y)
 
     assert chi.get() >= 0
+
 
 def test_chi_squared_empty():
     chi = stats.ChiSquared()

--- a/river/stats/test_chi_squared.py
+++ b/river/stats/test_chi_squared.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import numpy as np
+import scipy.stats
+
 from river import stats
 
 
@@ -17,6 +20,9 @@ def test_chi_squared_basic():
         chi.update(x, y)
 
     assert chi.get() > 0
+    assert chi.degrees_of_freedom == 1
+    assert np.isclose(chi.p_value, 0.04550026389635842)
+    assert chi.is_significant(alpha=0.05)
 
 
 def test_chi_squared_zero_case():
@@ -33,6 +39,8 @@ def test_chi_squared_zero_case():
         chi.update(x, y)
 
     assert chi.get() == 0.0
+    assert chi.degrees_of_freedom == 0
+    assert chi.p_value == 1.0
 
 
 def test_chi_squared_incremental():
@@ -65,7 +73,6 @@ def test_chi_squared_exact_value():
     assert abs(chi.get() - 4.0) < 1e-6
 
 
-# MULTIPLE CATEGORY TEST
 def test_chi_squared_multiple_categories():
     chi = stats.ChiSquared()
 
@@ -82,8 +89,111 @@ def test_chi_squared_multiple_categories():
         chi.update(x, y)
 
     assert chi.get() >= 0
+    assert chi.degrees_of_freedom == 2
 
 
 def test_chi_squared_empty():
     chi = stats.ChiSquared()
     assert chi.get() == 0.0
+    assert chi.degrees_of_freedom == 0
+    assert chi.p_value == 1.0
+
+
+def test_chi_squared_revert():
+    chi = stats.ChiSquared()
+    data = [
+        ("A", 0),
+        ("A", 0),
+        ("B", 1),
+        ("B", 1),
+    ]
+
+    for x, y in data:
+        chi.update(x, y)
+
+    # Revert one observation
+    chi.revert("B", 1)
+
+    # Expected contingency table:
+    # A: {0: 2}
+    # B: {1: 1}
+    # n = 3
+    # class_totals: {0: 2, 1: 1}
+    # value_totals: {A: 2, B: 1}
+
+    # Chi-squared for this:
+    # E(A,0) = 2*2 / 3 = 1.333
+    # E(A,1) = 2*1 / 3 = 0.666
+    # E(B,0) = 1*2 / 3 = 0.666
+    # E(B,1) = 1*1 / 3 = 0.333
+    # O(A,0)=2, O(A,1)=0, O(B,0)=0, O(B,1)=1
+    # Chi2 = (2-1.333)^2/1.333 + (0-0.666)^2/0.666 + (0-0.666)^2/0.666 + (1-0.333)^2/0.333
+    # Chi2 = 0.333 + 0.666 + 0.666 + 1.333 = 3.0
+
+    assert np.isclose(chi.get(), 3.0)
+
+    # Revert everything
+    chi.revert("A", 0)
+    chi.revert("A", 0)
+    chi.revert("B", 1)
+
+    assert chi.get() == 0.0
+    assert chi.n == 0
+    assert len(chi.counts) == 0
+
+
+def test_chi_squared_rolling():
+    chi = stats.RollingChiSquared(window_size=4)
+    data = [
+        ("A", 0),
+        ("A", 0),
+        ("B", 1),
+        ("B", 1),
+        ("C", 0),  # This will push out ("A", 0)
+    ]
+
+    for x, y in data[:4]:
+        chi.update(x, y)
+    assert np.isclose(chi.get(), 4.0)
+
+    chi.update(*data[4])
+    # Now window is [("A", 0), ("B", 1), ("B", 1), ("C", 0)]
+    # A: {0: 1}, B: {1: 2}, C: {0: 1}
+    # n=4
+    # class_totals: {0: 2, 1: 2}
+    # value_totals: {A: 1, B: 2, C: 1}
+    # E(A,0) = 1*2/4 = 0.5, E(A,1) = 0.5
+    # E(B,0) = 2*2/4 = 1.0, E(B,1) = 1.0
+    # E(C,0) = 0.5, E(C,1) = 0.5
+    # Chi2 = (1-0.5)^2/0.5 + (0-0.5)^2/0.5 + (0-1.0)^2/1.0 + (2-1.0)^2/1.0 + (1-0.5)^2/0.5 + (0-0.5)^2/0.5
+    # Chi2 = 0.5 + 0.5 + 1.0 + 1.0 + 0.5 + 0.5 = 4.0
+    assert np.isclose(chi.get(), 4.0)
+
+
+def test_chi_squared_scipy_comparison():
+    chi = stats.ChiSquared()
+
+    # Generate some random categorical data
+    np.random.seed(42)
+    n = 100
+    x = np.random.choice(["A", "B", "C"], size=n)
+    y = np.random.choice([0, 1], size=n)
+
+    for xi, yi in zip(x, y):
+        chi.update(xi, yi)
+
+    # Get contingency table for scipy
+    categories = sorted(list(set(x)))
+    classes = sorted(list(set(y)))
+    contingency = []
+    for cat in categories:
+        row = []
+        for cl in classes:
+            row.append(np.sum((x == cat) & (y == cl)))
+        contingency.append(row)
+
+    scipy_chi2, scipy_p, scipy_df, _ = scipy.stats.chi2_contingency(contingency, correction=False)
+
+    assert np.isclose(chi.get(), scipy_chi2)
+    assert np.isclose(chi.p_value, scipy_p)
+    assert chi.degrees_of_freedom == scipy_df

--- a/river/stats/test_stats.py
+++ b/river/stats/test_stats.py
@@ -53,7 +53,7 @@ def test_pickling(stat):
 @pytest.mark.parametrize("stat", load_stats(), ids=lambda stat: stat.__class__.__name__)
 def test_pickling_value(stat):
     for i in range(10):
-        if isinstance(stat, stats.base.Bivariate):
+        if isinstance(stat, (stats.base.Bivariate, stats.base.RollingBivariate)):
             stat.update(i, i)
         else:
             stat.update(i)
@@ -239,6 +239,29 @@ def test_bivariate(stat, func):
             assert math.isclose(stat.get(), func(X[: i + 1], Y[: i + 1]), abs_tol=1e-10)
 
 
+def _chi2_stat(x, y):
+    # This is a bit slow but correct for testing
+
+    import scipy.stats
+
+    # Get unique values to build contingency table
+    x_vals = sorted(list(set(x)))
+    y_vals = sorted(list(set(y)))
+    if len(x_vals) <= 1 or len(y_vals) <= 1:
+        return 0.0
+
+    table = []
+    for xv in x_vals:
+        row = []
+        for yv in y_vals:
+            count = sum(1 for xi, yi in zip(x, y) if xi == xv and yi == yv)
+            row.append(count)
+        table.append(row)
+
+    chi2, _, _, _ = scipy.stats.chi2_contingency(table, correction=False)
+    return chi2
+
+
 @pytest.mark.parametrize(
     "stat, func",
     [
@@ -246,13 +269,15 @@ def test_bivariate(stat, func):
         (utils.Rolling(stats.PearsonCorr(), 10), lambda x, y: sp_stats.pearsonr(x, y)[0]),  # type: ignore
         (utils.Rolling(stats.Cov(), 3), lambda x, y: np.cov(x, y)[0, 1]),  # type: ignore
         (utils.Rolling(stats.Cov(), 10), lambda x, y: np.cov(x, y)[0, 1]),  # type: ignore
+        (stats.RollingChiSquared(3), _chi2_stat),
+        (stats.RollingChiSquared(10), _chi2_stat),
     ],
 )
 def test_rolling_bivariate(stat, func):
     # Enough already
 
     def tail(iterable, n):
-        return collections.deque(iterable, maxlen=n)
+        return list(collections.deque(iterable, maxlen=n))
 
     n = stat.window_size
     X = [random.random() for _ in range(30)]
@@ -261,9 +286,10 @@ def test_rolling_bivariate(stat, func):
     for i, (x, y) in enumerate(zip(X, Y)):
         stat.update(x, y)
         if i >= 1:
-            x_tail = tail(X[: i + 1], n)
-            y_tail = tail(Y[: i + 1], n)
-            assert math.isclose(stat.get(), func(x_tail, y_tail), abs_tol=1e-10)
+            val = stat.get()
+            expected = func(tail(X[: i + 1], n), tail(Y[: i + 1], n))
+            if val is not None and not math.isnan(expected):
+                assert math.isclose(val, expected, abs_tol=1e-10)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR Adds a streaming implementation of the Chi-squared statistic to river.stats.

The class maintains a contingency table between feature values and target classes and computes the Chi-squared value incrementally. This can be useful for measuring the dependency between categorical variables in a streaming setting.

Includes basic and edge case tests to verify correctness.

issue closes: #1395