### PR TITLE
Speed up DenStream by removing speculative copy in _merge

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -27,6 +27,10 @@
 
 - Reimplemented `utils.VectorDict` (and the helper functions `euclidean_distance_dict`, `euclidean_distance_tuple`, `lazy_search_euclidean`) in Rust. The Cython sources are removed; the public API is unchanged. Element-wise operations are faster across the board: `vec + scalar` and `vec * scalar` are ~18% faster on 20-key dicts and ~14% faster on 1000-key dicts; `vec + vec` is 4-5% faster, `vec @ vec` (dot product) is 4-10% faster. The constructor and `__setitem__` are within 1-4% of the Cython baseline (~2 ns absolute, dominated by PyO3 object-allocation overhead).
 
+## cluster
+
+- Sped up `cluster.DenStream._merge` by replacing the speculative `copy.copy` + insert + radius check with a non-mutating `radius_with(x)` that computes the would-be radius directly from `linear_sum`, `squared_sum` and `N`. Cached each micro-cluster's center (it reduces to `linear_sum / N` once the fading factor is cancelled algebraically), and switched the per-candidate distance lookup in `_get_closest_cluster_key` from the `utils.math.minkowski_distance` Python wrapper to a direct call into the Rust `euclidean_distance_dict`. On a 20k-sample 10-feature synthetic stream, `learn_one` is ~1.7× faster (6.4 µs/point → 3.8 µs/point). The change also fixes a latent shallow-copy bug: the previous code shared `linear_sum`/`squared_sum` between the `copy.copy` and the original, so a failed radius check left the original cluster with the candidate point's contributions added in (without bumping `N`).
+
 ## tree
 
 - Fixed `MondrianNodeClassifier.replant` not copying the `counts` attribute when promoting a leaf to a branch, leaving the new branch with `n_samples != 0` but empty class counts. The fix mirrors the regressor's `_mean` copy and matches the reference [`onelearn`](https://github.com/onelearn/onelearn) implementation. Addresses [#1823](https://github.com/online-ml/river/issues/1823).

--- a/river/cluster/denstream.py
+++ b/river/cluster/denstream.py
@@ -5,7 +5,8 @@ import math
 from abc import ABCMeta
 from collections import defaultdict, deque
 
-from river import base, utils
+from river import base
+from river.utils.vectordict import euclidean_distance_dict
 
 
 class DenStream(base.Clusterer):
@@ -168,7 +169,7 @@ class DenStream(base.Clusterer):
         self._time_period = math.ceil(
             (1 / self.decaying_factor) * math.log((self.mu * self.beta) / (self.mu * self.beta - 1))
         )
-        self._init_buffer: deque[dict] = deque()
+        self._init_buffer: deque[DenStream.BufferItem] = deque()
         self._n_samples_seen = 0
 
         # check that the value of beta is within the range (0,1]
@@ -183,14 +184,13 @@ class DenStream(base.Clusterer):
 
     @staticmethod
     def _distance(point_a, point_b):
-        return utils.math.minkowski_distance(point_a, point_b, 2)
+        return euclidean_distance_dict(point_a, point_b)
 
     def _get_closest_cluster_key(self, point, clusters):
         min_distance = math.inf
         key = -1
         for k, cluster in clusters.items():
-            center = cluster.calc_center(self.timestamp)
-            distance = self._distance(center, point)
+            distance = euclidean_distance_dict(cluster.center, point)
             if distance < min_distance:
                 min_distance = distance
                 key = k
@@ -203,25 +203,22 @@ class DenStream(base.Clusterer):
         if len(self.p_micro_clusters) != 0:
             # try to merge p into its nearest p-micro-cluster c_p
             closest_pmc_key = self._get_closest_cluster_key(point, self.p_micro_clusters)
-            updated_pmc = copy.copy(self.p_micro_clusters[closest_pmc_key])
-            updated_pmc.insert(point, self.timestamp)
-            if updated_pmc.calc_radius(self.timestamp) <= self.epsilon:
+            closest_pmc = self.p_micro_clusters[closest_pmc_key]
+            if closest_pmc.radius_with(point) <= self.epsilon:
                 # keep updated p-micro-cluster
-                self.p_micro_clusters[closest_pmc_key] = updated_pmc
+                closest_pmc.insert(point, self.timestamp)
                 merged_status = True
 
         if not merged_status and len(self.o_micro_clusters) != 0:
             closest_omc_key = self._get_closest_cluster_key(point, self.o_micro_clusters)
-            updated_omc = copy.copy(self.o_micro_clusters[closest_omc_key])
-            updated_omc.insert(point, self.timestamp)
-            if updated_omc.calc_radius(self.timestamp) <= self.epsilon:
+            closest_omc = self.o_micro_clusters[closest_omc_key]
+            if closest_omc.radius_with(point) <= self.epsilon:
+                closest_omc.insert(point, self.timestamp)
                 # keep updated o-micro-cluster
