### PR TITLE
ci: verify sdist builds into a working wheel

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -73,3 +73,22 @@ jobs:
       - name: Run tests
         run: uv run --no-sync pytest
 
+  sdist-build:
+    name: Build wheel from sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.13"
+
+      - name: Build sdist and wheel from sdist
+        run: uv build --python 3.13
+
+      - name: Install wheel and smoke-test the native extension
+        run: |
+          uv venv --python 3.13 .venv-wheel
+          uv pip install --python .venv-wheel/bin/python dist/*.whl
+          .venv-wheel/bin/python -c "import river; from river._river_rust import stats, drift, tree, vectordict"

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -51,6 +51,7 @@
 ## tooling
 
 - Enabled the pep8-naming ruleset (`N801`, `N802`, `N804`) in ruff so that future class, function, and `classmethod`-first-argument naming violations are caught at lint time. `N803` (argument names) and `N806` (local variable names) were intentionally left out — `X: pd.DataFrame`, `A_numpy = ...`, and similar scientific-Python conventions are pervasive in the codebase.
+- Added a `sdist-build` CI job that runs `uv build` to build the sdist and then a wheel from that sdist, then imports the native submodules from the installed wheel. Catches regressions like [#1813](https://github.com/online-ml/river/issues/1813) where the sdist was missing `Cargo.toml` and `rust_src/`. Addresses [#1818](https://github.com/online-ml/river/issues/1818).
 
 ## docs
 


### PR DESCRIPTION
## Summary

- Adds a `sdist-build` job to `code-quality.yml` that runs `uv build` (which builds the sdist, then builds a wheel *from that sdist*, not from the source tree), installs the wheel into a fresh venv, and imports each `river._river_rust` submodule.
- Catches the class of regression from #1813 where the sdist was missing `Cargo.toml` / `rust_src/` and conda-forge couldn't build from source.

Closes #1818.

## Test plan

- [ ] CI passes (the new `sdist-build` job in particular).
- [ ] Verified locally: `uv build --python 3.13` produces an sdist + wheel-from-sdist, `uv pip install` of the wheel into a fresh venv succeeds, and `from river._river_rust import stats, drift, tree, vectordict` returns without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)