### PR TITLE
Add RandomTreesEmbedding feature

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## feature_extraction
+
+- Added `feature_extraction.RandomTreesEmbedding`, an online random-tree leaf embedding transformer for feeding sparse tree features into downstream models. Addresses [#1386](https://github.com/online-ml/river/issues/1386).
+
 ## neural_net
 
 - Deprecated `river.neural_net`; importing it now emits a `DeprecationWarning` and users are encouraged to use `deep-river` for neural networks. Addresses [#1828](https://github.com/online-ml/river/issues/1828).

--- a/river/feature_extraction/__init__.py
+++ b/river/feature_extraction/__init__.py
@@ -10,7 +10,7 @@ be processed by a particular machine learning algorithm.
 from __future__ import annotations
 
 from .agg import Agg, TargetAgg
-from .kernel_approx import RBFSampler
+from .kernel_approx import RandomTreesEmbedding, RBFSampler
 from .poly import PolynomialExtender
 from .vectorize import TFIDF, BagOfWords
 
@@ -18,6 +18,7 @@ __all__ = [
     "Agg",
     "BagOfWords",
     "PolynomialExtender",
+    "RandomTreesEmbedding",
     "RBFSampler",
     "TargetAgg",
     "TFIDF",

--- a/river/feature_extraction/kernel_approx.py
+++ b/river/feature_extraction/kernel_approx.py
@@ -102,9 +102,15 @@ class RandomTreesEmbedding(base.Transformer):
     leaf reached in every tree. The output is sparse: exactly one binary feature is active per tree.
 
     This is the online counterpart of feeding a linear model with random-tree leaf indicators.
+    By default, this implementation assumes that each feature has values comprised between 0 and
+    1. If this is not the case, then you can manually specify the limits via the `limits`
+    argument. If you do not know the limits in advance, then you can use a
+    `preprocessing.MinMaxScaler` as an initial preprocessing step.
+
     The trees are built lazily from the first sample that is observed, either via `transform_one`
     or `learn_one`. If new features appear later in the stream, then the forest is rebuilt so that
-    future splits may use them.
+    future splits may use them. Unless specified in `limits`, newly observed features are also
+    assumed to lie in the range `[0, 1]`.
 
     Parameters
     ----------
@@ -114,7 +120,8 @@ class RandomTreesEmbedding(base.Transformer):
         Height of each tree. A tree of height `h` contains `2 ** h` leaves.
     limits
         Specifies the range of each feature. By default each feature is assumed to be in
-        range `[0, 1]`.
+        range `[0, 1]`. If the feature ranges are unknown beforehand, then use a
+        `preprocessing.MinMaxScaler` upstream.
     seed
         Random seed for reproducibility.
 
@@ -124,12 +131,15 @@ class RandomTreesEmbedding(base.Transformer):
     >>> from river import feature_extraction as fx
     >>> from river import linear_model as lm
     >>> from river import optim
+    >>> from river import preprocessing
 
+    >>> # The input values are already comprised between 0 and 1.
     >>> embedding = fx.RandomTreesEmbedding(n_trees=3, height=2, seed=42)
     >>> len(embedding.transform_one({'x': 0.3, 'y': 0.7}))
     3
 
     >>> model = (
+    ...     preprocessing.MinMaxScaler() |
     ...     fx.RandomTreesEmbedding(n_trees=5, height=3, seed=42) |
     ...     lm.LogisticRegression(optimizer=optim.SGD(0.1))
     ... )

--- a/river/feature_extraction/kernel_approx.py
+++ b/river/feature_extraction/kernel_approx.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import collections
+import functools
 import math
 import random
 import typing
 
 from river import base
+from river.anomaly.hst import HSTBranch, HSTLeaf, make_padded_tree
+
+__all__ = ["RBFSampler", "RandomTreesEmbedding"]
 
 
 class RBFSampler(base.Transformer):
@@ -89,3 +93,117 @@ class RBFSampler(base.Transformer):
             for i, xi in x.items()
             for j, wj in enumerate(self.weights[i])
         }
+
+
+class RandomTreesEmbedding(base.Transformer):
+    """Embed samples according to the leaves of random trees.
+
+    This transformer builds an ensemble of totally random trees and encodes each sample with the
+    leaf reached in every tree. The output is sparse: exactly one binary feature is active per tree.
+
+    This is the online counterpart of feeding a linear model with random-tree leaf indicators.
+    The trees are built lazily from the first sample that is observed, either via `transform_one`
+    or `learn_one`. If new features appear later in the stream, then the forest is rebuilt so that
+    future splits may use them.
+
+    Parameters
+    ----------
+    n_trees
+        Number of trees in the ensemble.
+    height
+        Height of each tree. A tree of height `h` contains `2 ** h` leaves.
+    limits
+        Specifies the range of each feature. By default each feature is assumed to be in
+        range `[0, 1]`.
+    seed
+        Random seed for reproducibility.
+
+    Examples
+    --------
+
+    >>> from river import feature_extraction as fx
+    >>> from river import linear_model as lm
+    >>> from river import optim
+
+    >>> embedding = fx.RandomTreesEmbedding(n_trees=3, height=2, seed=42)
+    >>> len(embedding.transform_one({'x': 0.3, 'y': 0.7}))
+    3
+
+    >>> model = (
+    ...     fx.RandomTreesEmbedding(n_trees=5, height=3, seed=42) |
+    ...     lm.LogisticRegression(optimizer=optim.SGD(0.1))
+    ... )
+
+    References
+    ----------
+    [^1]: [Geurts, P., Ernst, D., and Wehenkel, L. (2006). Extremely randomized trees. Machine Learning, 63(1), 3-42.](https://link.springer.com/article/10.1007/s10994-006-6226-1)
+    [^2]: [scikit-learn random trees embedding](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomTreesEmbedding.html)
+
+    """
+
+    def __init__(
+        self,
+        n_trees=10,
+        height=8,
+        limits: dict[base.typing.FeatureName, tuple[float, float]] | None = None,
+        seed: int | None = None,
+    ):
+        self.n_trees = n_trees
+        self.height = height
+        self.limits: collections.defaultdict = collections.defaultdict(
+            functools.partial(tuple, (0.0, 1.0))
+        )
+        if limits is not None:
+            self.limits.update(limits)
+        self.seed = seed
+        self.rng = random.Random(seed)
+
+        self.trees: list[HSTBranch | HSTLeaf] = []
+        self._leaf_indices: list[dict[int, int]] = []
+        self._features: set[base.typing.FeatureName] = set()
+
+    def _make_trees(self):
+        self.trees = [
+            make_padded_tree(
+                limits={i: self.limits[i] for i in sorted(self._features)},
+                height=self.height,
+                padding=0.15,
+                rng=self.rng,
+                # kwargs
+                r_mass=0,
+                l_mass=0,
+            )
+            for _ in range(self.n_trees)
+        ]
+
+        self._leaf_indices = []
+        for tree in self.trees:
+            self._leaf_indices.append({id(leaf): i for i, leaf in enumerate(tree.iter_leaves())})
+
+    def _ensure_initialized(self, x):
+        new_features = set(x) - self._features
+        if self.trees and not new_features:
+            return
+
+        self._features.update(x)
+        if not self._features:
+            return
+
+        self._make_trees()
+
+    def learn_one(self, x):
+        self._ensure_initialized(x)
+
+        for tree in self.trees:
+            for node in tree.walk(x):
+                node.l_mass += 1
+
+    def transform_one(self, x):
+        self._ensure_initialized(x)
+
+        features = {}
+        for tree_id, tree in enumerate(self.trees):
+            leaf = tree if isinstance(tree, HSTLeaf) else tree.traverse(x)
+            features[(tree_id, self._leaf_indices[tree_id][id(leaf)])] = 1.0
+
+        return features


### PR DESCRIPTION
Hi @MaxHalford,
if I understood the RamdomTreeEmbeddings correctly, this PR should implement them.
The crucial lines are the following, where the transforms_one methods returns a dictionary showing which leaf x ends up in for each tree. 
```
features = {}
for tree_id, tree in enumerate(self.trees):
    leaf = tree if isinstance(tree, HSTLeaf) else tree.traverse(x)
    features[(tree_id, self._leaf_indices[tree_id][id(leaf)])] = 1.0
return features 
```

Could you please briefly check it ? 