### PR TITLE
Speed up DBSTREAM by removing deepcopy from cleanup and reclustering

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -27,6 +27,10 @@
 
 - Reimplemented `utils.VectorDict` (and the helper functions `euclidean_distance_dict`, `euclidean_distance_tuple`, `lazy_search_euclidean`) in Rust. The Cython sources are removed; the public API is unchanged. Element-wise operations are faster across the board: `vec + scalar` and `vec * scalar` are ~18% faster on 20-key dicts and ~14% faster on 1000-key dicts; `vec + vec` is 4-5% faster, `vec @ vec` (dot product) is 4-10% faster. The constructor and `__setitem__` are within 1-4% of the Cython baseline (~2 ns absolute, dominated by PyO3 object-allocation overhead).
 
+## cluster
+
+- Sped up `cluster.DBSTREAM` by replacing the per-cleanup `copy.deepcopy` of the micro-cluster dict with an in-place pop, replacing the `deepcopy` in the offline reclustering step with a direct micro-cluster construction, hoisting the Gaussian neighborhood factor out of the per-feature center update (it does not vary across dimensions), and folding the nested `try/except KeyError` shared-density update into a plain `dict.get`. Output is unchanged. On the 15k-sample synthetic-sklearn workload, `learn_one` is ~6.1× faster (0.516 s → 0.084 s) and `learn_one + predict_one` is ~4.3× faster (0.872 s → 0.204 s).
+
 ## tree
 
 - Fixed `MondrianNodeClassifier.replant` not copying the `counts` attribute when promoting a leaf to a branch, leaving the new branch with `n_samples != 0` but empty class counts. The fix mirrors the regressor's `_mean` copy and matches the reference [`onelearn`](https://github.com/onelearn/onelearn) implementation. Addresses [#1823](https://github.com/online-ml/river/issues/1823).

--- a/river/cluster/dbstream.py
+++ b/river/cluster/dbstream.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import collections
-import copy
 import math
 from abc import ABCMeta
 
@@ -179,116 +178,104 @@ class DBSTREAM(base.Clusterer):
     def _update(self, x):
         # Algorithm 1 of Michael Hahsler and Matthew Bolanos
         neighbor_clusters = self._find_fixed_radius_nn(x)
+        fading = self.fading_factor
+        t = self._time_stamp
 
-        if len(neighbor_clusters) < 1:
+        if not neighbor_clusters:
             # create new micro cluster
-            if len(self._micro_clusters) > 0:
-                self._micro_clusters[max(self._micro_clusters.keys()) + 1] = DBSTREAMMicroCluster(
-                    x=x, last_update=self._time_stamp, weight=1
-                )
-            else:
-                self._micro_clusters[0] = DBSTREAMMicroCluster(
-                    x=x, last_update=self._time_stamp, weight=1
-                )
+            new_id = (max(self._micro_clusters) + 1) if self._micro_clusters else 0
+            self._micro_clusters[new_id] = DBSTREAMMicroCluster(x=x, last_update=t, weight=1)
         else:
             # update existing micro clusters
             current_centers = {}
-            for i in neighbor_clusters.keys():
-                current_centers[i] = self._micro_clusters[i].center
-                self._micro_clusters[i].weight = (
-                    self._micro_clusters[i].weight
-                    * 2
-                    ** (
-                        -self.fading_factor
-                        * (self._time_stamp - self._micro_clusters[i].last_update)
-                    )
-                    + 1
-                )
+            neighbor_ids = list(neighbor_clusters)
+            for i in neighbor_ids:
+                mc = self._micro_clusters[i]
+                center = mc.center
+                current_centers[i] = center
 
-                # Update the center (i) with overlapping keys (j)
-                self._micro_clusters[i].center = {
-                    j: self._micro_clusters[i].center[j]
-                    + self._gaussian_neighborhood(x, self._micro_clusters[i].center)
-                    * (x[j] - self._micro_clusters[i].center[j])
-                    for j in self._micro_clusters[i].center.keys()
-                    if j in x
-                }
-                self._micro_clusters[i].last_update = self._time_stamp
+                # Fade the weight to the current time step, then add 1 for the new point.
+                mc.weight = mc.weight * 2 ** (-fading * (t - mc.last_update)) + 1
 
-                # update shared density
-                for j in neighbor_clusters.keys():
+                # Move the center towards x using a single Gaussian factor (same for all dims).
+                h = self._gaussian_neighborhood(x, center)
+                new_center = {j: c_j + h * (x[j] - c_j) for j, c_j in center.items() if j in x}
+                mc.center = new_center
+                mc.last_update = t
+
+                # Update shared density for every (i, j) pair with j > i.
+                # self.s[i] is created lazily on the first such j to keep the
+                # mapping free of empty rows.
+                s_i = self.s.get(i)
+                s_t_i = self.s_t.get(i) if s_i is not None else None
+                for j in neighbor_ids:
                     if j > i:
-                        try:
-                            self.s[i][j] = (
-                                self.s[i][j]
-                                * 2 ** (-self.fading_factor * (self._time_stamp - self.s_t[i][j]))
-                                + 1
-                            )
-                            self.s_t[i][j] = self._time_stamp
-                        except KeyError:
-                            try:
-                                self.s[i][j] = 1
-                                self.s_t[i][j] = self._time_stamp
-                            except KeyError:
-                                self.s[i] = {j: 1}
-                                self.s_t[i] = {j: self._time_stamp}
+                        if s_i is None:
+                            s_i = {}
+                            s_t_i = {}
+                            self.s[i] = s_i
+                            self.s_t[i] = s_t_i
+                        if j in s_i:
+                            s_i[j] = s_i[j] * 2 ** (-fading * (t - s_t_i[j])) + 1
+                        else:
+                            s_i[j] = 1
+                        s_t_i[j] = t
 
-            # prevent collapsing clusters
-            for i in neighbor_clusters.keys():
-                for j in neighbor_clusters.keys():
-                    if j > i:
-                        if (
-                            self._distance(
-                                self._micro_clusters[i].center,
-                                self._micro_clusters[j].center,
-                            )
-                            < self.clustering_threshold
-                        ):
-                            # revert centers of mc_i and mc_j to previous positions
-                            self._micro_clusters[i].center = current_centers[i]
-                            self._micro_clusters[j].center = current_centers[j]
+            # Prevent collapsing clusters: if any updated pair is now within the
+            # clustering threshold, revert both centers to their previous positions.
+            n = len(neighbor_ids)
+            for a in range(n):
+                i = neighbor_ids[a]
+                for b in range(a + 1, n):
+                    j = neighbor_ids[b]
+                    mc_i = self._micro_clusters[i]
+                    mc_j = self._micro_clusters[j]
+                    if self._distance(mc_i.center, mc_j.center) < self.clustering_threshold:
+                        mc_i.center = current_centers[i]
+                        mc_j.center = current_centers[j]
 
-        self._time_stamp += 1
+        self._time_stamp = t + 1
 
     def _cleanup(self):
         # Algorithm 2 of Michael Hahsler and Matthew Bolanos: Cleanup process to remove
-        # inactive clusters and shared density entries from memory
-        weight_weak = 2 ** (-self.fading_factor * self.cleanup_interval)
+        # inactive clusters and shared density entries from memory.
+        fading = self.fading_factor
+        t = self._time_stamp
+        weight_weak = 2 ** (-fading * self.cleanup_interval)
 
-        micro_clusters = copy.deepcopy(self._micro_clusters)
-        for i, micro_cluster_i in self._micro_clusters.items():
+        weak_ids = []
+        for i, mc in self._micro_clusters.items():
             try:
-                value = 2 ** (
-                    -self.fading_factor * (self._time_stamp - micro_cluster_i.last_update)
-                )
+                value = 2 ** (-fading * (t - mc.last_update))
             except OverflowError:
                 continue
+            if mc.weight * value < weight_weak:
+                weak_ids.append(i)
 
-            if micro_cluster_i.weight * value < weight_weak:
-                micro_clusters.pop(i)
-                self.s.pop(i, None)
-                self.s_t.pop(i, None)
-                # Since self.s and self.s_t always have the same keys and are arranged in ascending orders
-                for j in self.s:
-                    if j < i:
-                        self.s[j].pop(i, None)
-                        self.s_t[j].pop(i, None)
-                    else:
-                        break
+        for i in weak_ids:
+            del self._micro_clusters[i]
+            self.s.pop(i, None)
+            self.s_t.pop(i, None)
+            # self.s / self.s_t share keys and are inserted in ascending order, so
+            # we can stop scanning once j >= i.
+            for j in self.s:
+                if j < i:
+                    self.s[j].pop(i, None)
+                    self.s_t[j].pop(i, None)
+                else:
+                    break
 
-        # Update microclusters
-        self._micro_clusters = micro_clusters
-
-        for i in self.s.keys():
-            for j in self.s[i].keys():
+        threshold = self.intersection_factor * weight_weak
+        for i, s_i in self.s.items():
+            s_t_i = self.s_t[i]
+            for j, value in s_i.items():
                 try:
-                    value = 2 ** (-self.fading_factor * (self._time_stamp - self.s_t[i][j]))
+                    decay = 2 ** (-fading * (t - s_t_i[j]))
                 except OverflowError:
                     continue
-
-                if self.s[i][j] * value < self.intersection_factor * weight_weak:
-                    self.s[i][j] = 0
-                    self.s_t[i][j] = 0
+                if value * decay < threshold:
+                    s_i[j] = 0
+                    s_t_i[j] = 0
 
     def _generate_weighted_adjacency_matrix(self):
         # Algorithm 3 of Michael Hahsler and Matthew Bolanos: Reclustering using
