### PR TITLE
Add estimator checks for forecasters

### DIFF
--- a/river/checks/__init__.py
+++ b/river/checks/__init__.py
@@ -11,7 +11,7 @@ from river.base import Estimator
 from river.model_selection.base import ModelSelector
 from river.reco.base import Ranker
 
-from . import anomaly, clf, common, model_selection, reco
+from . import anomaly, clf, common, model_selection, reco, time_series
 
 __all__ = ["check_estimator", "yield_checks"]
 
@@ -53,6 +53,23 @@ def _yield_datasets(model: Estimator):
 
     from river import base, compose, datasets, preprocessing, stream
     from river.anomaly.base import AnomalyDetector
+    from river.time_series.base import Forecaster
+
+    # Time series forecasters have a specialized interface: learn_one(y, x=None) and
+    # forecast(horizon, xs=None). The dataset still yields (x, y) pairs so checks can
+    # exercise optional exogenous features.
+    if isinstance(model, Forecaster):
+        yield _DummyDataset(
+            ({"time": 1.0, "period": 1.0}, 10.0),
+            ({"time": 2.0, "period": 2.0}, 12.0),
+            ({"time": 3.0, "period": 3.0}, 13.0),
+            ({"time": 4.0, "period": 0.0}, 16.0),
+            ({"time": 5.0, "period": 1.0}, 18.0),
+            ({"time": 6.0, "period": 2.0}, 20.0),
+            ({"time": 7.0, "period": 3.0}, 21.0),
+            ({"time": 8.0, "period": 0.0}, 24.0),
+        )
+        return
 
     # Recommendation models can be regressors or classifiers, but they have requirements as to the
     # structure of the data
@@ -122,6 +139,7 @@ def yield_checks(model: Estimator) -> typing.Iterator[typing.Callable]:
 
     from river import base
     from river.anomaly.base import AnomalyDetector
+    from river.time_series.base import Forecaster
 
     # General checks
     yield common.check_repr
@@ -174,6 +192,12 @@ def yield_checks(model: Estimator) -> typing.Iterator[typing.Callable]:
 
     if isinstance(model, AnomalyDetector):
         dataset_checks.append(anomaly.check_roc_auc)
+
+    if isinstance(model, Forecaster):
+        dataset_checks = [
+            time_series.check_learn_one,
+            time_series.check_forecast,
+        ]
 
     for dataset_check in dataset_checks:
         for dataset in _yield_datasets(model):

--- a/river/checks/time_series.py
+++ b/river/checks/time_series.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import copy
+
+
+def check_learn_one(model, dataset):
+    """learn_one should accept a target followed by optional exogenous features."""
+
+    for x, y in dataset:
+        xx, yy = copy.deepcopy(x), copy.deepcopy(y)
+
+        model.learn_one(y, x)
+
+        assert x == xx
+        assert y == yy
+
+
+def check_forecast(model, dataset):
+    """forecast should return one prediction for each requested horizon step."""
+
+    horizon = 3
+    xs = [
+        {"time": 100.0, "period": 0.0},
+        {"time": 101.0, "period": 1.0},
+        {"time": 102.0, "period": 2.0},
+    ]
+
+    for x, y in dataset:
+        model.learn_one(y, x)
+
+    y_pred = model.forecast(horizon=horizon, xs=xs)
+
+    assert isinstance(y_pred, list)
+    assert len(y_pred) == horizon

--- a/river/test_estimators.py
+++ b/river/test_estimators.py
@@ -24,7 +24,6 @@ from river import (
     neighbors,
     neural_net,
     preprocessing,
-    time_series,
 )
 from river.compat.river_to_sklearn import River2SKLBase
 from river.compat.sklearn_to_river import SKL2RiverBase
@@ -74,7 +73,6 @@ def iter_estimators_which_can_be_tested():
         preprocessing.PreviousImputer,
         preprocessing.OneHotEncoder,
         preprocessing.StatImputer,
-        time_series.base.Forecaster,
     )
 
     def can_be_tested(estimator):

--- a/river/time_series/holt_winters.py
+++ b/river/time_series/holt_winters.py
@@ -17,6 +17,9 @@ class AdditiveLevel(Component):
         super().__init__([], maxlen=2)
         self.alpha = alpha
 
+    def __reduce__(self):
+        return self.__class__, (self.alpha,), None, iter(self)
+
     def update(self, y, trend, season):
         self.append(
             self.alpha * (y - (season[-season.seasonality] if season else 0))
@@ -28,6 +31,9 @@ class MultiplicativeLevel(Component):
     def __init__(self, alpha):
         super().__init__([], maxlen=2)
         self.alpha = alpha
+
+    def __reduce__(self):
+        return self.__class__, (self.alpha,), None, iter(self)
 
     def update(self, y, trend, season):
         self.append(
@@ -41,6 +47,9 @@ class Trend(Component):
         super().__init__([], maxlen=2)
         self.beta = beta
 
+    def __reduce__(self):
+        return self.__class__, (self.beta,), None, iter(self)
+
     def update(self, y, level):
         self.append(self.beta * (level[-1] - level[-2]) + (1 - self.beta) * self[-1])
 
@@ -50,6 +59,9 @@ class AdditiveSeason(Component):
         super().__init__([], maxlen=seasonality + 1)
         self.gamma = gamma
         self.seasonality = seasonality
+
+    def __reduce__(self):
+        return self.__class__, (self.gamma, self.seasonality), None, iter(self)
 
     def update(self, y, level, trend):
         self.append(
@@ -62,6 +74,9 @@ class MultiplicativeSeason(Component):
         super().__init__([], maxlen=seasonality + 1)
         self.gamma = gamma
         self.seasonality = seasonality
+
+    def __reduce__(self):
+        return self.__class__, (self.gamma, self.seasonality), None, iter(self)
 
     def update(self, y, level, trend):
         self.append(
@@ -151,6 +166,10 @@ class HoltWinters(time_series.base.Forecaster):
     [^3]: [What is Exponential Smoothing? — Engineering statistics handbook](https://www.itl.nist.gov/div898/handbook/pmc/section4/pmc43.htm)
 
     """
+
+    @classmethod
+    def _unit_test_params(cls):
+        yield {"alpha": 0.4}
 
     def __init__(
         self,

--- a/river/time_series/snarimax.py
+++ b/river/time_series/snarimax.py
@@ -271,6 +271,10 @@ class SNARIMAX(time_series.base.Forecaster):
 
     """
 
+    @classmethod
+    def _unit_test_params(cls):
+        yield {"p": 1, "d": 0, "q": 0}
+
     def __init__(
         self,
         p: int,
@@ -300,8 +304,7 @@ class SNARIMAX(time_series.base.Forecaster):
         self.errors: collections.deque[float] = collections.deque(maxlen=max(q, m * sq))
 
     def _add_lag_features(self, x, Y, errors):
-        if x is None:
-            x = {}
+        x = {} if x is None else x.copy()
 
         # AR
         for t in range(self.p):


### PR DESCRIPTION
## Summary
- include time series forecasters in River's estimator checks
- add forecaster-specific learn/forecast checks
- add unit-test params for HoltWinters and SNARIMAX
- fix issues surfaced by the checks: HoltWinters pickle roundtrip and SNARIMAX input mutation

Closes #1872.

## Tests
- pytest river/test_estimators.py -x --tb=short
- pytest river/time_series river/test_estimators.py -k 'HoltWinters or SNARIMAX'
- ruff check river/checks/__init__.py river/checks/time_series.py river/test_estimators.py river/time_series/holt_winters.py river/time_series/snarimax.py