### PR TITLE
Speed up preprocessing scalers and OneHotEncoder

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -37,6 +37,12 @@
 
 - Sped up `cluster.STREAMKMeans.predict_one` by switching the per-center distance from the `utils.math.minkowski_distance` Python wrapper to a direct call into the Rust `euclidean_distance_dict`.
 
+## preprocessing
+
+- Sped up `preprocessing.OneHotEncoder.transform_one` by ~8x and `learn_one + transform_one` by ~5.5x (on 100k rows × 5 features with cardinality 20). The previous implementation rebuilt the all-zeros dict via `{f"{i}_{v}": 0 ...}` on every call; the encoder now maintains an incremental cache of that zero-dict and `transform_one` copies it instead of rebuilding. Output is unchanged.
+- Sped up `preprocessing.StandardScaler` by ~15% on `learn_one` and `learn_one + transform_one` by hoisting the `self.counts`/`self.means`/`self.vars` dict references out of the inner loop, splitting the `with_std=True` and `with_std=False` paths, and folding the `safe_div` call in `transform_one` into an inline branch (eliminating ~1M function calls per 100k samples × 10 features). The Welford update formula is unchanged.
+- Sped up `preprocessing.MinMaxScaler.transform_one` by ~1.3x by caching each feature's `self.min[i].get()` and `self.max[i].get()` results in locals (previously `self.min[i].get()` was called twice per feature) and inlining `safe_div`. `preprocessing.MaxAbsScaler.transform_one` benefits from the same `safe_div` inlining. `learn_one` is also slightly faster thanks to hoisting `self.min`/`self.max`/`self.abs_max` out of the loop. `.update()`/`.get()` on `stats.Min`/`stats.Max`/`stats.AbsMax` remain the only paths into those objects.
+
 ## tree
 
 - Fixed `MondrianNodeClassifier.replant` not copying the `counts` attribute when promoting a leaf to a branch, leaving the new branch with `n_samples != 0` but empty class counts. The fix mirrors the regressor's `_mean` copy and matches the reference [`onelearn`](https://github.com/onelearn/onelearn) implementation. Addresses [#1823](https://github.com/online-ml/river/issues/1823).

--- a/river/preprocessing/one_hot.py
+++ b/river/preprocessing/one_hot.py
@@ -249,11 +249,14 @@ class OneHotEncoder(base.MiniBatchTransformer):
         self.drop_first = drop_first
         self.categories = categories
         self.values: collections.defaultdict | dict | None = None
+        self._zero_dict: dict = {}
 
         if self.categories is None:
             self.values = collections.defaultdict(set)
         else:
             self.values = self.categories
+            if not self.drop_zeros:
+                self._zero_dict = {f"{i}_{v}": 0 for i, vals in self.values.items() for v in vals}
 
     def learn_one(self, x):
         if self.drop_zeros:
@@ -262,42 +265,45 @@ class OneHotEncoder(base.MiniBatchTransformer):
         # NOTE: assume if category mappings are explicitly provided,
         # they're intended to be kept fixed.
         if self.categories is None:
+            values = self.values
+            zero_dict = self._zero_dict
             for i, xi in x.items():
-                if isinstance(xi, list) or isinstance(xi, set):
+                vi = values[i]
+                if isinstance(xi, (list, set)):
                     for xj in xi:
-                        self.values[i].add(xj)
-                else:
-                    self.values[i].add(xi)
+                        if xj not in vi:
+                            vi.add(xj)
+                            zero_dict[f"{i}_{xj}"] = 0
+                elif xi not in vi:
+                    vi.add(xi)
+                    zero_dict[f"{i}_{xi}"] = 0
 
     def transform_one(self, x, y=None):
-        oh = {}
-
-        # Add 0s
-        if not self.drop_zeros:
-            oh = {f"{i}_{v}": 0 for i, values in self.values.items() for v in values}
+        oh = {} if self.drop_zeros else self._zero_dict.copy()
 
         # Add 1
         # NOTE: assume if category mappings are explicitly provided,
         # no other category values are allowed for output. Aligns with `sklearn` behavior.
         if self.categories is None:
             for i, xi in x.items():