@@ -359,32 +346,32 @@ class DBSTREAM(base.Clusterer):
         return labels
 
     def _generate_clusters_from_labels(self, cluster_labels):
-        # initiate the set for final clusters
-        clusters = {}
+        # Group micro clusters by label in one pass, preserving the input ordering.
+        by_label: dict[int, list[DBSTREAMMicroCluster]] = {}
+        for index, label in cluster_labels.items():
+            if label is None:
+                continue
+            by_label.setdefault(label, []).append(self._micro_clusters[index])
 
-        # generate set of clusters with the same label with the structure {j: micro_cluster_index}
-        non_noise_labels = [v for v in cluster_labels.values() if v is not None]
-        if not non_noise_labels:
+        if not by_label:
             return 0, {}
-        for i in range(max(non_noise_labels) + 1):
-            j = 0
-            mcs_with_label_i = {}
-            for index, label in cluster_labels.items():
-                if label == i:
-                    mcs_with_label_i[j] = self._micro_clusters[index]
-                    j += 1
 
-            # generate a final macro-cluster from clusters with the same label using the
-            # merge function of DBStreamMicroCluster
-            macro_cluster = copy.deepcopy(mcs_with_label_i[0])
-            for m in range(1, len(mcs_with_label_i)):
-                macro_cluster.merge(mcs_with_label_i[m])
+        clusters: dict[int, DBSTREAMMicroCluster] = {}
+        for label in sorted(by_label):
+            members = by_label[label]
+            first = members[0]
+            # Build the macro cluster as a fresh DBSTREAMMicroCluster so the original
+            # micro cluster is not mutated by the subsequent merge calls.
+            macro_cluster = DBSTREAMMicroCluster(
+                x=dict(first.center),
+                last_update=first.last_update,
+                weight=first.weight,
+            )
+            for member in members[1:]:
+                macro_cluster.merge(member)
+            clusters[label] = macro_cluster
 
-            clusters[i] = macro_cluster
-
-        n_clusters = len(clusters)
-
-        return n_clusters, clusters
+        return len(clusters), clusters
 
     def _recluster(self):
         # Algorithm 3 of Michael Hahsler and Matthew Bolanos: Reclustering


### PR DESCRIPTION
## Summary

- cProfile of the `synthetic_sklearn` workload showed `copy.deepcopy(self._micro_clusters)` inside `_cleanup` accounting for ~91% of `learn_one` time, with a second `copy.deepcopy` in `_generate_clusters_from_labels` dominating the predict path.
- This PR replaces both deepcopies, hoists the Gaussian neighborhood factor out of the per-feature center update loop (it's a single scalar, not per-dimension), and folds the nested `try/except KeyError` shared-density update into a plain `dict.get` / lazy-init.
- Output is unchanged: all 10 `test_dbstream.py` tests pass, including `test_dbstream_synthetic_sklearn` (v_beta checked to 4 decimal places).
- On the 15k-sample `synthetic_sklearn` workload, `learn_one` is ~6.1× faster (0.516 s → 0.084 s) and `learn_one + predict_one` is ~4.3× faster (0.872 s → 0.204 s).

## Profile evidence (before)

```
   ncalls  tottime  cumtime  filename:lineno(function)
    15000    0.046    2.201  river/cluster/dbstream.py:253(_cleanup)
1920316/15000 0.981   2.147  copy.py:119(deepcopy)
```

`_cleanup` was 91% of total `learn_one` time, entirely from `copy.deepcopy(self._micro_clusters)` cloning every micro cluster on every cleanup tick just so a few could be popped. The fix is to collect weak ids in a first pass, then pop in place.

A second `copy.deepcopy` lived inside `_generate_clusters_from_labels`, called from every `_recluster` on the predict path. It was used purely to obtain a writable copy of the first micro cluster before merging the rest into it; building a fresh `DBSTREAMMicroCluster` with a shallow-copied center dict has the same semantics for the same price as a plain dict copy. While there, the O(k·m) double loop over `range(max_label + 1)` × `cluster_labels.items()` is collapsed to a single grouping pass.

## Changes

- `_cleanup`: collect weak ids in one pass, then pop in place. No `deepcopy`.
- `_generate_clusters_from_labels`: group by label in one pass; build the macro cluster as a fresh `DBSTREAMMicroCluster` with a shallow-copied center dict.
- `_update`: hoist `_gaussian_neighborhood(x, center)` out of the per-feature center dict comprehension (it returned the same scalar for every `j` and was being recomputed `n_features` times); replace the nested `try/except KeyError` shared-density update with a `dict.get` / lazy-init.
- Drops the now-unused `import copy`.

## Test plan

- [x] `uv run pytest river/cluster/test_dbstream.py river/cluster/dbstream.py` — 10/10 pass (incl. doctest and the synthetic_sklearn v_beta check to 4 decimals)
- [x] cProfile + timing harness on 15k samples (see Summary) — `learn_one` ~6.1× faster, `learn_one + predict_one` ~4.3× faster
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)