### PR TITLE
deprecate neural_net module

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## neural_net
+
+- Deprecated `river.neural_net`; importing it now emits a `DeprecationWarning` and users are encouraged to use `deep-river` for neural networks. Addresses [#1828](https://github.com/online-ml/river/issues/1828).
+
 ## tree
 
 - Fixed `MondrianNodeClassifier.replant` not copying the `counts` attribute when promoting a leaf to a branch, leaving the new branch with `n_samples != 0` but empty class counts. The fix mirrors the regressor's `_mean` copy and matches the reference [`onelearn`](https://github.com/onelearn/onelearn) implementation. Addresses [#1823](https://github.com/online-ml/river/issues/1823).

--- a/river/neural_net/__init__.py
+++ b/river/neural_net/__init__.py
@@ -2,7 +2,17 @@
 
 from __future__ import annotations
 
+import warnings
+
 from . import activations
 from .mlp import MLPRegressor
+
+warnings.warn(
+    "`river.neural_net` is deprecated and will be removed in a future release; "
+    "use `sklearn` for neural networks instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 
 __all__ = ["activations", "MLPRegressor"]


### PR DESCRIPTION
This PR deprecates the `neural_net` module.

It can be deleted in the upcoming releases