### PR TITLE
Fix SKL2RiverClassifier.predict_proba_many and cover wrappers in estimator checks

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -18,6 +18,11 @@
 
 - Reimplemented `drift.ADWIN`'s inner `AdaptiveWindowing` in Rust. The Cython sources are removed; output is bit-identical to the Cython baseline (width, total, variance, n_detections, drift_detected) over a 3.8k-step parity fuzz. Rust is 1.3-3.5x faster than the previous Cython implementation across `clock` settings.
 
+## compat
+
+- Fixed `compat.SKL2RiverClassifier.predict_proba_many` raising a `TypeError` whenever the wrapped estimator was already fitted: it incorrectly built a `pd.Series(..., columns=...)` instead of a `pd.DataFrame`. Test coverage previously only exercised the not-fitted branch. `SKL2RiverClassifier` and `SKL2RiverRegressor` are now also exercised by the generic estimator-check suite via `_unit_test_params`.
+- Fixed `compat.SKL2RiverClassifier._multiclass` advertising multi-class support unconditionally; it now reflects `len(classes) > 2`.
+
 ## metrics
 
 - Sped up `metrics.Silhouette` by switching the centroid distance computations from the `utils.math.minkowski_distance` Python wrapper to a direct call into the Rust `euclidean_distance_dict`.

--- a/river/compat/sklearn_to_river.py
+++ b/river/compat/sklearn_to_river.py
@@ -6,6 +6,7 @@ import functools
 import pandas as pd
 from sklearn import base as sklearn_base
 from sklearn import exceptions as sklearn_exceptions
+from sklearn import linear_model as sklearn_linear_model
 
 from river import base
 
@@ -121,6 +122,10 @@ class SKL2RiverRegressor(SKL2RiverBase, base.Regressor):
         except sklearn_exceptions.NotFittedError:
             return pd.Series([0] * len(X), index=X.index)
 
+    @classmethod
+    def _unit_test_params(cls):
+        yield {"estimator": sklearn_linear_model.SGDRegressor()}
+
 
 class SKL2RiverClassifier(SKL2RiverBase, base.Classifier):
     """Compatibility layer from scikit-learn to River for classification.
@@ -171,7 +176,7 @@ class SKL2RiverClassifier(SKL2RiverBase, base.Classifier):
 
     @property
     def _multiclass(self):
-        return True
+        return len(self.classes) > 2
 
     def learn_one(self, x, y):
         self.estimator.partial_fit(X=[self._align_dict(x)], y=[y], classes=self.classes)
@@ -188,7 +193,11 @@ class SKL2RiverClassifier(SKL2RiverBase, base.Classifier):
 
     def predict_proba_many(self, X):
         try:
-            return pd.Series(self.estimator.predict_proba(self._align_df(X)), columns=self.classes)
+            return pd.DataFrame(
+                self.estimator.predict_proba(self._align_df(X)),
+                columns=self.classes,
+                index=X.index,
+            )
         except sklearn_exceptions.NotFittedError:
             return pd.DataFrame(
                 [[1 / len(self.classes)] * len(self.classes)] * len(X),
@@ -208,3 +217,10 @@ class SKL2RiverClassifier(SKL2RiverBase, base.Classifier):
             return pd.Series(self.estimator.predict(self._align_df(X)))
         except sklearn_exceptions.NotFittedError:
             return pd.Series([self.classes[0]] * len(X), index=X.index)
+
+    @classmethod
+    def _unit_test_params(cls):
+        yield {
+            "estimator": sklearn_linear_model.SGDClassifier(loss="log_loss"),
+            "classes": [False, True],
+        }

--- a/river/compat/test_sklearn.py
+++ b/river/compat/test_sklearn.py
@@ -75,13 +75,22 @@ def test_not_fitted_still_works_regression(estimator):
     ],
 )
 def test_not_fitted_still_works_classification(estimator, n_classes):
-    X, _ = sk_datasets.make_classification(
+    X, y = sk_datasets.make_classification(
         n_samples=500, n_features=10, n_informative=6, n_classes=n_classes
     )
     X = pd.DataFrame(X)
+    y = pd.Series(y)
     y_pred = estimator.predict_many(X)
     assert len(y_pred) == len(X)
     assert y_pred.eq(0).all()
 
     y_pred_proba = estimator.predict_proba_many(X)
+    assert isinstance(y_pred_proba, pd.DataFrame)
     assert y_pred_proba.shape == (len(X), n_classes)
+
+    # Also exercise the fitted path of predict_proba_many.
+    estimator.learn_many(X, y)
+    y_pred_proba = estimator.predict_proba_many(X)
+    assert isinstance(y_pred_proba, pd.DataFrame)
+    assert y_pred_proba.shape == (len(X), n_classes)
+    assert list(y_pred_proba.index) == list(X.index)

--- a/river/test_estimators.py
+++ b/river/test_estimators.py
@@ -26,7 +26,6 @@ from river import (
     preprocessing,
 )
 from river.compat.river_to_sklearn import River2SKLBase
-from river.compat.sklearn_to_river import SKL2RiverBase
 
 
 def iter_estimators():
@@ -44,7 +43,6 @@ def iter_estimators():
 def iter_estimators_which_can_be_tested():
     ignored = (
         River2SKLBase,
-        SKL2RiverBase,
         anomaly.LocalOutlierFactor,  # needs warm-start to work correctly
         compose.FuncTransformer,
         compose.Grouper,


### PR DESCRIPTION
## Summary

- `SKL2RiverClassifier.predict_proba_many` was building a `pd.Series(..., columns=...)` whenever the wrapped estimator was already fitted — `pd.Series` does not accept `columns`, so this raised `TypeError` on every fitted call. Replaced with `pd.DataFrame(..., columns=self.classes, index=X.index)`. The bug stayed hidden because the only test for the method (`test_not_fitted_still_works_classification`) never calls `learn_*`, so it only ever hit the `NotFittedError` fallback (which already returned a `DataFrame`).
- `SKL2RiverClassifier` and `SKL2RiverRegressor` were excluded from the auto-discovered `check_estimator` suite (via `SKL2RiverBase` in the `ignored` tuple) because they require an sklearn estimator in `__init__`. Added `_unit_test_params` classmethods that yield a default `SGDRegressor` / `SGDClassifier(loss="log_loss")` and removed `SKL2RiverBase` from `ignored`. Both wrappers now run through every relevant check.
- `_multiclass` on `SKL2RiverClassifier` was unconditionally `True`; it now reflects `len(self.classes) > 2` so the estimator-check framework picks the appropriate datasets.
- Extended `test_not_fitted_still_works_classification` to also call `learn_many` and re-invoke `predict_proba_many`, locking in the fix on the fitted path.

## Test plan

- [x] `uv run pytest river/test_estimators.py -k SKL2River` — 50 new check_estimator cases pass.
- [x] `uv run pytest river/compat/` — all compat tests pass, including the strengthened fitted-path assertion.
- [x] pre-commit hooks (ruff, mypy) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)