### PR TITLE
ci: bump actions/cache to v5 and purge caches monthly

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -23,7 +23,7 @@ jobs:
         run: uv sync --locked --all-extras --dev
 
       - name: Cache datasets
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/river_data
           key: river-data-${{ hashFiles('river/datasets/**/*.py', 'river/bandit/datasets/**/*.py', 'Makefile') }}
@@ -38,7 +38,6 @@ jobs:
 
       - name: Run prek
         uses: j178/prek-action@v2
-       
 
   no-pandas:
     name: Tests without pandas
@@ -53,7 +52,7 @@ jobs:
         run: uv sync --locked --all-extras --dev
 
       - name: Cache datasets
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/river_data
           key: river-data-${{ hashFiles('river/datasets/**/*.py', 'river/bandit/datasets/**/*.py', 'Makefile') }}

--- a/.github/workflows/delete-caches.yml
+++ b/.github/workflows/delete-caches.yml
@@ -3,7 +3,7 @@ name: delete-github-action-caches
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * 0"
+    - cron: "0 0 1 * *"
 
 jobs:
   my-job:


### PR DESCRIPTION
## Summary
- Bump `actions/cache@v4` → `@v5` in `code-quality.yml` (silences the Node 20 deprecation warning and follows the current major).
- Change `delete-caches.yml` cron from weekly Sunday (`0 0 * * 0`) to the 1st of each month (`0 0 1 * *`), so CI runs aren't wiped back to cold every Monday.

`setup-uv@v7` already enables uv caching on hosted runners by default — no change needed there.

## Test plan
- [ ] CI passes on this PR (verifies the cache action upgrade)
- [ ] After merge, confirm `setup-uv-*` and `river-data-*` caches survive across runs on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)