-                if isinstance(xi, list) or isinstance(xi, set):
+                if isinstance(xi, (list, set)):
                     for xj in xi:
                         oh[f"{i}_{xj}"] = 1
                 else:
                     oh[f"{i}_{xi}"] = 1
         else:
+            values = self.values
             for i, xi in x.items():
-                if isinstance(xi, list) or isinstance(xi, set):
+                vi = values[i]
+                if isinstance(xi, (list, set)):
                     for xj in xi:
-                        if xj in self.values[i]:
+                        if xj in vi:
                             oh[f"{i}_{xj}"] = 1
-                else:
-                    if xi in self.values[i]:
-                        oh[f"{i}_{xi}"] = 1
+                elif xi in vi:
+                    oh[f"{i}_{xi}"] = 1
 
         if self.drop_first:
-            oh.pop(min(oh.keys()))
+            oh.pop(min(oh))
 
         return oh
 
@@ -308,8 +314,14 @@ class OneHotEncoder(base.MiniBatchTransformer):
         # NOTE: assume if category mappings are explicitly provided,
         # they're intended to be kept fixed.
         if self.categories is None:
+            values = self.values
+            zero_dict = self._zero_dict
             for col in X.columns:
-                self.values[col].update(X[col].unique())
+                vi = values[col]
+                for v in X[col].unique():
+                    if v not in vi:
+                        vi.add(v)
+                        zero_dict[f"{col}_{v}"] = 0
 
     def transform_many(self, X):
         oh = pd.get_dummies(X, columns=X.columns, sparse=True, dtype="uint8")

--- a/river/preprocessing/scale.py
+++ b/river/preprocessing/scale.py
@@ -159,19 +159,31 @@ class StandardScaler(base.MiniBatchTransformer):
         self.vars: collections.defaultdict = collections.defaultdict(float)
 
     def learn_one(self, x):
-        for i, xi in x.items():
-            self.counts[i] += 1
-            old_mean = self.means[i]
-            self.means[i] += (xi - old_mean) / self.counts[i]
-            if self.with_std:
-                self.vars[i] += (
-                    (xi - old_mean) * (xi - self.means[i]) - self.vars[i]
-                ) / self.counts[i]
+        counts = self.counts
+        means = self.means
+        vars_ = self.vars
+        if self.with_std:
+            for i, xi in x.items():
+                counts[i] += 1
+                old_mean = means[i]
+                means[i] += (xi - old_mean) / counts[i]
+                vars_[i] += ((xi - old_mean) * (xi - means[i]) - vars_[i]) / counts[i]
+        else:
+            for i, xi in x.items():
+                counts[i] += 1
+                old_mean = means[i]
+                means[i] += (xi - old_mean) / counts[i]
 
     def transform_one(self, x):
+        means = self.means
         if self.with_std:
