### PR TITLE
build(ci): add ppc64le architecture to linux wheel builds

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -27,7 +27,7 @@ jobs:
         timeout-minutes: 720
         env:
           CIBW_BUILD: "cp${{ matrix.python-version }}-${{ matrix.linux_tag }}_*"
-          CIBW_ARCHS_LINUX: "x86_64 aarch64"
+          CIBW_ARCHS_LINUX: "x86_64 aarch64 ppc64le"
       - uses: actions/upload-artifact@v5
         with:
           name: cibw-wheels-${{ matrix.linux_tag }}-${{ matrix.python-version }}-${{ strategy.job-index }}

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,3 @@
+# Unreleased
+
+* Add `ppc64le` architecture to Linux wheel builds. (@ChidiebereNjoku)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8286,6 +8286,7 @@ nav:
     - examples/on-hoeffding-trees.md
   - FAQ: faq
   - Releases:
+    - 'Unreleased': 'releases/unreleased.md'
     - "0.25.0": releases/0.25.0.md
     - "0.24.2": releases/0.24.2.md
     - "0.24.1": releases/0.24.1.md


### PR DESCRIPTION
## Description
Fixes #1810 

This PR expands the `cibuildwheel` Linux architecture matrix to include `ppc64le`. 

Since the `docker/setup-qemu-action` is already configured with `platforms: all` in the `build_linux_wheels` job, `cibuildwheel` natively leverages the existing QEMU layer to cross-compile the Cython extensions and build the wheels for PowerPC systems without requiring any additional runner infrastructure.