### PR TITLE
Replace minkowski_distance(p=2) with euclidean_distance_dict

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -20,12 +20,22 @@
 
 ## metrics
 
+- Sped up `metrics.Silhouette` by switching the centroid distance computations from the `utils.math.minkowski_distance` Python wrapper to a direct call into the Rust `euclidean_distance_dict`.
+
 - Reimplemented the inner `expected_mutual_info` routine (used by `metrics.AdjustedMutualInfo`) in Rust. The Cython sources are removed and the new implementation is roughly twice as fast as the old one across all tested contingency-table sizes.
 - Reimplemented `metrics.RollingROCAUC` and `metrics.RollingPRAUC` in Rust. The C++ implementation is removed. Output is bit-identical to the C++ version on all tested inputs and a latent bug in `revert()` with a non-default `pos_val` is also fixed.
 
 ## utils
 
 - Reimplemented `utils.VectorDict` (and the helper functions `euclidean_distance_dict`, `euclidean_distance_tuple`, `lazy_search_euclidean`) in Rust. The Cython sources are removed; the public API is unchanged. Element-wise operations are faster across the board: `vec + scalar` and `vec * scalar` are ~18% faster on 20-key dicts and ~14% faster on 1000-key dicts; `vec + vec` is 4-5% faster, `vec @ vec` (dot product) is 4-10% faster. The constructor and `__setitem__` are within 1-4% of the Cython baseline (~2 ns absolute, dominated by PyO3 object-allocation overhead).
+
+## anomaly
+
+- Sped up `anomaly.LocalOutlierFactor` by replacing the default `functools.partial(utils.math.minkowski_distance, p=2)` distance function with a direct call into the Rust `euclidean_distance_dict`, removing the Python-level dispatch.
+
+## cluster
+
+- Sped up `cluster.STREAMKMeans.predict_one` by switching the per-center distance from the `utils.math.minkowski_distance` Python wrapper to a direct call into the Rust `euclidean_distance_dict`.
 
 ## tree
 

--- a/river/anomaly/lof.py
+++ b/river/anomaly/lof.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import copy
-import functools
 
 import pandas as pd
 
-from river import anomaly, utils
+from river import anomaly
 from river.neighbors.base import DistanceFunc
+from river.utils.vectordict import euclidean_distance_dict
 
 
 def check_equal(x_list: list, y_list: list):
@@ -267,11 +267,7 @@ class LocalOutlierFactor(anomaly.base.AnomalyDetector):
         self.lof: dict = {}
         self.local_reach: dict = {}
         self.distance_func = distance_func
-        self.distance = (
-            distance_func
-            if distance_func is not None
-            else functools.partial(utils.math.minkowski_distance, p=2)
-        )
+        self.distance = distance_func if distance_func is not None else euclidean_distance_dict
 
     def learn_many(self, x: pd.DataFrame):
         x = x[0].tolist()

--- a/river/cluster/streamkmeans.py
+++ b/river/cluster/streamkmeans.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from river import base, cluster, utils
+from river import base, cluster
+from river.utils.vectordict import euclidean_distance_dict
 
 
 class STREAMKMeans(base.Clusterer):
@@ -107,6 +108,6 @@ class STREAMKMeans(base.Clusterer):
 
     def predict_one(self, x, w=None):
         def get_distance(c):
-            return utils.math.minkowski_distance(self.centers[c], x, 2)
+            return euclidean_distance_dict(self.centers[c], x)
 
         return min(self.centers, key=get_distance)

--- a/river/metrics/silhouette.py
+++ b/river/metrics/silhouette.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import math
 
-from river import metrics, utils
+from river import metrics
+from river.utils.vectordict import euclidean_distance_dict
 
 
 class Silhouette(metrics.base.ClusteringMetric):
@@ -65,14 +66,14 @@ class Silhouette(metrics.base.ClusteringMetric):
 
     @staticmethod
     def _find_distance_second_closest_center(centers, x):
-        distances = {i: utils.math.minkowski_distance(centers[i], x, 2) for i in centers}
+        distances = {i: euclidean_distance_dict(centers[i], x) for i in centers}
         return sorted(distances.values())[-2]
 
     def update(self, x, y_pred, centers, w=1.0):
         if y_pred not in centers or len(centers) < 2:
             return
 
-        distance_closest_centroid = utils.math.minkowski_distance(centers[y_pred], x, 2)
+        distance_closest_centroid = euclidean_distance_dict(centers[y_pred], x)
         self._sum_distance_closest_centroid += distance_closest_centroid
 
         distance_second_closest_centroid = self._find_distance_second_closest_center(centers, x)
@@ -82,7 +83,7 @@ class Silhouette(metrics.base.ClusteringMetric):
         if y_pred not in centers or len(centers) < 2:
             return
 
-        distance_closest_centroid = utils.math.minkowski_distance(centers[y_pred], x, 2)
+        distance_closest_centroid = euclidean_distance_dict(centers[y_pred], x)
         self._sum_distance_closest_centroid -= distance_closest_centroid
 
         distance_second_closest_centroid = self._find_distance_second_closest_center(centers, x)


### PR DESCRIPTION
## Summary

- `utils.math.minkowski_distance(a, b, 2)` already short-circuits to the Rust `euclidean_distance_dict`, so callers that hardcode `p=2` pay an extra Python-level branch and function call for no reason.
- Swap the direct call sites in `metrics.Silhouette` (3 sites), `cluster.STREAMKMeans.predict_one` (1 site), and the default distance in `anomaly.LocalOutlierFactor` (1 site, dropping a `functools.partial` wrap) to call the Rust function directly.
- `minkowski_distance` itself is untouched — it remains part of the public `utils.math` API.

Not in scope: `cluster.DBSTREAM` and the corresponding test handle the same pattern but are being addressed in a separate branch. `cluster.DenStream` and the `KNNClassifier` docstring example still reference `minkowski_distance`, but the former isn't restricted to `p=2` in this codebase's usage pattern and the latter is illustrating the `p=1` use case.

## Test plan

- [x] `uv run pytest river/metrics/silhouette.py river/cluster/streamkmeans.py river/anomaly/lof.py` — all pass (including doctests)
- [x] Pre-commit (ruff, mypy) passes on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)