### PR TITLE
feat(preprocessing): add windowed scaling and warm-start to scalers

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,3 +1,8 @@
 # Unreleased
 
 * Add `ppc64le` architecture to Linux wheel builds. (@ChidiebereNjoku)
+
+## preprocessing
+
+- Added `window_size` parameter to `preprocessing.MinMaxScaler` and `preprocessing.MaxAbsScaler`. When set, the scaler tracks the min/max (or absolute max) over the last `window_size` observations via `stats.RollingMin` / `stats.RollingMax` / `stats.RollingAbsMax` instead of the running statistic over the entire stream.
+- Added `_from_state` classmethod to `preprocessing.MinMaxScaler`, `preprocessing.MaxAbsScaler`, and `preprocessing.StandardScaler` so a scaler can be warm-started from offline-computed statistics or resumed from a checkpoint without replaying past observations.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -7,6 +7,10 @@
 - Added `window_size` parameter to `preprocessing.MinMaxScaler` and `preprocessing.MaxAbsScaler`. When set, the scaler tracks the min/max (or absolute max) over the last `window_size` observations via `stats.RollingMin` / `stats.RollingMax` / `stats.RollingAbsMax` instead of the running statistic over the entire stream.
 - Added `_from_state` classmethod to `preprocessing.MinMaxScaler`, `preprocessing.MaxAbsScaler`, and `preprocessing.StandardScaler` so a scaler can be warm-started from offline-computed statistics or resumed from a checkpoint without replaying past observations.
 