-            return {i: safe_div(xi - self.means[i], self.vars[i] ** 0.5) for i, xi in x.items()}
-        return {i: xi - self.means[i] for i, xi in x.items()}
+            vars_ = self.vars
+            result = {}
+            for i, xi in x.items():
+                v = vars_[i]
+                result[i] = (xi - means[i]) / v**0.5 if v else 0.0
+            return result
+        return {i: xi - means[i] for i, xi in x.items()}
 
     def learn_many(self, X: pd.DataFrame):
         """Update with a mini-batch of features.
@@ -295,15 +307,22 @@ class MinMaxScaler(base.Transformer):
         self.max: collections.defaultdict = collections.defaultdict(stats.Max)
 
     def learn_one(self, x):
+        min_ = self.min
+        max_ = self.max
         for i, xi in x.items():
-            self.min[i].update(xi)
-            self.max[i].update(xi)
+            min_[i].update(xi)
+            max_[i].update(xi)
 
     def transform_one(self, x):
-        return {
-            i: safe_div(xi - self.min[i].get(), self.max[i].get() - self.min[i].get())
-            for i, xi in x.items()
-        }
+        min_ = self.min
+        max_ = self.max
+        result = {}
+        for i, xi in x.items():
+            lo = min_[i].get()
+            hi = max_[i].get()
+            d = hi - lo
+            result[i] = (xi - lo) / d if d else 0.0
+        return result
 
 
 class MaxAbsScaler(base.Transformer):
@@ -351,11 +370,17 @@ class MaxAbsScaler(base.Transformer):
         self.abs_max: collections.defaultdict = collections.defaultdict(stats.AbsMax)
 
     def learn_one(self, x):
+        abs_max = self.abs_max
         for i, xi in x.items():
-            self.abs_max[i].update(xi)
+            abs_max[i].update(xi)
 
     def transform_one(self, x):
-        return {i: safe_div(xi, self.abs_max[i].get()) for i, xi in x.items()}
+        abs_max = self.abs_max
+        result = {}
+        for i, xi in x.items():
+            m = abs_max[i].get()
+            result[i] = xi / m if m else 0.0
+        return result
 
 
 class RobustScaler(base.Transformer):


### PR DESCRIPTION
## Summary

Profiled and optimized the three preprocessing estimators in scope:

- **`OneHotEncoder.transform_one`** — ~8.0× faster. The previous implementation rebuilt the all-zeros dict via `{f"{i}_{v}": 0 ...}` on every call. The encoder now maintains an incremental cache of that zero-dict in `learn_one` / `learn_many`, and `transform_one` just `.copy()`s it before setting the 1s.
- **`StandardScaler`** — ~15% faster `learn_one`. Hoisted `self.counts`/`self.means`/`self.vars` references into locals, split the `with_std=True`/`with_std=False` branches out of the loop, and inlined the `safe_div` call in `transform_one` (which was a 1M-times-called function for 100k × 10 features). Welford's update formula is unchanged.
- **`MinMaxScaler` / `MaxAbsScaler`** — ~1.3× faster `transform_one`. Cache each feature's `.get()` result in a local (`self.min[i].get()` was called twice per feature) and inline `safe_div`. `stats.Min`/`stats.Max`/`stats.AbsMax` are still updated and read only via their `.update()` / `.get()` methods — no internal abstractions were bypassed.

### Benchmarks (best of 5, 100k samples)

| Op | Baseline | After | Speedup |
|---|---|---|---|
| `StandardScaler.learn_one` (10 feat) | 232.8 ms | 204.7 ms | 1.14× |
| `StandardScaler.transform_one` | 112.3 ms | 96.3 ms | 1.17× |
| `StandardScaler.learn+transform` | 345.6 ms | 305.3 ms | 1.13× |
| `MinMaxScaler.transform_one` (10 feat) | 127.7 ms | 99.2 ms | 1.29× |
| `MinMaxScaler.learn+transform` | 196.9 ms | 166.1 ms | 1.19× |
| `OneHotEncoder.transform_one` (5 feat, k=20) | 566.5 ms | 69.1 ms | **8.20×** |
| `OneHotEncoder.learn+transform` | 607.6 ms | 109.5 ms | **5.55×** |

### Correctness

Outputs are bit-identical to baseline across a 500-row parity test for `StandardScaler`, `MinMaxScaler`, `MaxAbsScaler`, and `OneHotEncoder` (including `drop_zeros=True, drop_first=True`).

## Test plan

- [x] `uv run pytest river/preprocessing` — 32 passed
- [x] `uv run pytest river/test_estimators.py -k 'StandardScaler or MinMaxScaler or MaxAbsScaler or OneHotEncoder'` — 312 `check_estimator` framework checks passed
- [x] `uv run pytest river/compose` — pipeline integration still passes
- [x] Parity check: encoded outputs identical to baseline for all four classes
- [x] Pickle roundtrip and `categories=...` / `learn_many` paths for `OneHotEncoder` exercised manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)