### PR TITLE
Skip range_extension_c for pure nodes in Mondrian classifier

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -7,3 +7,5 @@
 ## tree
 
 - Fixed `MondrianNodeClassifier.replant` not copying the `counts` attribute when promoting a leaf to a branch, leaving the new branch with `n_samples != 0` but empty class counts. The fix mirrors the regressor's `_mean` copy and matches the reference [`onelearn`](https://github.com/onelearn/onelearn) implementation. Addresses [#1823](https://github.com/online-ml/river/issues/1823).
+
+- Skipped the expensive `range_extension_c` call for pure nodes in the Mondrian classifier's downward pass when `split_pure=False` (default). Benchmarks show ~3–5% speedup on datasets with 50+ features.

--- a/river/tree/mondrian/_mondrian_ops.pyx
+++ b/river/tree/mondrian/_mondrian_ops.pyx
@@ -195,23 +195,22 @@ cpdef object go_downwards_classifier_c(
 
     branch_no = -1
     while True:
-        # Compute range extension
-        extensions_sum, extensions = range_extension_c(
-            current_node.memory_range_min, current_node.memory_range_max, x
-        )
-
-        # Compute split time
         split_time = 0.0
-        if max_nodes >= 0 and (n_nodes + nodes_added) >= max_nodes:
-            pass  # max_nodes reached, no split
-        elif extensions_sum > 0:
-            do_split_check = split_pure
-            if not do_split_check:
-                counts = current_node.counts
-                count_val = <int>counts[y_idx] if y_idx < len(counts) else 0
-                if current_node.n_samples != count_val:
-                    do_split_check = True
-            if do_split_check:
+
+        # When split_pure is False (default), check purity before the
+        # expensive range_extension_c call to skip it for pure nodes.
+        do_split_check = split_pure
+        if not do_split_check:
+            counts = current_node.counts
+            count_val = <int>counts[y_idx] if y_idx < len(counts) else 0
+            if current_node.n_samples != count_val:
+                do_split_check = True
+
+        if do_split_check and not (max_nodes >= 0 and (n_nodes + nodes_added) >= max_nodes):
+            extensions_sum, extensions = range_extension_c(
+                current_node.memory_range_min, current_node.memory_range_max, x
+            )
+            if extensions_sum > 0:
                 T = -log(1.0 - <double>rng_random()) / extensions_sum
                 split_time_candidate = <double>current_node.time + T
                 is_leaf = current_node.is_leaf


### PR DESCRIPTION
## Summary

- When `split_pure=False` (default), moves the purity check **before** the `range_extension_c` call in the classifier's downward pass. Pure nodes never split, so the range extension computation can be skipped entirely.
- Credit to @shi-zq for the [observation](https://github.com/online-ml/river/pull/1835#issuecomment-4333870137).

## Benchmark results

`range_extension_c` cost scales linearly with feature count (~1μs at 20 features, ~10μs at 200).

Pure nodes are ~50% of all nodes (exclusively leaves — branches are always impure). The optimization saves one `range_extension_c` call per `learn_one` at the terminal pure leaf.

| Config | Baseline | Optimized | Delta |
|--------|----------|-----------|-------|
| 20 features, 3 classes | 0.1781s | 0.1774s | -0.4% |
| 50 features, 3 classes | 0.4067s | 0.3876s | **-4.7%** |
| 100 features, 3 classes | 0.6655s | 0.6425s | **-3.5%** |
| 200 features, 3 classes | 1.0568s | 1.0203s | **-3.5%** |
| 50 features, 2 classes | 0.4338s | 0.4128s | **-4.8%** |
| 50 features, 5 classes | 0.4071s | 0.3891s | **-4.4%** |
| 50 features, 10 classes | 0.3868s | 0.3692s | **-4.6%** |

(5000 samples, best of 5 runs, `split_pure=False`, `seed=42`)

## Test plan

- [x] `pytest river/tree/mondrian/` passes (including doctests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)