-                if updated_omc.calc_weight(self.timestamp) > self.mu * self.beta:
+                if closest_omc.calc_weight(self.timestamp) > self.mu * self.beta:
                     # it has grown into a p-micro-cluster
                     del self.o_micro_clusters[closest_omc_key]
-                    self.p_micro_clusters[len(self.p_micro_clusters)] = updated_omc
-                else:
-                    self.o_micro_clusters[closest_omc_key] = updated_omc
+                    self.p_micro_clusters[len(self.p_micro_clusters)] = closest_omc
             else:
                 # create a new o-micro-cluster by p and add it to o_micro_clusters
                 mc_from_p = DenStreamMicroCluster(
@@ -243,9 +240,7 @@ class DenStream(base.Clusterer):
     def _is_directly_density_reachable(self, c_p, c_q):
         if c_p.calc_weight(self.timestamp) > self.mu and c_q.calc_weight(self.timestamp) > self.mu:
             # check distance of two clusters and compare with 2*epsilon
-            c_p_center = c_p.calc_center(self.timestamp)
-            c_q_center = c_q.calc_center(self.timestamp)
-            distance = self._distance(c_p_center, c_q_center)
+            distance = euclidean_distance_dict(c_p.center, c_q.center)
             if distance < 2 * self.epsilon and distance <= c_p.calc_radius(
                 self.timestamp
             ) + c_q.calc_radius(self.timestamp):
@@ -293,7 +288,7 @@ class DenStream(base.Clusterer):
         neighborhood_ids = deque()
         for idx, other in enumerate(self._init_buffer):
             if not other.covered:
-                if self._distance(item.x, other.x) < self.epsilon:
+                if euclidean_distance_dict(item.x, other.x) < self.epsilon:
                     neighborhood_ids.append(idx)
         return neighborhood_ids
 
@@ -402,63 +397,111 @@ class DenStreamMicroCluster(metaclass=ABCMeta):
         self.decaying_factor = decaying_factor
 
         self.N = 1
-        self.linear_sum = x
+        # Copy x so subsequent mutations don't alias the caller's dict.
+        self.linear_sum = dict(x)
         self.squared_sum = {i: (x_val * x_val) for i, x_val in x.items()}
+        self._center: dict | None = None
 
     def calc_norm_cf1_cf2(self, fading_factor):
         # |CF1| and |CF2| in the paper
-        sum_of_squares_cf1 = 0
-        sum_of_squares_cf2 = 0
-        for key in self.linear_sum.keys():
-            val_ls = self.linear_sum[key]
-            val_ss = self.squared_sum[key]
-            sum_of_squares_cf1 += fading_factor * val_ls * fading_factor * val_ls
-            sum_of_squares_cf2 += fading_factor * val_ss * fading_factor * val_ss
-        # return |CF1| and |CF2|
-        return math.sqrt(sum_of_squares_cf1), math.sqrt(sum_of_squares_cf2)
+        sum_of_squares_cf1 = 0.0
+        sum_of_squares_cf2 = 0.0
+        squared_sum = self.squared_sum
+        for key, val_ls in self.linear_sum.items():
+            val_ss = squared_sum[key]
+            sum_of_squares_cf1 += val_ls * val_ls
+            sum_of_squares_cf2 += val_ss * val_ss
+        # (ff * v)^2 = ff^2 * v^2 -- factor ff out of the sum once.
+        return fading_factor * math.sqrt(sum_of_squares_cf1), fading_factor * math.sqrt(
+            sum_of_squares_cf2
+        )
 
     def calc_weight(self, timestamp):
-        return self._weight(self.fading_function(timestamp - self.last_edit_time))
+        return self.N * 2 ** (-self.decaying_factor * (timestamp - self.last_edit_time))
 
     def _weight(self, fading_factor):
         return self.N * fading_factor
 
+    @property
+    def center(self):
+        # The fading factor cancels in (ff * ls[k]) / (N * ff), so the center is
+        # just linear_sum / N -- independent of timestamp -- and can be cached.
+        if self._center is None:
+            inv_n = 1.0 / self.N
+            self._center = {key: val * inv_n for key, val in self.linear_sum.items()}
+        return self._center
+
     def calc_center(self, timestamp):
-        ff = self.fading_function(timestamp - self.last_edit_time)
-        weight = self._weight(ff)
-        center = {key: (ff * val) / weight for key, val in self.linear_sum.items()}
-        return center
+        return self.center
 
     def calc_radius(self, timestamp):
-        ff = self.fading_function(timestamp - self.last_edit_time)
-        weight = self._weight(ff)
-        norm_cf1, norm_cf2 = self.calc_norm_cf1_cf2(ff)
-        diff = (norm_cf2 / weight) - ((norm_cf1 / weight) ** 2)
-        radius = math.sqrt(diff) if diff > 0 else 0
-        return radius
+        # The fading factor cancels here too: diff = sqrt(sum ss^2)/N - sum ls^2/N^2.
+        inv_n = 1.0 / self.N
+        sum_ls_sq = 0.0
+        sum_ss_sq = 0.0
+        squared_sum = self.squared_sum
+        for key, ls_k in self.linear_sum.items():
+            ss_k = squared_sum[key]
+            sum_ls_sq += ls_k * ls_k
+            sum_ss_sq += ss_k * ss_k
+        diff = math.sqrt(sum_ss_sq) * inv_n - sum_ls_sq * inv_n * inv_n
+        return math.sqrt(diff) if diff > 0 else 0.0
+
+    def radius_with(self, x):
+        """Radius the cluster would have if ``x`` were inserted, without mutating state."""
+        n1 = self.N + 1
+        inv_n = 1.0 / n1
+        ls = self.linear_sum
+        ss = self.squared_sum
+        sum_ls_sq = 0.0
+        sum_ss_sq = 0.0
+        shared = 0
+        for key, v in x.items():
+            ls_k = ls.get(key, 0.0) + v
+            ss_k = ss.get(key, 0.0) + v * v
+            sum_ls_sq += ls_k * ls_k
+            sum_ss_sq += ss_k * ss_k
+            if key in ls:
+                shared += 1
+        if shared < len(ls):
+            for key, ls_k in ls.items():
+                if key in x:
+                    continue
+                ss_k = ss[key]
+                sum_ls_sq += ls_k * ls_k
+                sum_ss_sq += ss_k * ss_k
+        diff = math.sqrt(sum_ss_sq) * inv_n - sum_ls_sq * inv_n * inv_n
+        return math.sqrt(diff) if diff > 0 else 0.0
 
     def insert(self, x, timestamp):
         self.N += 1
         self.last_edit_time = timestamp
+        linear_sum = self.linear_sum
+        squared_sum = self.squared_sum
         for key, val in x.items():
-            try:
-                self.linear_sum[key] += val
-                self.squared_sum[key] += val * val
-            except KeyError:
-                self.linear_sum[key] = val
-                self.squared_sum[key] = val * val
+            if key in linear_sum:
+                linear_sum[key] += val
+                squared_sum[key] += val * val
+            else:
+                linear_sum[key] = val
+                squared_sum[key] = val * val
+        self._center = None
 
     def merge(self, cluster):
         self.N += cluster.N
-        for key in cluster.linear_sum.keys():
-            try:
-                self.linear_sum[key] += cluster.linear_sum[key]
-                self.squared_sum[key] += cluster.squared_sum[key]
-            except KeyError:
-                self.linear_sum[key] = cluster.linear_sum[key]
-                self.squared_sum[key] = cluster.squared_sum[key]
+        linear_sum = self.linear_sum
+        squared_sum = self.squared_sum
+        other_ss = cluster.squared_sum
+        for key, val in cluster.linear_sum.items():
+            if key in linear_sum:
+                linear_sum[key] += val
+                squared_sum[key] += other_ss[key]
+            else:
+                linear_sum[key] = val
+                squared_sum[key] = other_ss[key]
         if self.last_edit_time < cluster.creation_time:
             self.last_edit_time = cluster.creation_time
+        self._center = None
 
     def fading_function(self, time):
         return 2 ** (-self.decaying_factor * time)


### PR DESCRIPTION
## Summary

- Replace the `copy.copy(cluster) + insert + calc_radius` pattern in `DenStream._merge` with a non-mutating `DenStreamMicroCluster.radius_with(x)` that computes the would-be radius directly. The previous shallow `copy.copy` aliased `linear_sum`/`squared_sum` between the copy and the original, so a failed radius check left the original cluster with the candidate point's contributions added in (without bumping `N`) — fixing this is a side effect of removing the copy.
- Cache each micro-cluster's center: the fading factor algebraically cancels in `(ff * linear_sum[k]) / (N * ff)`, so center is just `linear_sum / N`, independent of timestamp. Same cancellation applies to `calc_radius`. Invalidate the cache on `insert`/`merge`.
- Call `euclidean_distance_dict` (Rust) directly in the hot paths instead of going through the `utils.math.minkowski_distance` Python wrapper.

On a 20k-sample 10-feature synthetic Gaussian-mixture stream, `learn_one` goes from 6.37 µs/point to 3.79 µs/point — ~1.7× faster. The pyinstrument profile shifts `_get_closest_cluster_key` from 0.142 s to 0.046 s, and `_merge` overall from 0.222 s to 0.135 s.

## Test plan

- [x] `uv run pytest --doctest-modules river/cluster/denstream.py`
- [x] `uv run pytest river/test_estimators.py -k DenStream` (11 `check_estimator` checks pass)
- [x] `uv run pytest river/cluster --doctest-modules` (all 16 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)