### PR TITLE
Speed up CluStream learn_one ~3.9x

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -27,6 +27,10 @@
 
 - Reimplemented `utils.VectorDict` (and the helper functions `euclidean_distance_dict`, `euclidean_distance_tuple`, `lazy_search_euclidean`) in Rust. The Cython sources are removed; the public API is unchanged. Element-wise operations are faster across the board: `vec + scalar` and `vec * scalar` are ~18% faster on 20-key dicts and ~14% faster on 1000-key dicts; `vec + vec` is 4-5% faster, `vec @ vec` (dot product) is 4-10% faster. The constructor and `__setitem__` are within 1-4% of the Cython baseline (~2 ns absolute, dominated by PyO3 object-allocation overhead).
 
+## cluster
+
+- Sped up `cluster.CluStream.learn_one` by caching each micro-cluster's `center` dict on the micro-cluster itself (invalidated on `insert` / `__iadd__`), materializing the center list once at the top of `_maintain_micro_clusters` instead of rebuilding it inside the n² pairwise scan, replacing the deepcopy-heavy `Var.__add__` calls in `CluStreamMicroCluster.__iadd__` with in-place `Var.__iadd__`, and switching `_distance` from the `utils.math.minkowski_distance` Python wrapper to a direct call into the Rust `euclidean_distance_dict`. The fix removes ~36M redundant `center` dict rebuilds and 367M `Mean.get` calls on a 5k-sample 10-feature synthetic stream. End-to-end `learn_one` is ~3.9× faster at d=10 (25.5 s → 6.5 s for 5k points), ~3.8× at d=20 and ~3.8× at d=50.
+
 ## tree
 
 - Fixed `MondrianNodeClassifier.replant` not copying the `counts` attribute when promoting a leaf to a branch, leaving the new branch with `n_samples != 0` but empty class counts. The fix mirrors the regressor's `_mean` copy and matches the reference [`onelearn`](https://github.com/onelearn/onelearn) implementation. Addresses [#1823](https://github.com/online-ml/river/issues/1823).

--- a/river/cluster/clustream.py
+++ b/river/cluster/clustream.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import math
 from collections import defaultdict
 
-from river import base, cluster, stats, utils
+from river import base, cluster, stats
+from river.utils.vectordict import euclidean_distance_dict
 
 
 class CluStream(base.Clusterer):
@@ -164,19 +165,24 @@ class CluStream(base.Clusterer):
             )
             return
 
-        # Merge the two closest micro-clusters
-        closest_a = 0
-        closest_b = 0
+        # Merge the two closest micro-clusters. Materialize centers once —
+        # `mc.center` is cached but iterating it n² times is still wasteful.
+        # Iterate `b < a` so the higher-index micro-cluster is kept as the
+        # merge target (preserves the original i>j convention).
+        ids = list(self.micro_clusters)
+        centers = [self.micro_clusters[i].center for i in ids]
+
+        closest_a = ids[0]
+        closest_b = ids[0]
         min_distance = math.inf
-        for i, mc_a in self.micro_clusters.items():
-            for j, mc_b in self.micro_clusters.items():
-                if i <= j:
-                    continue
-                dist = self._distance(mc_a.center, mc_b.center)
+        for a in range(len(ids)):
+            center_a = centers[a]
+            for b in range(a):
+                dist = self._distance(center_a, centers[b])
                 if dist < min_distance:
                     min_distance = dist
-                    closest_a = i
-                    closest_b = j
+                    closest_a = ids[a]
+                    closest_b = ids[b]
 
         self.micro_clusters[closest_a] += self.micro_clusters[closest_b]
         self.micro_clusters[closest_b] = CluStreamMicroCluster(
@@ -198,7 +204,7 @@ class CluStream(base.Clusterer):
 
     @staticmethod
     def _distance(point_a, point_b):
-        return utils.math.minkowski_distance(point_a, point_b, 2)
+        return euclidean_distance_dict(point_a, point_b)
 
     def learn_one(self, x, w=1.0):
         self._timestamp += 1
@@ -284,10 +290,13 @@ class CluStreamMicroCluster(base.Base):
             self.var_x[k] = v
         self.var_time = stats.Var()
         self.var_time.update(timestamp, w)
+        self._center: dict | None = None
 
     @property
     def center(self):
-        return {k: var.mean.get() for k, var in self.var_x.items()}
+        if self._center is None:
+            self._center = {k: var.mean.get() for k, var in self.var_x.items()}
+        return self._center
 
     def radius(self, r_factor):
         if self.weight == 1:
@@ -308,6 +317,7 @@ class CluStreamMicroCluster(base.Base):
         self.var_time.update(timestamp, w)
         for x_idx, x_val in x.items():
             self.var_x[x_idx].update(x_val, w)
+        self._center = None
 
     def relevance_stamp(self, max_mc):
         mu_time = self.var_time.mean.get()
@@ -348,5 +358,9 @@ class CluStreamMicroCluster(base.Base):
 
     def __iadd__(self, other: CluStreamMicroCluster):
         self.var_time += other.var_time
-        self.var_x = {k: self.var_x[k] + other.var_x.get(k, stats.Var()) for k in self.var_x}
+        for k, var in self.var_x.items():
+            other_var = other.var_x.get(k)
+            if other_var is not None:
+                var += other_var
+        self._center = None
         return self


### PR DESCRIPTION
## Summary

- `cluster.CluStream.learn_one` was dominated by `_maintain_micro_clusters` rebuilding every micro-cluster's `center` dict inside an n² pairwise scan (~36M `center` rebuilds, 367M `Mean.get` calls per 5k-sample d=10 run under cProfile).
- Cache the `center` dict on each `CluStreamMicroCluster` (invalidated in `insert` / `__iadd__`); materialize centers once before the pairwise scan and iterate `for b in range(a)` so the half-triangle reuses the cached centers; preserve the original `i > j` merge-target convention so the existing doctest is unchanged.
- Replace the deepcopy-heavy `var_x[k] + other.var_x.get(k, stats.Var())` in `CluStreamMicroCluster.__iadd__` with in-place `Var.__iadd__`, and switch `_distance` from the `utils.math.minkowski_distance` Python wrapper to a direct call into the Rust `euclidean_distance_dict` (same swap DenStream / Silhouette already use).

## Throughput

Best of 3 on a synthetic Gaussian-mixture stream (`max_micro_clusters=100`, default params):

| n_points | d   | before  | after   | speedup |
| -------- | --- | ------- | ------- | ------- |
| 5000     | 10  | 25.49 s | 6.49 s  | ~3.9×   |
| 5000     | 20  | 52.60 s | 13.72 s | ~3.8×   |
| 2000     | 50  | 50.42 s | 13.24 s | ~3.8×   |

## Test plan

- [x] `uv run pytest river/cluster/clustream.py` (doctest passes — merge order preserved)
- [x] `uv run pytest river/test_estimators.py -k CluStream` (all 11 estimator checks pass)
- [x] `uv run pre-commit run --all-files` on the staged changes (ruff, ruff format, mypy all pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)