+## utils
+
+- `utils.Rolling` and `utils.TimeRolling` now accept a class as their first argument and forward extra keyword arguments to its constructor, e.g. `utils.Rolling(stats.Mean, window_size=3)` or `utils.Rolling(stats.Var, window_size=3, ddof=0)`. This avoids a footgun when using these wrappers as `collections.defaultdict` factories, where the previous instance form silently shared state across keys. Passing a pre-built instance still works but now emits a `DeprecationWarning` and will be removed in a future release.
+
 ## stream
 
 - Added `stream.iter_frame`, a dataframe-agnostic row iterator powered by [Narwhals](https://narwhals-dev.github.io/narwhals/) that works with any eager dataframe (pandas, polars, PyArrow, Modin, cuDF, ...).

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -4,7 +4,7 @@
 
 ## preprocessing
 
-- Added `window_size` parameter to `preprocessing.MinMaxScaler` and `preprocessing.MaxAbsScaler`. When set, the scaler tracks the min/max (or absolute max) over the last `window_size` observations via `stats.RollingMin` / `stats.RollingMax` / `stats.RollingAbsMax` instead of the running statistic over the entire stream.
+- Added `window_size` parameter to `preprocessing.StandardScaler`, `preprocessing.MinMaxScaler`, and `preprocessing.MaxAbsScaler`. When set, the scaler tracks its statistics over the last `window_size` observations instead of the entire stream.
 - Added `_from_state` classmethod to `preprocessing.MinMaxScaler`, `preprocessing.MaxAbsScaler`, and `preprocessing.StandardScaler` so a scaler can be warm-started from offline-computed statistics or resumed from a checkpoint without replaying past observations.
 
 ## utils

--- a/river/anomaly/gaussian.py
+++ b/river/anomaly/gaussian.py
@@ -51,7 +51,7 @@ class GaussianScorer(anomaly.base.SupervisedAnomalyDetector):
     def __init__(self, window_size=None, grace_period=100):
         self.window_size = window_size
         self.gaussian = (
-            utils.Rolling(proba.Gaussian(), window_size=self.window_size)
+            utils.Rolling(proba.Gaussian, window_size=self.window_size)
             if window_size
             else proba.Gaussian()
         )

--- a/river/anomaly/gaussian.py
+++ b/river/anomaly/gaussian.py
@@ -51,7 +51,7 @@ class GaussianScorer(anomaly.base.SupervisedAnomalyDetector):
     def __init__(self, window_size=None, grace_period=100):
         self.window_size = window_size
         self.gaussian = (
-            utils.Rolling(proba.Gaussian, window_size=self.window_size)
+            utils.Rolling(proba.Gaussian, window_size=window_size)
             if window_size
             else proba.Gaussian()
         )

--- a/river/base/base.py
+++ b/river/base/base.py
@@ -148,6 +148,7 @@ class Base:
         Pipeline (
           StandardScaler (
             with_std=True
+            window_size=None
           ),
           LinearRegression (
             optimizer=SGD (
@@ -277,6 +278,7 @@ class Base:
         Pipeline (
           StandardScaler (
             with_std=True
+            window_size=None
           ),
           LinearRegression (
             optimizer=SGD (

--- a/river/compose/pipeline.py
+++ b/river/compose/pipeline.py
@@ -178,6 +178,7 @@ class Pipeline(base.Estimator):
     Pipeline (
       StandardScaler (
         with_std=True
+        window_size=None
       ),
       LinearRegression (
         optimizer=SGD (

--- a/river/feature_extraction/agg.py
+++ b/river/feature_extraction/agg.py
@@ -147,7 +147,7 @@ class Agg(base.Transformer):
     >>> agg = fx.Agg(
     ...     on="value",
     ...     by="group",
-    ...     how=utils.TimeRolling(stats.Mean(), dt.timedelta(days=7))
+    ...     how=utils.TimeRolling(stats.Mean, dt.timedelta(days=7))
     ... )
 
     >>> for day in range(366):
@@ -322,7 +322,7 @@ class TargetAgg(base.SupervisedTransformer, Agg):
 
     >>> agg = feature_extraction.TargetAgg(
     ...     by="group",
-    ...     how=utils.TimeRolling(stats.Mean(), dt.timedelta(days=7))
+    ...     how=utils.TimeRolling(stats.Mean, dt.timedelta(days=7))
     ... )
 
     >>> for day in range(366):

--- a/river/metrics/__init__.py
+++ b/river/metrics/__init__.py
@@ -12,7 +12,7 @@ from river import metrics, utils
 y_true = [True, False, True, True]
 y_pred = [False, False, True, True]
 
-metric = utils.Rolling(metrics.Accuracy(), window_size=3)
+metric = utils.Rolling(metrics.Accuracy, window_size=3)
 
 for yt, yp in zip(y_true, y_pred):
     print(metric.update(yt, yp))

--- a/river/metrics/test_fbeta.py
+++ b/river/metrics/test_fbeta.py
@@ -33,8 +33,10 @@ def test_rolling_multi_fbeta():
         return collections.deque(iterable, maxlen=n)
 
     fbeta = utils.Rolling(
-        metrics.MultiFBeta(betas={0: 0.25, 1: 1, 2: 4}, weights={0: 1, 1: 1, 2: 2}),
+        metrics.MultiFBeta,
         window_size=3,
+        betas={0: 0.25, 1: 1, 2: 4},
+        weights={0: 1, 1: 1, 2: 2},
     )
     n = fbeta.window_size
     sk_fbeta = sk_metrics.fbeta_score

--- a/river/metrics/test_metrics.py
+++ b/river/metrics/test_metrics.py
@@ -276,6 +276,7 @@ def test_metric(metric, sk_metric):
 )
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.filterwarnings("ignore::sklearn.exceptions.UndefinedMetricWarning")
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_rolling_metric(metric, sk_metric):
     def tail(iterable, n):
         return collections.deque(iterable, maxlen=n)

--- a/river/metrics/test_r2.py
+++ b/river/metrics/test_r2.py
@@ -62,7 +62,7 @@ def test_rolling_r2():
     def tail(iterable, n):
         return collections.deque(iterable, maxlen=n)
 
-    r2 = utils.Rolling(metrics.R2(), window_size=3)
+    r2 = utils.Rolling(metrics.R2, window_size=3)
     n = r2.window_size
     sk_r2 = sk_metrics.r2_score
     y_true = [

--- a/river/model_selection/sh.py
+++ b/river/model_selection/sh.py
@@ -207,6 +207,7 @@ class SuccessiveHalvingRegressor(SuccessiveHalving, ModelSelectionRegressor):
     Pipeline (
       StandardScaler (
         with_std=True
+        window_size=None
       ),
       LinearRegression (
         optimizer=Adam (
@@ -364,6 +365,7 @@ class SuccessiveHalvingClassifier(SuccessiveHalving, ModelSelectionClassifier):
     Pipeline (
       StandardScaler (
         with_std=True
+        window_size=None
       ),
       LogisticRegression (
         optimizer=Adam (

--- a/river/preprocessing/scale.py
+++ b/river/preprocessing/scale.py
@@ -25,7 +25,7 @@ __all__ = [
 
 
 def safe_div(a, b):
-    """Returns a if b is nil, else divides a by b.
+    """Return a if b is nil, else divides a by b.
 
     When scaling, sometimes a denominator might be nil. For instance, during standard scaling
     the denominator can be nil if a feature has no variance.
@@ -35,7 +35,7 @@ def safe_div(a, b):
 
 
 class Binarizer(base.Transformer):
-    """Binarizes the data to 0 or 1 according to a threshold.
+    """Binarize the data to 0 or 1 according to a threshold.
 
     Parameters
     ----------
@@ -46,7 +46,6 @@ class Binarizer(base.Transformer):
 
     Examples
     --------
-
     >>> import river
     >>> import numpy as np
 
@@ -100,7 +99,6 @@ class StandardScaler(base.MiniBatchTransformer):
 
     Examples
     --------
-
     >>> import random
     >>> from river import preprocessing
 
@@ -148,6 +146,17 @@ class StandardScaler(base.MiniBatchTransformer):
     4 -0.444084 -0.914195
     5 -1.274664  0.992296
 
+    A scaler can also be warm-started from previously computed statistics, e.g. to
+    resume from a checkpoint or to seed the stream with an offline estimate:
+
+    >>> scaler = preprocessing.StandardScaler._from_state(
+    ...     counts={'x': 100},
+    ...     means={'x': 10.0},
+    ...     vars={'x': 4.0},
+    ... )
+    >>> scaler.transform_one({'x': 12.0})
+    {'x': 1.0}
+
     References
     ----------
     [^1]: [Welford's Method (and Friends)](https://www.embeddedrelated.com/showarticle/785.php)
@@ -160,6 +169,41 @@ class StandardScaler(base.MiniBatchTransformer):
         self.counts: collections.Counter = collections.Counter()
         self.means: collections.defaultdict = collections.defaultdict(float)
         self.vars: collections.defaultdict = collections.defaultdict(float)
+
+    @classmethod
+    def _from_state(
+        cls,
+        counts: dict,
+        means: dict,
+        vars: dict | None = None,
+        *,
+        with_std: bool = True,
+    ) -> StandardScaler:
+        """Create a new instance with pre-populated running statistics.
+
+        Useful to warm-start a scaler from offline-computed statistics or to resume
+        from a checkpoint without replaying past observations.
+
+        Parameters
+        ----------
+        counts
+            Mapping between features and the number of observations they have been
+            updated with.
+        means
+            Mapping between features and their running mean.
+        vars
+            Mapping between features and their running variance. Required when
+            ``with_std`` is ``True``; ignored otherwise.
+        with_std
+            Whether or not each feature should be divided by its standard deviation.
+
+        """
+        new = cls(with_std=with_std)
+        new.counts.update(counts)
+        new.means.update(means)
+        if with_std and vars is not None:
+            new.vars.update(vars)
+        return new
 
     def learn_one(self, x):
         counts = self.counts
@@ -198,9 +242,7 @@ class StandardScaler(base.MiniBatchTransformer):
         ----------
         X
             A dataframe where each column is a feature.
-
         """
-
         # Operating on X.values, which is a view to the underlying numpy array, is slightly faster
         # than operating on X
         columns = X.columns
@@ -268,17 +310,26 @@ class MinMaxScaler(base.Transformer):
     """Scales the data to a fixed range from 0 to 1.
 
     Under the hood a running min and a running peak to peak (max - min) are maintained.
+    When ``window_size`` is set, the scaler tracks the min and max over the last
+    ``window_size`` observations via `stats.RollingMin` and `stats.RollingMax` instead.
+
+    Parameters
+    ----------
+    window_size
+        Size of the rolling window used to compute the min and max. If ``None``, the
+        running min and max over the entire stream are used.
 
     Attributes
     ----------
     min : dict
-        Mapping between features and instances of `stats.Min`.
+        Mapping between features and instances of `stats.Min` (or `stats.RollingMin`
+        when ``window_size`` is set).
     max : dict
-        Mapping between features and instances of `stats.Max`.
+        Mapping between features and instances of `stats.Max` (or `stats.RollingMax`
+        when ``window_size`` is set).
 
     Examples
     --------
-
     >>> import random
     >>> from river import preprocessing
 
@@ -303,11 +354,67 @@ class MinMaxScaler(base.Transformer):
     {'x': 0.322582}
     {'x': 1.0}
 
+    A rolling window can be used to scale relative to the most recent observations
+    only:
+
+    >>> scaler = preprocessing.MinMaxScaler(window_size=3)
+    >>> for x in X:
+    ...     scaler.learn_one(x)
+    ...     print(scaler.transform_one(x))
+    {'x': 0.0}
+    {'x': 0.0}
+    {'x': 0.406920}
+    {'x': 0.792741}
+    {'x': 1.0}
+
+    A scaler can also be warm-started from previously computed statistics, e.g. to
+    resume from a checkpoint or to seed the stream with an offline estimate:
+
+    >>> scaler = preprocessing.MinMaxScaler._from_state(min={'x': 8.0}, max={'x': 12.0})
+    >>> scaler.transform_one({'x': 10.0})
+    {'x': 0.5}
+
     """
 
-    def __init__(self) -> None:
-        self.min: collections.defaultdict = collections.defaultdict(stats.Min)
-        self.max: collections.defaultdict = collections.defaultdict(stats.Max)
+    def __init__(self, window_size: int | None = None) -> None:
+        self.window_size = window_size
+        if window_size is None:
+            self.min: collections.defaultdict = collections.defaultdict(stats.Min)
+            self.max: collections.defaultdict = collections.defaultdict(stats.Max)
+        else:
+            self.min = collections.defaultdict(functools.partial(stats.RollingMin, window_size))
+            self.max = collections.defaultdict(functools.partial(stats.RollingMax, window_size))
+
+    @classmethod
+    def _from_state(
+        cls,
+        min: dict,
+        max: dict,
+        window_size: int | None = None,
+    ) -> MinMaxScaler:
+        """Create a new instance with pre-populated running min and max.
+
+        Useful to warm-start a scaler from offline-computed statistics or to resume
+        from a checkpoint without replaying past observations.
+
+        Parameters
+        ----------
+        min
+            Mapping between features and their initial min.
+        max
+            Mapping between features and their initial max.
+        window_size
+            Size of the rolling window, forwarded to ``__init__``. When set, each
+            initial value seeds one slot of the rolling window and will eventually be
+            evicted as fresh observations arrive.
+
+        """
+        new = cls(window_size=window_size)
+        for k, v in min.items():
+            new.min[k].update(v)
+        for k, v in max.items():
+            new.max[k].update(v)
+        return new
 
     def learn_one(self, x):
         min_ = self.min
@@ -335,14 +442,24 @@ class MaxAbsScaler(base.Transformer):
     data that is already centered at zero or sparse data. It does not shift/center
     the data, and thus does not destroy any sparsity.
 
+    When ``window_size`` is set, the scaler tracks the absolute max over the last
+    ``window_size`` observations via `stats.RollingAbsMax` instead of the entire
+    stream.
+
+    Parameters
+    ----------
+    window_size
+        Size of the rolling window used to compute the absolute max. If ``None``,
+        the running absolute max over the entire stream is used.
+
     Attributes
     ----------
     abs_max : dict
-        Mapping between features and instances of `stats.AbsMax`.
+        Mapping between features and instances of `stats.AbsMax` (or
+        `stats.RollingAbsMax` when ``window_size`` is set).
 
     Examples
     --------
-
     >>> import random
     >>> from river import preprocessing
 
@@ -367,10 +484,48 @@ class MaxAbsScaler(base.Transformer):
     {'x': 0.842308}
     {'x': 1.0}
 
+    A scaler can also be warm-started from a previously computed absolute max:
+
+    >>> scaler = preprocessing.MaxAbsScaler._from_state(abs_max={'x': 12.0})
+    >>> scaler.transform_one({'x': 6.0})
+    {'x': 0.5}
+
     """
 
-    def __init__(self) -> None:
-        self.abs_max: collections.defaultdict = collections.defaultdict(stats.AbsMax)
+    def __init__(self, window_size: int | None = None) -> None:
+        self.window_size = window_size
+        if window_size is None:
+            self.abs_max: collections.defaultdict = collections.defaultdict(stats.AbsMax)
+        else:
+            self.abs_max = collections.defaultdict(
+                functools.partial(stats.RollingAbsMax, window_size)
+            )
+
+    @classmethod
+    def _from_state(
+        cls,
+        abs_max: dict,
+        window_size: int | None = None,
+    ) -> MaxAbsScaler:
+        """Create a new instance with a pre-populated running absolute max.
+
+        Useful to warm-start a scaler from an offline-computed statistic or to resume
+        from a checkpoint without replaying past observations.
+
+        Parameters
+        ----------
+        abs_max
+            Mapping between features and their initial absolute max.
+        window_size
+            Size of the rolling window, forwarded to ``__init__``. When set, each
+            initial value seeds one slot of the rolling window and will eventually
+            be evicted as fresh observations arrive.
+
+        """
+        new = cls(window_size=window_size)
+        for k, v in abs_max.items():
+            new.abs_max[k].update(v)
+        return new
 
     def learn_one(self, x):
         abs_max = self.abs_max
@@ -412,7 +567,6 @@ class RobustScaler(base.Transformer):
 
     Examples
     --------
-
     >>> from pprint import pprint
     >>> import random
     >>> from river import preprocessing
@@ -481,7 +635,6 @@ class Normalizer(base.Transformer):
 
     Examples
     --------
-
     >>> from river import preprocessing
     >>> from river import stream
 
@@ -523,7 +676,6 @@ class AdaptiveStandardScaler(base.Transformer):
 
     Examples
     --------
-
     Consider the following series which contains a positive trend.
 
     >>> import random

--- a/river/preprocessing/scale.py
+++ b/river/preprocessing/scale.py
@@ -34,6 +34,23 @@ def safe_div(a, b):
     return a / b if b else 0.0
 
 
+class _RollingStatFactory:
+    """Picklable factory producing a fresh `utils.Rolling(stat_factory(), window_size=n)` per call.
+
+    A plain `functools.partial(utils.Rolling, stat_factory(), window_size=n)` would share the
+    same underlying `stat_factory()` instance across every key of a `defaultdict`, which is a
+    silent correctness bug for per-feature rolling statistics. This factory creates a fresh
+    stat instance on each call while remaining picklable (unlike a closure / `lambda`).
+    """
+
+    def __init__(self, stat_factory: typing.Callable[[], typing.Any], window_size: int) -> None:
+        self.stat_factory = stat_factory
+        self.window_size = window_size
+
+    def __call__(self) -> utils.Rolling:
+        return utils.Rolling(self.stat_factory(), window_size=self.window_size)
+
+
 class Binarizer(base.Transformer):
     """Binarize the data to 0 or 1 according to a threshold.
 
@@ -92,10 +109,18 @@ class StandardScaler(base.MiniBatchTransformer):
     calls. In other words, this transformer will keep working even if you add and/or remove
     features every time you call `learn_many` and `transform_many`.
 
+    When ``window_size`` is set, the running mean and variance are replaced by rolling versions
+    computed over the last ``window_size`` observations via `utils.Rolling` wrapping `stats.Mean`
+    and `stats.Var`. In this mode, `learn_many` is processed row by row because the mini-batch
+    merge formula for variance does not yield a correct rolling estimate.
+
     Parameters
     ----------
     with_std
         Whether or not each feature should be divided by its standard deviation.
+    window_size
+        Size of the rolling window used to compute the mean and variance. If ``None``, the
+        running mean and variance over the entire stream are used.
 
     Examples
     --------
@@ -124,6 +149,21 @@ class StandardScaler(base.MiniBatchTransformer):
     {'x': 1.129, 'y': -0.651}
     {'x': -0.776, 'y': -0.729}
     {'x': -1.274, 'y': 0.992}
+
+    A rolling window can be used to scale relative to the most recent observations only.
+    The variance is the population variance (``ddof=0``), matching the running estimator
+    used in the default mode:
+
+    >>> scaler = preprocessing.StandardScaler(window_size=3)
+    >>> for x in X:
+    ...     scaler.learn_one(x)
+    ...     print(scaler.transform_one(x))
+    {'x': 0.0, 'y': 0.0}
+    {'x': -1.0, 'y': 1.0}
+    {'x': 0.937, 'y': 1.351}
+    {'x': 0.983, 'y': -0.960}
+    {'x': -1.337, 'y': -0.803}
+    {'x': -1.036, 'y': 1.406}
 
     This transformer also supports mini-batch updates. You can call `learn_many` and provide a
     `pandas.DataFrame`:
@@ -164,11 +204,20 @@ class StandardScaler(base.MiniBatchTransformer):
 
     """
 
-    def __init__(self, with_std=True) -> None:
+    def __init__(self, with_std=True, window_size: int | None = None) -> None:
         self.with_std = with_std
+        self.window_size = window_size
         self.counts: collections.Counter = collections.Counter()
-        self.means: collections.defaultdict = collections.defaultdict(float)
-        self.vars: collections.defaultdict = collections.defaultdict(float)
+        if window_size is None:
+            self.means: collections.defaultdict = collections.defaultdict(float)
+            self.vars: collections.defaultdict = collections.defaultdict(float)
+        else:
+            self.means = collections.defaultdict(_RollingStatFactory(stats.Mean, window_size))
+            # Use ddof=0 (population variance) to match the Welford estimator used in the
+            # non-windowed branch; otherwise the two modes would disagree.
+            self.vars = collections.defaultdict(
+                _RollingStatFactory(functools.partial(stats.Var, ddof=0), window_size)
+            )
 
     @classmethod
     def _from_state(
@@ -183,6 +232,11 @@ class StandardScaler(base.MiniBatchTransformer):
 
         Useful to warm-start a scaler from offline-computed statistics or to resume
         from a checkpoint without replaying past observations.
+
+        Note that warm-starting a windowed scaler from scalar statistics is not
+        supported because a single mean/variance cannot reconstruct the underlying
+        window of observations; replay the recent observations through ``learn_one``
+        instead.
 
         Parameters
         ----------
@@ -209,6 +263,18 @@ class StandardScaler(base.MiniBatchTransformer):
         counts = self.counts
         means = self.means
         vars_ = self.vars
+        if self.window_size is not None:
+            # Rolling Mean/Var: delegate eviction logic to the underlying stats objects.
+            if self.with_std:
+                for i, xi in x.items():
+                    counts[i] += 1
+                    means[i].update(xi)
+                    vars_[i].update(xi)
+            else:
+                for i, xi in x.items():
+                    counts[i] += 1
+                    means[i].update(xi)
+            return
         if self.with_std:
             for i, xi in x.items():
                 counts[i] += 1
@@ -223,6 +289,16 @@ class StandardScaler(base.MiniBatchTransformer):
 
     def transform_one(self, x):
         means = self.means
+        if self.window_size is not None:
+            if self.with_std:
+                vars_ = self.vars
+                result = {}
+                for i, xi in x.items():
+                    m = means[i].get()
+                    v = vars_[i].get()
+                    result[i] = (xi - m) / v**0.5 if v else 0.0
+                return result
+            return {i: xi - means[i].get() for i, xi in x.items()}
         if self.with_std:
             vars_ = self.vars
             result = {}
@@ -236,13 +312,22 @@ class StandardScaler(base.MiniBatchTransformer):
         """Update with a mini-batch of features.
 
         Note that the update formulas for mean and variance are slightly different than in the
-        single instance case, but they produce exactly the same result.
+        single instance case, but they produce exactly the same result. When ``window_size``
+        is set, the rows are processed sequentially because the batched merge formula is not
+        compatible with rolling-window eviction.
 
         Parameters
         ----------
         X
             A dataframe where each column is a feature.
         """
+        if self.window_size is not None:
+            # Row-by-row to preserve correct rolling-window semantics.
+            columns = X.columns
+            for row in X.values:
+                self.learn_one(dict(zip(columns, row)))
+            return
+
         # Operating on X.values, which is a view to the underlying numpy array, is slightly faster
         # than operating on X
         columns = X.columns
@@ -296,11 +381,17 @@ class StandardScaler(base.MiniBatchTransformer):
             bytes_size = dtype.itemsize
             dtype = np.dtype(f"float{bytes_size * 8}")  # type: ignore[operator]
 
-        means = np.array([self.means[c] for c in X.columns], dtype=dtype)
+        if self.window_size is None:
+            means = np.array([self.means[c] for c in X.columns], dtype=dtype)
+        else:
+            means = np.array([self.means[c].get() for c in X.columns], dtype=dtype)
         Xt = X.values - means
 
         if self.with_std:
-            stds = np.array([self.vars[c] ** 0.5 for c in X.columns], dtype=dtype)
+            if self.window_size is None:
+                stds = np.array([self.vars[c] ** 0.5 for c in X.columns], dtype=dtype)
+            else:
+                stds = np.array([self.vars[c].get() ** 0.5 for c in X.columns], dtype=dtype)
             np.divide(Xt, stds, where=stds > 0, out=Xt)
 
         return pd.DataFrame(Xt, index=X.index, columns=X.columns, copy=False)

--- a/river/preprocessing/scale.py
+++ b/river/preprocessing/scale.py
@@ -34,23 +34,6 @@ def safe_div(a, b):
     return a / b if b else 0.0
 
 
-class _RollingStatFactory:
-    """Picklable factory producing a fresh `utils.Rolling(stat_factory(), window_size=n)` per call.
-
-    A plain `functools.partial(utils.Rolling, stat_factory(), window_size=n)` would share the
-    same underlying `stat_factory()` instance across every key of a `defaultdict`, which is a
-    silent correctness bug for per-feature rolling statistics. This factory creates a fresh
-    stat instance on each call while remaining picklable (unlike a closure / `lambda`).
-    """
-
-    def __init__(self, stat_factory: typing.Callable[[], typing.Any], window_size: int) -> None:
-        self.stat_factory = stat_factory
-        self.window_size = window_size
-
-    def __call__(self) -> utils.Rolling:
-        return utils.Rolling(self.stat_factory(), window_size=self.window_size)
-
-
 class Binarizer(base.Transformer):
     """Binarize the data to 0 or 1 according to a threshold.
 
@@ -212,11 +195,13 @@ class StandardScaler(base.MiniBatchTransformer):
             self.means: collections.defaultdict = collections.defaultdict(float)
             self.vars: collections.defaultdict = collections.defaultdict(float)
         else:
-            self.means = collections.defaultdict(_RollingStatFactory(stats.Mean, window_size))
+            self.means = collections.defaultdict(
+                functools.partial(utils.Rolling, stats.Mean, window_size=window_size)
+            )
             # Use ddof=0 (population variance) to match the Welford estimator used in the
             # non-windowed branch; otherwise the two modes would disagree.
             self.vars = collections.defaultdict(
-                _RollingStatFactory(functools.partial(stats.Var, ddof=0), window_size)
+                functools.partial(utils.Rolling, stats.Var, window_size=window_size, ddof=0)
             )
 
     def __setstate__(self, state: dict) -> None:

--- a/river/preprocessing/scale.py
+++ b/river/preprocessing/scale.py
@@ -219,6 +219,12 @@ class StandardScaler(base.MiniBatchTransformer):
                 _RollingStatFactory(functools.partial(stats.Var, ddof=0), window_size)
             )
 
+    def __setstate__(self, state: dict) -> None:
+        # Default `window_size` to None so pickles written before this attribute was
+        # introduced keep working without re-running __init__.
+        state.setdefault("window_size", None)
+        self.__dict__.update(state)
+
     @classmethod
     def _from_state(
         cls,
@@ -476,6 +482,12 @@ class MinMaxScaler(base.Transformer):
             self.min = collections.defaultdict(functools.partial(stats.RollingMin, window_size))
             self.max = collections.defaultdict(functools.partial(stats.RollingMax, window_size))
 
+    def __setstate__(self, state: dict) -> None:
+        # Default `window_size` to None so pickles written before this attribute was
+        # introduced keep working without re-running __init__.
+        state.setdefault("window_size", None)
+        self.__dict__.update(state)
+
     @classmethod
     def _from_state(
         cls,
@@ -591,6 +603,12 @@ class MaxAbsScaler(base.Transformer):
             self.abs_max = collections.defaultdict(
                 functools.partial(stats.RollingAbsMax, window_size)
             )
+
+    def __setstate__(self, state: dict) -> None:
+        # Default `window_size` to None so pickles written before this attribute was
+        # introduced keep working without re-running __init__.
+        state.setdefault("window_size", None)
+        self.__dict__.update(state)
 
     @classmethod
     def _from_state(

--- a/river/preprocessing/test_scale.py
+++ b/river/preprocessing/test_scale.py
@@ -463,6 +463,48 @@ def test_standard_scaler_window_counts_track_cumulative_observations():
     assert scaler.counts["x"] == 5
 
 
+def _strip_attr(obj, attr):
+    """Simulate an old pickle by deleting an attribute added later."""
+    new = obj.__class__.__new__(obj.__class__)
+    new.__dict__.update({k: v for k, v in obj.__dict__.items() if k != attr})
+    return new
+
+
+def test_standard_scaler_unpickle_missing_window_size():
+    """Old pickles (pre-`window_size`) must keep working after upgrade."""
+    scaler = preprocessing.StandardScaler()
+    for v in [1.0, 2.0, 3.0]:
+        scaler.learn_one({"x": v})
+
+    legacy = pickle.loads(pickle.dumps(_strip_attr(scaler, "window_size")))
+    assert legacy.window_size is None
+    legacy.learn_one({"x": 4.0})
+    out = legacy.transform_one({"x": 4.0})
+    assert isinstance(out["x"], float)
+
+
+def test_minmax_scaler_unpickle_missing_window_size():
+    scaler = preprocessing.MinMaxScaler()
+    for v in [1.0, 2.0, 3.0]:
+        scaler.learn_one({"x": v})
+
+    legacy = pickle.loads(pickle.dumps(_strip_attr(scaler, "window_size")))
+    assert legacy.window_size is None
+    legacy.learn_one({"x": 4.0})
+    assert legacy.transform_one({"x": 4.0}) == {"x": 1.0}
+
+
+def test_maxabs_scaler_unpickle_missing_window_size():
+    scaler = preprocessing.MaxAbsScaler()
+    for v in [1.0, 2.0, 3.0]:
+        scaler.learn_one({"x": v})
+
+    legacy = pickle.loads(pickle.dumps(_strip_attr(scaler, "window_size")))
+    assert legacy.window_size is None
+    legacy.learn_one({"x": 4.0})
+    assert legacy.transform_one({"x": 4.0}) == {"x": 1.0}
+
+
 def test_issue_1313():
     """>>> import numpy as np
     >>> import pandas as pd

--- a/river/preprocessing/test_scale.py
+++ b/river/preprocessing/test_scale.py
@@ -16,7 +16,6 @@ def _pd_split(df, n):
 
 def test_standard_scaler_one_many_consistent():
     """Checks that using learn_one or learn_many produces the same result."""
-
     for with_std in (False, True):
         X = pd.read_csv(datasets.TrumpApproval().path)
 
@@ -36,7 +35,6 @@ def test_standard_scaler_one_many_consistent():
 
 def test_standard_scaler_shuffle_columns():
     """Checks that learn_many works identically whether columns are shuffled or not."""
-
     X = pd.read_csv(datasets.TrumpApproval().path)
 
     normal = preprocessing.StandardScaler()
@@ -56,7 +54,6 @@ def test_standard_scaler_shuffle_columns():
 
 def test_standard_scaler_add_remove_columns():
     """Checks that no exceptions are raised whenever columns are dropped and/or added."""
-
     X = pd.read_csv(datasets.TrumpApproval().path)
 
     ss = preprocessing.StandardScaler()
@@ -66,10 +63,192 @@ def test_standard_scaler_add_remove_columns():
         ss.learn_many(xb[cols])
 
 
-def test_issue_1313():
-    """
+def test_minmax_scaler_warm_start():
+    """`_from_state` seeds min/max so the very first transform uses them."""
+    scaler = preprocessing.MinMaxScaler._from_state(min={"x": 8.0}, max={"x": 12.0})
+    assert scaler.transform_one({"x": 10.0}) == {"x": 0.5}
+    assert scaler.transform_one({"x": 8.0}) == {"x": 0.0}
+    assert scaler.transform_one({"x": 12.0}) == {"x": 1.0}
 
-    >>> import numpy as np
+
+def test_minmax_scaler_warm_start_extends_after_learn():
+    """A subsequent learn_one with a value below the seeded min lowers the running min."""
+    scaler = preprocessing.MinMaxScaler._from_state(min={"x": 8.0}, max={"x": 12.0})
+    scaler.learn_one({"x": 6.0})
+    assert scaler.min["x"].get() == 6.0
+    assert scaler.max["x"].get() == 12.0
+    assert scaler.transform_one({"x": 6.0}) == {"x": 0.0}
+
+
+def test_minmax_scaler_warm_start_partial_keys():
+    """Features absent from the warm-start dicts get fresh default stats."""
+    scaler = preprocessing.MinMaxScaler._from_state(min={"x": 1.0}, max={"x": 5.0})
+    scaler.learn_one({"x": 3.0, "y": 7.0})
+    assert scaler.transform_one({"x": 3.0, "y": 7.0}) == {"x": 0.5, "y": 0.0}
+
+
+def test_minmax_scaler_window_size_uses_rolling_stats():
+    """With window_size set, the scaler relies on RollingMin/RollingMax."""
+    from river import stats
+
+    scaler = preprocessing.MinMaxScaler(window_size=3)
+    for v in [10.0, 20.0, 30.0, 40.0]:
+        scaler.learn_one({"x": v})
+    assert isinstance(scaler.min["x"], stats.RollingMin)
+    assert isinstance(scaler.max["x"], stats.RollingMax)
+    assert scaler.min["x"].get() == 20.0
+    assert scaler.max["x"].get() == 40.0
+
+
+def test_minmax_scaler_window_evicts_old_values():
+    """Values beyond the window no longer influence the scaling range."""
+    scaler = preprocessing.MinMaxScaler(window_size=2)
+    for v in [1.0, 100.0, 5.0, 10.0]:
+        scaler.learn_one({"x": v})
+    assert scaler.transform_one({"x": 5.0}) == {"x": 0.0}
+    assert scaler.transform_one({"x": 10.0}) == {"x": 1.0}
+
+
+def test_minmax_scaler_default_unchanged():
+    """Zero-arg construction must remain behavior-identical to the previous version."""
+    scaler = preprocessing.MinMaxScaler()
+    assert scaler.window_size is None
+    for v in [10.0, 20.0, 30.0]:
+        scaler.learn_one({"x": v})
+    assert scaler.transform_one({"x": 20.0}) == {"x": 0.5}
+
+
+def test_maxabs_scaler_warm_start():
+    scaler = preprocessing.MaxAbsScaler._from_state(abs_max={"x": 12.0})
+    assert scaler.transform_one({"x": 6.0}) == {"x": 0.5}
+    assert scaler.transform_one({"x": -12.0}) == {"x": -1.0}
+
+
+def test_maxabs_scaler_window_evicts_old_values():
+    scaler = preprocessing.MaxAbsScaler(window_size=2)
+    for v in [-100.0, 1.0, 2.0]:
+        scaler.learn_one({"x": v})
+    assert scaler.transform_one({"x": 2.0}) == {"x": 1.0}
+
+
+def test_standard_scaler_warm_start():
+    """`_from_state` seeds counts/means/vars so transform uses them immediately."""
+    scaler = preprocessing.StandardScaler._from_state(
+        counts={"x": 100},
+        means={"x": 10.0},
+        vars={"x": 4.0},
+    )
+    assert scaler.transform_one({"x": 12.0}) == {"x": 1.0}
+    assert scaler.transform_one({"x": 10.0}) == {"x": 0.0}
+
+
+def test_standard_scaler_warm_start_then_extends():
+    """After warm-start, learn_one should keep refining the running statistics."""
+    scaler = preprocessing.StandardScaler._from_state(
+        counts={"x": 1},
+        means={"x": 10.0},
+        vars={"x": 0.0},
+    )
+    scaler.learn_one({"x": 20.0})
+    assert scaler.counts["x"] == 2
+    assert math.isclose(scaler.means["x"], 15.0)
+
+
+def test_minmax_scaler_from_state_with_window_size():
+    """`_from_state` with `window_size` set seeds the rolling window."""
+    from river import stats
+
+    scaler = preprocessing.MinMaxScaler._from_state(
+        min={"x": 0.0},
+        max={"x": 100.0},
+        window_size=3,
+    )
+    assert isinstance(scaler.min["x"], stats.RollingMin)
+    assert scaler.transform_one({"x": 50.0}) == {"x": 0.5}
+    # Seed value gets evicted after window_size more observations.
+    for v in [10.0, 20.0, 30.0]:
+        scaler.learn_one({"x": v})
+    assert scaler.min["x"].get() == 10.0
+    assert scaler.max["x"].get() == 30.0
+
+
+def test_maxabs_scaler_from_state_partial_keys():
+    """Features absent from the warm-start dict get fresh default stats."""
+    scaler = preprocessing.MaxAbsScaler._from_state(abs_max={"x": 4.0})
+    scaler.learn_one({"x": 2.0, "y": 3.0})
+    out = scaler.transform_one({"x": 2.0, "y": 3.0})
+    assert out == {"x": 0.5, "y": 1.0}
+
+
+def test_minmax_scaler_clone_preserves_window_size():
+    """`clone()` reconstructs window_size via __init__ but drops learned state."""
+    from river import stats
+
+    scaler = preprocessing.MinMaxScaler(window_size=5)
+    scaler.learn_one({"x": 1.0})
+    cloned = scaler.clone()
+    assert cloned.window_size == 5
+    assert isinstance(cloned.min["x"], stats.RollingMin)
+    # Learned state must not carry over.
+    assert len(cloned.min["x"].window) == 0
+
+
+def test_maxabs_scaler_clone_preserves_window_size():
+    scaler = preprocessing.MaxAbsScaler(window_size=7)
+    cloned = scaler.clone()
+    assert cloned.window_size == 7
+
+
+def test_standard_scaler_warm_start_matches_running():
+    """A warm-started scaler should match one trained from scratch on the same data."""
+    data = [{"x": v} for v in [1.0, 2.0, 3.0, 4.0, 5.0]]
+
+    full = preprocessing.StandardScaler()
+    for x in data:
+        full.learn_one(x)
+
+    # Take a snapshot after the first 3 observations and resume from it.
+    snapshot = preprocessing.StandardScaler()
+    for x in data[:3]:
+        snapshot.learn_one(x)
+
+    resumed = preprocessing.StandardScaler._from_state(
+        counts=dict(snapshot.counts),
+        means=dict(snapshot.means),
+        vars=dict(snapshot.vars),
+    )
+    for x in data[3:]:
+        resumed.learn_one(x)
+
+    assert resumed.counts["x"] == full.counts["x"]
+    assert math.isclose(resumed.means["x"], full.means["x"])
+    assert math.isclose(resumed.vars["x"], full.vars["x"])
+
+
+def test_standard_scaler_warm_start_then_learn_many():
+    """Warm-start must be compatible with the mini-batch `learn_many` path."""
+    snapshot = preprocessing.StandardScaler._from_state(
+        counts={"x": 2},
+        means={"x": 1.5},
+        vars={"x": 0.25},
+    )
+    snapshot.learn_many(pd.DataFrame({"x": [2.0, 3.0]}))
+    assert snapshot.counts["x"] == 4
+    assert math.isclose(snapshot.means["x"], 2.0)
+
+
+def test_standard_scaler_warm_start_without_std():
+    """When with_std is False the vars argument is ignored, not required."""
+    scaler = preprocessing.StandardScaler._from_state(
+        counts={"x": 5},
+        means={"x": 3.0},
+        with_std=False,
+    )
+    assert scaler.transform_one({"x": 5.0}) == {"x": 2.0}
+
+
+def test_issue_1313():
+    """>>> import numpy as np
     >>> import pandas as pd
     >>> from sklearn import datasets
     >>> from river import preprocessing

--- a/river/preprocessing/test_scale.py
+++ b/river/preprocessing/test_scale.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import math
+import pickle
+import random
 
 import numpy as np
 import pandas as pd
 
-from river import datasets, preprocessing, stream
+from river import datasets, preprocessing, stats, stream, utils
 
 
 def _pd_split(df, n):
@@ -245,6 +247,220 @@ def test_standard_scaler_warm_start_without_std():
         with_std=False,
     )
     assert scaler.transform_one({"x": 5.0}) == {"x": 2.0}
+
+
+def _np_population_stats(values: list[float]) -> tuple[float, float]:
+    """Compute population mean and variance (ddof=0) for a list of floats."""
+    arr = np.asarray(values, dtype=float)
+    return float(arr.mean()), float(arr.var(ddof=0))
+
+
+def test_standard_scaler_window_default_unchanged():
+    """Zero-arg construction stays behavior-identical to the previous version."""
+    scaler = preprocessing.StandardScaler()
+    assert scaler.window_size is None
+    assert isinstance(scaler.means["x"], float)
+    assert isinstance(scaler.vars["x"], float)
+
+
+def test_standard_scaler_window_uses_rolling_stats():
+    """With window_size set, per-feature means/vars are Rolling wrappers."""
+    scaler = preprocessing.StandardScaler(window_size=3)
+    scaler.learn_one({"x": 1.0})
+    assert isinstance(scaler.means["x"], utils.Rolling)
+    assert isinstance(scaler.vars["x"], utils.Rolling)
+    assert isinstance(scaler.means["x"].obj, stats.Mean)
+    assert isinstance(scaler.vars["x"].obj, stats.Var)
+    # ddof=0 to match the Welford population-variance estimator.
+    assert scaler.vars["x"].obj.ddof == 0
+
+
+def test_standard_scaler_window_independent_per_feature():
+    """Each feature must have its own underlying Mean/Var instance.
+
+    This guards against the silent-aliasing bug that occurs when the
+    `defaultdict` factory shares a single stats instance across keys.
+    """
+    scaler = preprocessing.StandardScaler(window_size=10)
+    scaler.learn_one({"x": 1.0, "y": 100.0})
+    scaler.learn_one({"x": 2.0, "y": 200.0})
+
+    assert scaler.means["x"] is not scaler.means["y"]
+    assert scaler.means["x"].obj is not scaler.means["y"].obj
+    assert scaler.vars["x"].obj is not scaler.vars["y"].obj
+    assert math.isclose(scaler.means["x"].get(), 1.5)
+    assert math.isclose(scaler.means["y"].get(), 150.0)
+
+
+def test_standard_scaler_window_matches_numpy_pop_var():
+    """The rolling mean/var must equal a NumPy ddof=0 computation over the window."""
+    rng = random.Random(0)
+    window_size = 5
+    scaler = preprocessing.StandardScaler(window_size=window_size)
+    values = [rng.uniform(-10, 10) for _ in range(25)]
+
+    for i, v in enumerate(values, start=1):
+        scaler.learn_one({"x": v})
+        window = values[max(0, i - window_size) : i]
+        expected_mean, expected_var = _np_population_stats(window)
+        assert math.isclose(scaler.means["x"].get(), expected_mean, abs_tol=1e-9)
+        assert math.isclose(scaler.vars["x"].get(), expected_var, abs_tol=1e-9)
+
+
+def test_standard_scaler_window_transform_one_matches_numpy():
+    """transform_one must compute (x - rolling_mean) / rolling_std."""
+    rng = random.Random(42)
+    window_size = 4
+    scaler = preprocessing.StandardScaler(window_size=window_size)
+    values = [rng.uniform(0, 50) for _ in range(20)]
+
+    for i, v in enumerate(values, start=1):
+        scaler.learn_one({"x": v})
+        out = scaler.transform_one({"x": v})
+        window = values[max(0, i - window_size) : i]
+        m, var = _np_population_stats(window)
+        expected = (v - m) / var**0.5 if var else 0.0
+        assert math.isclose(out["x"], expected, abs_tol=1e-9)
+
+
+def test_standard_scaler_window_equivalent_below_threshold():
+    """While n <= window_size, the windowed and running scalers must agree exactly."""
+    rng = random.Random(7)
+    window_size = 8
+    running = preprocessing.StandardScaler()
+    windowed = preprocessing.StandardScaler(window_size=window_size)
+
+    for _ in range(window_size):
+        x = {"x": rng.uniform(-5, 5)}
+        running.learn_one(x)
+        windowed.learn_one(x)
+        r_out = running.transform_one(x)
+        w_out = windowed.transform_one(x)
+        assert math.isclose(r_out["x"], w_out["x"], abs_tol=1e-9)
+
+
+def test_standard_scaler_window_adapts_to_drift():
+    """After a drift, the windowed scaler's mean must move toward the new regime
+    faster than the global running scaler.
+    """
+    pre_drift = [1.0] * 50
+    post_drift = [100.0] * 10
+    running = preprocessing.StandardScaler()
+    windowed = preprocessing.StandardScaler(window_size=5)
+    for v in pre_drift + post_drift:
+        x = {"x": v}
+        running.learn_one(x)
+        windowed.learn_one(x)
+    assert windowed.means["x"].get() == 100.0
+    assert running.means["x"] < 50.0
+
+
+def test_standard_scaler_window_with_std_false():
+    """`with_std=False` skips the variance update path under windowed mode."""
+    scaler = preprocessing.StandardScaler(with_std=False, window_size=3)
+    for v in [1.0, 2.0, 3.0, 4.0]:
+        scaler.learn_one({"x": v})
+    # Mean is updated; vars stay at their default empty Rolling(Var).
+    assert math.isclose(scaler.means["x"].get(), 3.0)
+    out = scaler.transform_one({"x": 4.0})
+    assert math.isclose(out["x"], 4.0 - 3.0)
+
+
+def test_standard_scaler_window_learn_many_matches_learn_one():
+    """In windowed mode, learn_many should be equivalent to row-by-row learn_one."""
+    rng = random.Random(1)
+    values = [rng.uniform(-5, 5) for _ in range(30)]
+    df = pd.DataFrame({"x": values, "y": [v * 2 for v in values]})
+
+    one = preprocessing.StandardScaler(window_size=7)
+    for _, row in df.iterrows():
+        one.learn_one(row.to_dict())
+
+    many = preprocessing.StandardScaler(window_size=7)
+    many.learn_many(df)
+
+    assert math.isclose(one.means["x"].get(), many.means["x"].get(), abs_tol=1e-9)
+    assert math.isclose(one.vars["x"].get(), many.vars["x"].get(), abs_tol=1e-9)
+    assert math.isclose(one.means["y"].get(), many.means["y"].get(), abs_tol=1e-9)
+    assert math.isclose(one.vars["y"].get(), many.vars["y"].get(), abs_tol=1e-9)
+
+
+def test_standard_scaler_window_learn_many_chunks_equivalent():
+    """Splitting a stream into mini-batches must not change the final rolling state."""
+    rng = random.Random(2)
+    df = pd.DataFrame({"x": [rng.uniform(-3, 3) for _ in range(50)]})
+
+    monolithic = preprocessing.StandardScaler(window_size=10)
+    monolithic.learn_many(df)
+
+    chunked = preprocessing.StandardScaler(window_size=10)
+    for piece in _pd_split(df, 7):
+        chunked.learn_many(piece)
+
+    assert math.isclose(monolithic.means["x"].get(), chunked.means["x"].get(), abs_tol=1e-9)
+    assert math.isclose(monolithic.vars["x"].get(), chunked.vars["x"].get(), abs_tol=1e-9)
+
+
+def test_standard_scaler_window_transform_many_matches_transform_one():
+    """transform_many under windowed mode must match per-row transform_one."""
+    rng = random.Random(3)
+    df = pd.DataFrame({"x": [rng.uniform(-2, 2) for _ in range(15)]})
+
+    scaler = preprocessing.StandardScaler(window_size=4)
+    scaler.learn_many(df)
+
+    out_many = scaler.transform_many(df)
+    out_one = pd.DataFrame([scaler.transform_one(row.to_dict()) for _, row in df.iterrows()])
+    np.testing.assert_allclose(out_many.values, out_one.values, atol=1e-9)
+
+
+def test_standard_scaler_window_clone_preserves_window_size():
+    """`clone()` reconstructs window_size via __init__ but drops learned state."""
+    scaler = preprocessing.StandardScaler(window_size=5, with_std=False)
+    scaler.learn_one({"x": 1.0})
+    cloned = scaler.clone()
+    assert cloned.window_size == 5
+    assert cloned.with_std is False
+    assert isinstance(cloned.means["x"], utils.Rolling)
+    assert len(cloned.means["x"].window) == 0
+
+
+def test_standard_scaler_window_pickle_roundtrip():
+    """A windowed scaler must survive pickle and keep producing correct outputs."""
+    scaler = preprocessing.StandardScaler(window_size=4)
+    for v in [1.0, 2.0, 3.0, 4.0]:
+        scaler.learn_one({"x": v})
+
+    restored = pickle.loads(pickle.dumps(scaler))
+    assert restored.window_size == 4
+    assert isinstance(restored.means["x"], utils.Rolling)
+    assert math.isclose(restored.means["x"].get(), scaler.means["x"].get())
+    assert math.isclose(restored.vars["x"].get(), scaler.vars["x"].get())
+
+    # Continued learning after unpickling stays correct (no aliased state).
+    restored.learn_one({"x": 5.0})
+    expected_mean = (2.0 + 3.0 + 4.0 + 5.0) / 4
+    assert math.isclose(restored.means["x"].get(), expected_mean)
+
+
+def test_standard_scaler_window_pipeline_integration():
+    """A windowed scaler composes through `|` like any other Transformer."""
+    from river import compose
+
+    pipeline = compose.Select("x") | preprocessing.StandardScaler(window_size=3)
+    for v in [1.0, 2.0, 3.0]:
+        pipeline.learn_one({"x": v, "ignored": 99.0})
+    out = pipeline.transform_one({"x": 3.0, "ignored": 0.0})
+    # mean(1,2,3)=2, popvar=2/3, std=sqrt(2/3); (3-2)/std
+    assert math.isclose(out["x"], (3.0 - 2.0) / (2.0 / 3.0) ** 0.5)
+
+
+def test_standard_scaler_window_counts_track_cumulative_observations():
+    """In windowed mode, counts still track the cumulative observation count."""
+    scaler = preprocessing.StandardScaler(window_size=3)
+    for v in [1.0, 2.0, 3.0, 4.0, 5.0]:
+        scaler.learn_one({"x": v})
+    assert scaler.counts["x"] == 5
 
 
 def test_issue_1313():

--- a/river/proba/gaussian.py
+++ b/river/proba/gaussian.py
@@ -199,7 +199,7 @@ class MultivariateGaussian(base.MultivariateContinuousDistribution):
 
     >>> from river import utils
 
-    >>> p = utils.Rolling(MultivariateGaussian(), window_size=5)
+    >>> p = utils.Rolling(MultivariateGaussian, window_size=5)
     >>> for x in X.to_dict(orient="records"):
     ...     p.update(x)
     >>> p.var
@@ -212,7 +212,7 @@ class MultivariateGaussian(base.MultivariateContinuousDistribution):
 
     >>> from datetime import datetime as dt, timedelta as td
     >>> X.index = [dt(2023, 3, 28, 0, 0, 0) + td(seconds=x) for x in range(8)]
-    >>> p = utils.TimeRolling(MultivariateGaussian(), period=td(seconds=5))
+    >>> p = utils.TimeRolling(MultivariateGaussian, period=td(seconds=5))
     >>> for t, x in X.iterrows():
     ...     p.update(x.to_dict(), t=t)
     >>> p.var

--- a/river/proba/multinomial.py
+++ b/river/proba/multinomial.py
@@ -45,7 +45,7 @@ class Multinomial(base.DiscreteDistribution):
     >>> X = ['red', 'green', 'green', 'blue', 'blue']
 
     >>> dist = utils.Rolling(
-    ...     proba.Multinomial(),
+    ...     proba.Multinomial,
     ...     window_size=3
     ... )
 
@@ -78,7 +78,7 @@ class Multinomial(base.DiscreteDistribution):
     >>> days = [1, 2, 3, 4]
 
     >>> dist = utils.TimeRolling(
-    ...     proba.Multinomial(),
+    ...     proba.Multinomial,
     ...     period=dt.timedelta(days=2)
     ... )
 

--- a/river/stats/cov.py
+++ b/river/stats/cov.py
@@ -39,7 +39,7 @@ class Cov(stats.base.Bivariate):
     >>> x = [-2.1,  -1, 4.3, 1, -2.1,  -1, 4.3]
     >>> y = [   3, 1.1, .12, 1,    3, 1.1, .12]
 
-    >>> rcov = utils.Rolling(stats.Cov(), window_size=3)
+    >>> rcov = utils.Rolling(stats.Cov, window_size=3)
 
     >>> for xi, yi in zip(x, y):
     ...     rcov.update(xi, yi)

--- a/river/stats/mean.py
+++ b/river/stats/mean.py
@@ -38,7 +38,7 @@ class Mean(stats.base.Univariate):
     >>> from river import utils
 
     >>> X = [1, 2, 3, 4, 5, 6]
-    >>> rmean = utils.Rolling(stats.Mean(), window_size=2)
+    >>> rmean = utils.Rolling(stats.Mean, window_size=2)
 
     >>> for x in X:
     ...     rmean.update(x)

--- a/river/stats/pearson.py
+++ b/river/stats/pearson.py
@@ -50,7 +50,7 @@ class PearsonCorr(stats.base.Bivariate):
     >>> x = [0, 0, 0, 1, 1, 1, 1]
     >>> y = [0, 1, 2, 3, 4, 5, 6]
 
-    >>> pearson = utils.Rolling(stats.PearsonCorr(), window_size=4)
+    >>> pearson = utils.Rolling(stats.PearsonCorr, window_size=4)
 
     >>> for xi, yi in zip(x, y):
     ...     pearson.update(xi, yi)

--- a/river/stats/sem.py
+++ b/river/stats/sem.py
@@ -39,7 +39,7 @@ class SEM(var.Var):
 
     >>> X = [1, 4, 2, -4, -8, 0]
 
-    >>> rolling_sem = utils.Rolling(stats.SEM(ddof=1), window_size=3)
+    >>> rolling_sem = utils.Rolling(stats.SEM, window_size=3, ddof=1)
     >>> for x in X:
     ...     rolling_sem.update(x)
     ...     print(rolling_sem.get())

--- a/river/stats/summing.py
+++ b/river/stats/summing.py
@@ -31,7 +31,7 @@ class Sum(stats.base.Univariate):
     >>> from river import utils
 
     >>> X = [1, -4, 3, -2, 2, 1]
-    >>> rolling_sum = utils.Rolling(stats.Sum(), window_size=2)
+    >>> rolling_sum = utils.Rolling(stats.Sum, window_size=2)
     >>> for x in X:
     ...     rolling_sum.update(x)
     ...     print(rolling_sum.get())

--- a/river/stats/test_stats.py
+++ b/river/stats/test_stats.py
@@ -134,11 +134,10 @@ def test_univariate_reliability_weights(stat, func):
 @pytest.mark.parametrize(
     "stat, func",
     [
-        # TODO: we shouldn't ignore these types
-        (utils.Rolling(stats.Mean(), 3), statistics.mean),  # type: ignore
-        (utils.Rolling(stats.Mean(), 10), statistics.mean),  # type: ignore
-        (utils.Rolling(stats.Var(ddof=0), 3), np.var),  # type: ignore
-        (utils.Rolling(stats.Var(ddof=0), 10), np.var),  # type: ignore
+        (utils.Rolling(stats.Mean, 3), statistics.mean),
+        (utils.Rolling(stats.Mean, 10), statistics.mean),
+        (utils.Rolling(stats.Var, 3, ddof=0), np.var),
+        (utils.Rolling(stats.Var, 10, ddof=0), np.var),
         (
             stats.RollingQuantile(0.0, 10),
             functools.partial(np.quantile, q=0.0, method="linear"),
@@ -177,9 +176,8 @@ def test_rolling_univariate(stat, func):
 @pytest.mark.parametrize(
     "stat, func",
     [
-        # TODO: we shouldn't ignore these types
-        (utils.Rolling(stats.Mean(), 3), lambda x, w: np.average(x, weights=w)),  # type: ignore
-        (utils.Rolling(stats.Mean(), 10), lambda x, w: np.average(x, weights=w)),  # type: ignore
+        (utils.Rolling(stats.Mean, 3), lambda x, w: np.average(x, weights=w)),
+        (utils.Rolling(stats.Mean, 10), lambda x, w: np.average(x, weights=w)),
     ],
 )
 def test_rolling_univariate_sample_weights(stat, func):
@@ -201,9 +199,8 @@ def test_rolling_univariate_sample_weights(stat, func):
 @pytest.mark.parametrize(
     "stat, func",
     [
-        # TODO: we shouldn't ignore these types
-        (utils.Rolling(stats.Mean(), 3), lambda x, w: np.average(x, weights=w)),  # type: ignore
-        (utils.Rolling(stats.Mean(), 10), lambda x, w: np.average(x, weights=w)),  # type: ignore
+        (utils.Rolling(stats.Mean, 3), lambda x, w: np.average(x, weights=w)),
+        (utils.Rolling(stats.Mean, 10), lambda x, w: np.average(x, weights=w)),
     ],
 )
 def test_rolling_univariate_reliability_weights(stat, func):
@@ -242,10 +239,10 @@ def test_bivariate(stat, func):
 @pytest.mark.parametrize(
     "stat, func",
     [
-        (utils.Rolling(stats.PearsonCorr(), 3), lambda x, y: sp_stats.pearsonr(x, y)[0]),  # type: ignore
-        (utils.Rolling(stats.PearsonCorr(), 10), lambda x, y: sp_stats.pearsonr(x, y)[0]),  # type: ignore
-        (utils.Rolling(stats.Cov(), 3), lambda x, y: np.cov(x, y)[0, 1]),  # type: ignore
-        (utils.Rolling(stats.Cov(), 10), lambda x, y: np.cov(x, y)[0, 1]),  # type: ignore
+        (utils.Rolling(stats.PearsonCorr, 3), lambda x, y: sp_stats.pearsonr(x, y)[0]),
+        (utils.Rolling(stats.PearsonCorr, 10), lambda x, y: sp_stats.pearsonr(x, y)[0]),
+        (utils.Rolling(stats.Cov, 3), lambda x, y: np.cov(x, y)[0, 1]),
+        (utils.Rolling(stats.Cov, 10), lambda x, y: np.cov(x, y)[0, 1]),
     ],
 )
 def test_rolling_bivariate(stat, func):

--- a/river/stats/var.py
+++ b/river/stats/var.py
@@ -49,7 +49,7 @@ class Var(stats.base.Univariate):
     >>> from river import utils
 
     >>> X = [1, 4, 2, -4, -8, 0]
-    >>> rvar = utils.Rolling(stats.Var(ddof=1), window_size=3)
+    >>> rvar = utils.Rolling(stats.Var, window_size=3, ddof=1)
     >>> for x in X:
     ...     rvar.update(x)
     ...     print(rvar.get())

--- a/river/utils/rolling.py
+++ b/river/utils/rolling.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import bisect
 import collections
 import datetime as dt
+import inspect
+import warnings
 from typing import Any, Generic, Protocol, TypeVar, runtime_checkable
 
 
@@ -16,11 +18,16 @@ class Rollable(Protocol):
 _T = TypeVar("_T", bound=Rollable)
 
 
+_INSTANCE_DEPRECATION = (
+    "Passing an instance to utils.{cls} is deprecated and will be removed in a future release. "
+    "Pass the class and forward constructor kwargs instead, "
+    "e.g. utils.{cls}(stats.Mean, {window_kw}=...) "
+    "or utils.{cls}(stats.Var, {window_kw}=..., ddof=0)."
+)
+
+
 class BaseRolling(Generic[_T]):
     def __init__(self, obj: _T) -> None:
-        if not isinstance(obj, Rollable):
-            raise ValueError(f"{obj} does not satisfy the necessary protocol")
-
         self.obj = obj
 
     def __getattr__(self, name: str) -> object:
@@ -44,16 +51,20 @@ class BaseRolling(Generic[_T]):
 class Rolling(BaseRolling[_T]):
     """A generic wrapper for performing rolling computations.
 
-    This can be wrapped around any object which implements both an `update` and a `revert` method.
-    Inputs to `update` are stored in a queue. Elements of the queue are popped when the window is
-    full.
+    This can be wrapped around any class whose instances implement both an ``update`` and a
+    ``revert`` method. The wrapped class is instantiated internally; any extra keyword
+    arguments are forwarded to its constructor. Inputs to ``update`` are stored in a queue,
+    and elements of the queue are popped when the window is full.
 
     Parameters
     ----------
-    obj
-        An object that implements both an `update` method and a `rolling `method.
+    cls
+        A class whose instances implement ``update`` and ``revert``. Passing a pre-built
+        instance is deprecated and will be removed in a future release.
     window_size
         Size of the window.
+    **kwargs
+        Forwarded to ``cls`` when instantiating the wrapped object.
 
     Examples
     --------
@@ -63,7 +74,7 @@ class Rolling(BaseRolling[_T]):
     >>> from river import stats, utils
 
     >>> X = [1, 3, 5, 7]
-    >>> rmean = utils.Rolling(stats.Mean(), window_size=3)
+    >>> rmean = utils.Rolling(stats.Mean, window_size=3)
 
     >>> for x in X:
     ...     rmean.update(x)
@@ -73,9 +84,29 @@ class Rolling(BaseRolling[_T]):
     3.0
     5.0
 
+    Constructor arguments for the wrapped class are passed as keyword arguments:
+
+    >>> rvar = utils.Rolling(stats.Var, window_size=3, ddof=0)
+
     """
 
-    def __init__(self, obj: _T, window_size: int) -> None:
+    def __init__(self, cls: type[_T] | _T, window_size: int, **kwargs: Any) -> None:
+        if inspect.isclass(cls):
+            obj: _T = cls(**kwargs)
+        else:
+            if kwargs:
+                raise TypeError(
+                    "utils.Rolling received constructor kwargs alongside a pre-built instance. "
+                    "Pass the class instead, e.g. utils.Rolling(stats.Var, window_size=..., ddof=0)."
+                )
+            warnings.warn(
+                _INSTANCE_DEPRECATION.format(cls="Rolling", window_kw="window_size"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            obj = cls
+        if not isinstance(obj, Rollable):
+            raise ValueError(f"{obj} does not satisfy the necessary protocol")
         super().__init__(obj)
         self._window_size = window_size
         self.window: collections.deque[tuple[tuple[Any, ...], dict[str, Any]]] = collections.deque(
@@ -98,16 +129,20 @@ class Rolling(BaseRolling[_T]):
 class TimeRolling(BaseRolling[_T]):
     """A generic wrapper for performing time rolling computations.
 
-    This can be wrapped around any object which implements both an `update` and a `revert` method.
-    Inputs to `update` are stored in a queue. Elements of the queue are popped when they are too
-    old.
+    This can be wrapped around any class whose instances implement both an ``update`` and a
+    ``revert`` method. The wrapped class is instantiated internally; any extra keyword
+    arguments are forwarded to its constructor. Inputs to ``update`` are stored in a queue,
+    and elements of the queue are popped when they are too old.
 
     Parameters
     ----------
-    obj
-        An object that implements both an `update` method and a `rolling `method.
+    cls
+        A class whose instances implement ``update`` and ``revert``. Passing a pre-built
+        instance is deprecated and will be removed in a future release.
     period
         A duration of time, expressed as a `datetime.timedelta`.
+    **kwargs
+        Forwarded to ``cls`` when instantiating the wrapped object.
 
     Examples
     --------
@@ -123,7 +158,7 @@ class TimeRolling(BaseRolling[_T]):
     ...     dt.datetime(2019, 1, 4): 13
     ... }
 
-    >>> rmean = utils.TimeRolling(stats.Mean(), period=dt.timedelta(days=3))
+    >>> rmean = utils.TimeRolling(stats.Mean, period=dt.timedelta(days=3))
     >>> for t, x in X.items():
     ...     rmean.update(x, t=t)
     ...     print(rmean.get())
@@ -134,7 +169,23 @@ class TimeRolling(BaseRolling[_T]):
 
     """
 
-    def __init__(self, obj: _T, period: dt.timedelta) -> None:
+    def __init__(self, cls: type[_T] | _T, period: dt.timedelta, **kwargs: Any) -> None:
+        if inspect.isclass(cls):
+            obj: _T = cls(**kwargs)
+        else:
+            if kwargs:
+                raise TypeError(
+                    "utils.TimeRolling received constructor kwargs alongside a pre-built instance. "
+                    "Pass the class instead, e.g. utils.TimeRolling(stats.Var, period=..., ddof=0)."
+                )
+            warnings.warn(
+                _INSTANCE_DEPRECATION.format(cls="TimeRolling", window_kw="period"),
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            obj = cls
+        if not isinstance(obj, Rollable):
+            raise ValueError(f"{obj} does not satisfy the necessary protocol")
         super().__init__(obj)
         self.period = period
         self._timestamps: list[dt.datetime] = []

--- a/river/utils/rolling.py
+++ b/river/utils/rolling.py
@@ -5,7 +5,7 @@ import collections
 import datetime as dt
 import inspect
 import warnings
-from typing import Any, Generic, Protocol, TypeVar, runtime_checkable
+from typing import Any, Generic, Protocol, TypeVar, cast, overload, runtime_checkable
 
 
 @runtime_checkable
@@ -90,9 +90,13 @@ class Rolling(BaseRolling[_T]):
 
     """
 
+    @overload
+    def __init__(self, cls: type[_T], window_size: int, **kwargs: Any) -> None: ...
+    @overload
+    def __init__(self, cls: _T, window_size: int) -> None: ...
     def __init__(self, cls: type[_T] | _T, window_size: int, **kwargs: Any) -> None:
         if inspect.isclass(cls):
-            obj: _T = cls(**kwargs)
+            obj = cls(**kwargs)
         else:
             if kwargs:
                 raise TypeError(
@@ -107,7 +111,7 @@ class Rolling(BaseRolling[_T]):
             obj = cls
         if not isinstance(obj, Rollable):
             raise ValueError(f"{obj} does not satisfy the necessary protocol")
-        super().__init__(obj)
+        super().__init__(cast(_T, obj))
         self._window_size = window_size
         self.window: collections.deque[tuple[tuple[Any, ...], dict[str, Any]]] = collections.deque(
             maxlen=window_size
@@ -169,9 +173,13 @@ class TimeRolling(BaseRolling[_T]):
 
     """
 
+    @overload
+    def __init__(self, cls: type[_T], period: dt.timedelta, **kwargs: Any) -> None: ...
+    @overload
+    def __init__(self, cls: _T, period: dt.timedelta) -> None: ...
     def __init__(self, cls: type[_T] | _T, period: dt.timedelta, **kwargs: Any) -> None:
         if inspect.isclass(cls):
-            obj: _T = cls(**kwargs)
+            obj = cls(**kwargs)
         else:
             if kwargs:
                 raise TypeError(
@@ -186,7 +194,7 @@ class TimeRolling(BaseRolling[_T]):
             obj = cls
         if not isinstance(obj, Rollable):
             raise ValueError(f"{obj} does not satisfy the necessary protocol")
-        super().__init__(obj)
+        super().__init__(cast(_T, obj))
         self.period = period
         self._timestamps: list[dt.datetime] = []
         self._datum: list[Any] = []

--- a/river/utils/test_rolling.py
+++ b/river/utils/test_rolling.py
@@ -13,7 +13,7 @@ def test_with_counter() -> None:
     >>> import collections
     >>> collections.Counter.revert = collections.Counter.subtract
 
-    >>> counter = utils.Rolling(collections.Counter(), window_size=3)
+    >>> counter = utils.Rolling(collections.Counter, window_size=3)
 
     >>> for i in range(5):
     ...     counter.update([i])
@@ -32,12 +32,34 @@ def test_with_counter() -> None:
 
 def test_rolling_with_not_rollable() -> None:
     with pytest.raises(ValueError):
-        utils.Rolling(stats.Quantile(), window_size=10)  # type: ignore[type-var]
+        utils.Rolling(stats.Quantile, window_size=10)  # type: ignore[type-var]
 
 
 def test_time_rolling_with_not_rollable() -> None:
     with pytest.raises(ValueError):
-        utils.TimeRolling(stats.Quantile(), period=dt.timedelta(seconds=10))  # type: ignore[type-var]
+        utils.TimeRolling(stats.Quantile, period=dt.timedelta(seconds=10))  # type: ignore[type-var]
+
+
+def test_rolling_forwards_kwargs_to_class() -> None:
+    rvar = utils.Rolling(stats.Var, window_size=3, ddof=0)
+    for x in [1, 2, 3]:
+        rvar.update(x)
+    assert rvar.get() == pytest.approx(2 / 3)
+
+
+def test_rolling_instance_is_deprecated() -> None:
+    with pytest.warns(DeprecationWarning, match="deprecated"):
+        utils.Rolling(stats.Mean(), window_size=3)
+
+
+def test_time_rolling_instance_is_deprecated() -> None:
+    with pytest.warns(DeprecationWarning, match="deprecated"):
+        utils.TimeRolling(stats.Mean(), period=dt.timedelta(seconds=10))
+
+
+def test_rolling_rejects_kwargs_alongside_instance() -> None:
+    with pytest.raises(TypeError, match="instance"):
+        utils.Rolling(stats.Var(), window_size=3, ddof=0)  # type: ignore[call-overload]
 
 
 def test_issue_1343() -> None:
@@ -46,7 +68,7 @@ def test_issue_1343() -> None:
     https://github.com/online-ml/river/issues/1343
 
     """
-    rmean = utils.TimeRolling(proba.MultivariateGaussian(), period=dt.timedelta(microseconds=1))
+    rmean = utils.TimeRolling(proba.MultivariateGaussian, period=dt.timedelta(microseconds=1))
     t = dt.datetime.now()
     rmean.update({"a": 0}, t=t)
     rmean.update({"a": 1}, t=t)

--- a/river/utils/test_rolling.py
+++ b/river/utils/test_rolling.py
@@ -44,7 +44,7 @@ def test_rolling_forwards_kwargs_to_class() -> None:
     rvar = utils.Rolling(stats.Var, window_size=3, ddof=0)
     for x in [1, 2, 3]:
         rvar.update(x)
-    assert rvar.get() == pytest.approx(2 / 3)
+    assert rvar.get() == pytest.approx(2 / 3)  # type: ignore[operator]
 
 
 def test_rolling_instance_is_deprecated() -> None:


### PR DESCRIPTION
## Summary

Two related, atomic extensions to `preprocessing.MinMaxScaler`, `preprocessing.MaxAbsScaler`, and `preprocessing.StandardScaler`.

### 1. `window_size` (all three scalers)

A new `window_size: int | None = None` keyword argument switches the underlying running statistics to their rolling counterparts:

| Scaler | Running (default) | Rolling (`window_size` set) |
|---|---|---|
| `MinMaxScaler` | `stats.Min` / `stats.Max` | `stats.RollingMin` / `stats.RollingMax` |
| `MaxAbsScaler` | `stats.AbsMax` | `stats.RollingAbsMax` |
| `StandardScaler` | Welford `mean` / `var` | `utils.Rolling(stats.Mean())` / `utils.Rolling(stats.Var(ddof=0))` |

The `MinMaxScaler` / `MaxAbsScaler` branching follows the established `anomaly.GaussianScorer` pattern (kwarg dispatch via `functools.partial` in the `defaultdict` factory).

For `StandardScaler`, two extra design points were required:

- **Population variance (`ddof=0`)** is used in windowed mode so that the windowed and running modes agree exactly while `n ≤ window_size`. (River's non-windowed Welford estimator is also population variance.)
- A small picklable `_RollingStatFactory` is used instead of the obvious `functools.partial(utils.Rolling, stats.Mean(), n)`, which would silently share a single `stats.Mean()` instance across every key of the `defaultdict` — a per-feature aliasing bug.

```python
scaler = preprocessing.MinMaxScaler(window_size=100)
scaler = preprocessing.StandardScaler(window_size=100)
```

This is useful when the data distribution drifts and a global running statistic would saturate the scaling range.

#### Windowed `StandardScaler` — known limitations and compromises

- `learn_many` in windowed mode falls back to row-by-row updates, because the existing mini-batch Welford merge formula (`a·old_var + b·new_var + a·b·(old_mean − new_mean)²`) cannot be inverted to support eviction.
- `_from_state` does not seed the rolling window from scalar statistics; for a windowed warm-start, replay recent observations through `learn_one` instead. (This is documented in the classmethod's docstring.)
- `counts` continues to track cumulative observations (not window occupancy) in windowed mode — purely informational, kept for API symmetry with the non-windowed branch.
- `AdaptiveStandardScaler` remains the right choice when an EWMA-style "weight recent observations more" behavior is desired rather than a hard window.

### 2. `_from_state` warm-start (all three scalers)

A new `_from_state` classmethod constructs a scaler with pre-populated running statistics, so a stream can be warm-started from an offline estimate or resumed from a checkpoint without replaying past observations.

```python
scaler = preprocessing.StandardScaler._from_state(
    counts={'x': 100},
    means={'x': 10.0},
    vars={'x': 4.0},
)
scaler.transform_one({'x': 12.0})  # {'x': 1.0}
```

The classmethod naming and shape mirror the existing convention used elsewhere in river — `stats.Var._from_state`, `stats.Cov._from_state`, `proba.Gaussian._from_state`, `covariance.EmpiricalCovariance._from_state`.

For `MinMaxScaler` / `MaxAbsScaler`, `_from_state` composes with `window_size`: each initial value seeds one slot of the rolling window and is eventually evicted as fresh observations arrive.

## Backward compatibility

- Defaults are unchanged across all three classes; zero-argument construction remains behavior-identical to the previous version (regression-tested).
- Every non-windowed code path falls through to the original implementation unmodified — the new branches are gated by `if self.window_size is not None: ... return` at the top of each affected method.
- Pickles produced by the previous version (missing the new `window_size` attribute) are restored transparently via a small `__setstate__` shim on each of the three scalers that defaults missing `window_size` to `None`. Regression-tested.

## Test plan

- [x] `uv run pytest -n auto` — 4677 passed, 50 skipped, 0 failed
- [x] `uv run mypy river` / `uv run prek run --files <changed>` — ruff check, ruff format, mypy all pass
- [x] `test_estimators.py` — global estimator checks pass for the three scalers (including `check_pickling`, `check_clone_is_independent`, `check_predict_one_before_any_learn`)
- [x] 39 unit tests in `river/preprocessing/test_scale.py` covering:
  - warm-start (full keys, partial keys, then-extend)
  - windowed `MinMaxScaler` / `MaxAbsScaler` (eviction, type-of-stat, default-unchanged regression)
  - windowed `StandardScaler` (per-feature independence guard, numpy ddof=0 parity, drift adaptation, `learn_one` ↔ `learn_many` parity, chunked `learn_many` consistency, `transform_many` parity, pipeline integration, `with_std=False`, cumulative counts)
  - `_from_state` + `window_size` composition
  - `clone()` round-trip preserves `window_size`
  - warm-start matches a from-scratch trained scaler
  - warm-start composes with `learn_many` mini-batch path
  - pickle backward-compat: legacy (pre-`window_size`) pickles continue to work for all three scalers
- [x] Updated doctests for all three classes + repr-anchored doctests in `base/base.py`, `compose/pipeline.py`, `model_selection/sh.py`
- [x] Release note added in `docs/releases/unreleased.md`
