### PR TITLE
Speed up HalfSpaceTrees with an iterative walk

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -27,6 +27,10 @@
 
 - Reimplemented `utils.VectorDict` (and the helper functions `euclidean_distance_dict`, `euclidean_distance_tuple`, `lazy_search_euclidean`) in Rust. The Cython sources are removed; the public API is unchanged. Element-wise operations are faster across the board: `vec + scalar` and `vec * scalar` are ~18% faster on 20-key dicts and ~14% faster on 1000-key dicts; `vec + vec` is 4-5% faster, `vec @ vec` (dot product) is 4-10% faster. The constructor and `__setitem__` are within 1-4% of the Cython baseline (~2 ns absolute, dominated by PyO3 object-allocation overhead).
 
+## anomaly
+
+- Sped up `anomaly.HalfSpaceTrees.learn_one` and `score_one` by replacing the generic recursive `tree.base.Branch.walk` traversal with an iterative tight loop specialised for HST, caching the (constant) `size_limit` and tree height as locals, and pivoting node masses through a precomputed flat node list. Output is unchanged. On a synthetic 10-feature stream `score+learn` is ~3.0× faster (27.9k → 85.2k obs/s), `learn_one` ~2.6×, and `score_one` ~3.8×; in a `MinMaxScaler | HalfSpaceTrees` pipeline on CreditCard the end-to-end pipeline is ~2.0× faster (20.5k → 40.5k obs/s).
+
 ## tree
 
 - Fixed `MondrianNodeClassifier.replant` not copying the `counts` attribute when promoting a leaf to a branch, leaving the new branch with `n_samples != 0` but empty class counts. The fix mirrors the regressor's `_mean` copy and matches the reference [`onelearn`](https://github.com/onelearn/onelearn) implementation. Addresses [#1823](https://github.com/online-ml/river/issues/1823).

--- a/river/anomaly/hst.py
+++ b/river/anomaly/hst.py
@@ -56,6 +56,45 @@ class HSTLeaf(tree.base.Leaf):
         return str(self.r_mass)
 
 
+def _walk_learn(root, x, height):
+    """Walk root-to-leaf along the path induced by x, incrementing l_mass at each node."""
+    node = root
+    for _ in range(height):
+        node.l_mass += 1
+        try:
+            value = x[node.feature]
+        except KeyError:
+            c = node.children
+            node = c[1] if c[0].l_mass < c[1].l_mass else c[0]
+        else:
+            c = node.children
+            node = c[0] if value < node.threshold else c[1]
+    node.l_mass += 1
+
+
+def _walk_score(root, x, height, size_limit):
+    """Walk root-to-leaf accumulating r_mass * 2**depth; stop early when r_mass < size_limit."""
+    node = root
+    depth_pow = 1
+    score = 0.0
+    for _ in range(height):
+        r = node.r_mass
+        score += r * depth_pow
+        if r < size_limit:
+            return score
+        try:
+            value = x[node.feature]
+        except KeyError:
+            c = node.children
+            node = c[1] if c[0].l_mass < c[1].l_mass else c[0]
+        else:
+            c = node.children
+            node = c[0] if value < node.threshold else c[1]
+        depth_pow <<= 1
+    score += node.r_mass * depth_pow
+    return score
+
+
 def make_padded_tree(limits, height, padding, rng=random, **node_params):
     if height == 0:
         return HSTLeaf(**node_params)
@@ -220,6 +259,7 @@ class HalfSpaceTrees(anomaly.base.AnomalyDetector):
         self.rng = random.Random(seed)
 
         self.trees: list[HSTBranch] = []
+        self._tree_nodes: list[list] = []
         self.counter = 0
         self._first_window = True
 
@@ -252,17 +292,19 @@ class HalfSpaceTrees(anomaly.base.AnomalyDetector):
                 )
                 for _ in range(self.n_trees)
             ]
+            # Flat node list per tree, used for the window-pivot step
+            self._tree_nodes = [list(t.iter_dfs()) for t in self.trees]
 
         # Update each tree
+        height = self.height
         for t in self.trees:
-            for node in t.walk(x):
-                node.l_mass += 1
+            _walk_learn(t, x, height)
 
         # Pivot the masses if necessary
         self.counter += 1
         if self.counter == self.window_size:
-            for t in self.trees:
-                for node in t.iter_dfs():
+            for nodes in self._tree_nodes:
+                for node in nodes:
                     node.r_mass = node.l_mass
                     node.l_mass = 0
             self._first_window = False
@@ -272,15 +314,11 @@ class HalfSpaceTrees(anomaly.base.AnomalyDetector):
         if self._first_window:
             return 0
 
+        size_limit = 0.1 * self.window_size
+        height = self.height
         score = 0.0
         for t in self.trees:
-            for depth, node in enumerate(t.walk(x)):
-                score += node.r_mass * 2**depth
-                if node.r_mass < self.size_limit:
-                    break
+            score += _walk_score(t, x, height, size_limit)
 
-        # Normalize the score between 0 and 1
-        score /= self._max_score
-
-        # We want high score -> anomaly, but we have high score -> normal
-        return 1 - score
+        # Normalize the score between 0 and 1 and flip (high score -> anomaly)
+        return 1 - score / self._max_score


### PR DESCRIPTION
## Summary

Replaces the recursive generic `tree.base.Branch.walk` traversal in `anomaly.HalfSpaceTrees.learn_one`/`score_one` with HST-specific iterative loops that:

- Inline the split-and-descend logic (no per-level generator allocation, no `HSTBranch.next` call).
- Cache `size_limit = 0.1 * window_size` and `self.height` as locals (was a property recomputed ~1.1M times in profile).
- Pivot node masses through a precomputed flat node list built once at tree construction, instead of `iter_dfs()` every `window_size` observations.

The public API is unchanged — no constructor changes, no behaviour changes. The docstring scores remain byte-identical and all 50 `check_estimator` cases for `MinMaxScaler | HalfSpaceTrees` pass.

## Benchmarks

macOS arm64, Python 3.13, default `HalfSpaceTrees(n_trees=10, height=8, window_size=250)`, best of 3.

Pure HST on a synthetic 10-feature uniform stream (no scaler):

| Workload | Before | After | Speedup |
|---|---|---|---|
| score+learn | 27,902 obs/s | 85,231 obs/s | **3.05x** |
| learn_one   | 64,232 obs/s | 169,098 obs/s | 2.63x |
| score_one   | 49,598 obs/s | 188,172 obs/s | 3.79x |

`MinMaxScaler | HalfSpaceTrees` on `datasets.CreditCard()` (10k samples):

| Workload | Before | After | Speedup |
|---|---|---|---|
| score+learn | 20,493 obs/s | 40,513 obs/s | **1.98x** |
| learn_one   | 42,943 obs/s | 74,241 obs/s | 1.73x |
| score_one   | 38,590 obs/s | 89,623 obs/s | 2.32x |

In the post-fix profile, HST itself (`_walk_learn` + `_walk_score`) is no longer the dominant cost — `MinMaxScaler.transform_one`/`learn_one` is. Further wins would need a Rust port (cf. the recent ADWIN/Mondrian/VectorDict efforts) or speeding up `MinMaxScaler`.

## Test plan

- [x] `uv run pytest --doctest-modules river/anomaly/hst.py` — passes, docstring outputs byte-identical
- [x] `uv run pytest river/anomaly/ -x` — all 16 tests pass
- [x] `uv run pytest river/test_estimators.py -k "HalfSpaceTrees"` — all 50 estimator checks pass
- [x] pre-commit (ruff, mypy) — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)