### PR TITLE
feat(stream): Add dataframe-agnostic `iter_frame` via narwhals, deprecate `iter_pandas`/`iter_polars`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,5 +28,6 @@ repos:
           - "--python-version=3.11"
           - "--implicit-optional"
         additional_dependencies:
+          - "narwhals"
           - "numpy"
           - "pytest"

--- a/docs/recipes/feature-extraction.ipynb
+++ b/docs/recipes/feature-extraction.ipynb
@@ -498,7 +498,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {

--- a/docs/recipes/feature-extraction.ipynb
+++ b/docs/recipes/feature-extraction.ipynb
@@ -498,7 +498,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -523,7 +523,7 @@
     "\n",
     "rolling_history = []\n",
     "\n",
-    "for x, y in stream.iter_pandas(\n",
+    "for x, y in stream.iter_frame(\n",
     "    df[[\"open\", \"high\", \"low\", \"close\", \"volume\"]],\n",
     "    df[\"target\"],\n",
     "):\n",

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,3 +1,8 @@
 # Unreleased
 
 * Add `ppc64le` architecture to Linux wheel builds. (@ChidiebereNjoku)
+
+## stream
+
+- Added `stream.iter_frame`, a dataframe-agnostic row iterator powered by [Narwhals](https://narwhals-dev.github.io/narwhals/) that works with any eager dataframe (pandas, polars, PyArrow, Modin, cuDF, ...).
+- Deprecated `stream.iter_pandas` and `stream.iter_polars` in favour of `stream.iter_frame`. They now emit a `DeprecationWarning` and will be removed in a future release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,6 @@ Repository = "https://github.com/online-ml/river/"
 requires = ["maturin>=1.13,<2"]
 build-backend = "maturin"
 
-[[tool.uv.index]]
-url = "https://pypi.org/"
-
 [tool.maturin]
 module-name = "river._river_rust"
 python-source = "."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "scipy>=1.16,<2",
     "numpy>=2.3.4,<3",
     "altair>=5.0.0",
+    "narwhals>=2.18.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dev = [
     "jupyter>=1.0.0",
     "mike @ git+https://github.com/squidfunk/mike.git",
     "polars>=1.1.0",
+    "pyarrow>=11.0.0",
 ]
 compat = [
     "scikit-learn>=1.5.1,<2",
@@ -202,6 +203,7 @@ module = [
     "gymnasium.*",
     "sympy.*",
     "polars.*",
+    "pyarrow.*",
     "river._river_rust",
     "river._river_rust.*",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "scipy>=1.16,<2",
     "numpy>=2.3.4,<3",
     "altair>=5.0.0",
-    "narwhals>=2.18.1",
+    "narwhals>=2.0.0",
 ]
 
 [project.optional-dependencies]
@@ -25,6 +25,9 @@ Repository = "https://github.com/online-ml/river/"
 [build-system]
 requires = ["maturin>=1.13,<2"]
 build-backend = "maturin"
+
+[[tool.uv.index]]
+url = "https://pypi.org/"
 
 [tool.maturin]
 module-name = "river._river_rust"

--- a/river/compat/river_to_sklearn.py
+++ b/river/compat/river_to_sklearn.py
@@ -26,7 +26,7 @@ STREAM_METHODS: dict[type, typing.Callable] = {np.ndarray: stream.iter_array}
 if PANDAS_INSTALLED:
     import pandas as pd
 
-    STREAM_METHODS[pd.DataFrame] = stream.iter_pandas
+    STREAM_METHODS[pd.DataFrame] = stream.iter_frame
 
 # Params passed to sklearn.utils.check_X_y and sklearn.utils.check_array
 SKLEARN_INPUT_X_PARAMS = {

--- a/river/compose/test_product.py
+++ b/river/compose/test_product.py
@@ -195,7 +195,7 @@ def test_one_many_consistent():
     X = pd.read_csv(datasets.TrumpApproval().path)
 
     one_outputs = []
-    for x, _ in stream.iter_pandas(X):
+    for x, _ in stream.iter_frame(X):
         one_outputs.append(product.transform_one(x))
     one_outputs = pd.DataFrame(one_outputs)
 

--- a/river/linear_model/test_glm.py
+++ b/river/linear_model/test_glm.py
@@ -125,7 +125,7 @@ def test_one_many_consistent():
     Y = X.pop("five_thirty_eight")
 
     one = lm.LinearRegression()
-    for x, y in stream.iter_pandas(X[:100], Y[:100]):
+    for x, y in stream.iter_frame(X[:100], Y[:100]):
         one.learn_one(x, y)
 
     many = lm.LinearRegression()
@@ -413,7 +413,7 @@ def test_lin_reg_sklearn_l1_non_regression():
         }
     )
 
-    for xi, yi in stream.iter_pandas(X, y):
+    for xi, yi in stream.iter_frame(X, y):
         ss.learn_one(xi)
         xi_tr = ss.transform_one(xi)
         rv.learn_one(xi_tr, yi)
@@ -466,7 +466,7 @@ def test_log_reg_sklearn_l1_non_regression():
 
     rv_pred = list()
     sk_pred = list()
-    for xi, yi in stream.iter_pandas(X, y):
+    for xi, yi in stream.iter_frame(X, y):
         ss.learn_one(xi)
         xi_tr = ss.transform_one(xi)
         rv.learn_one(xi_tr, yi)

--- a/river/multiclass/test_ovr.py
+++ b/river/multiclass/test_ovr.py
@@ -39,7 +39,7 @@ def test_online_batch_consistent():
     X = pd.read_csv(dataset.path)
     Y = X.pop("category")
 
-    for i, (x, y) in enumerate(stream.iter_pandas(X, Y)):
+    for i, (x, y) in enumerate(stream.iter_frame(X, Y)):
         y_pred = online.predict_one(x)
         online.learn_one(x, y)
 

--- a/river/preprocessing/test_scale.py
+++ b/river/preprocessing/test_scale.py
@@ -21,7 +21,7 @@ def test_standard_scaler_one_many_consistent():
         X = pd.read_csv(datasets.TrumpApproval().path)
 
         one = preprocessing.StandardScaler(with_std=with_std)
-        for x, _ in stream.iter_pandas(X):
+        for x, _ in stream.iter_frame(X):
             one.learn_one(x)
 
         many = preprocessing.StandardScaler(with_std=with_std)

--- a/river/stream/__init__.py
+++ b/river/stream/__init__.py
@@ -10,7 +10,10 @@ from .cache import Cache
 from .iter_arff import iter_arff
 from .iter_array import iter_array
 from .iter_csv import iter_csv
+from .iter_frame import iter_frame
 from .iter_libsvm import iter_libsvm
+from .iter_pandas import iter_pandas
+from .iter_polars import iter_polars
 from .qa import simulate_qa
 from .shuffling import shuffle
 from .tweet_stream import TwitterLiveStream
@@ -21,26 +24,15 @@ __all__ = [
     "iter_arff",
     "iter_array",
     "iter_csv",
+    "iter_frame",
     "iter_libsvm",
+    "iter_pandas",
+    "iter_polars",
     "simulate_qa",
     "shuffle",
     "TwitterLiveStream",
     "TwitchChatStream",
 ]
-
-try:
-    from .iter_polars import iter_polars
-
-    __all__ += ["iter_polars"]
-except ImportError:
-    pass
-
-try:
-    from .iter_pandas import iter_pandas
-
-    __all__ += ["iter_pandas"]
-except ImportError:
-    pass
 
 try:
     from .iter_sklearn import iter_sklearn_dataset

--- a/river/stream/iter_frame.py
+++ b/river/stream/iter_frame.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import typing
+
+import narwhals.stable.v2 as nw
+
+from river import base, stream
+
+if typing.TYPE_CHECKING:
+    from narwhals.stable.v2.typing import IntoDataFrame, IntoSeries
+
+
+def iter_frame(
+    X: IntoDataFrame, y: IntoSeries | IntoDataFrame | None = None, **kwargs
+) -> base.typing.Stream:
+    """Iterates over the rows of a dataframe.
+
+    This is a dataframe-agnostic iterator: it works with any eager dataframe supported by
+    [Narwhals](https://narwhals-dev.github.io/narwhals/) (pandas, polars, PyArrow, Modin, cuDF,
+    ...). It supersedes `stream.iter_pandas` and `stream.iter_polars`.
+
+    Parameters
+    ----------
+    X
+        A dataframe of features. Any eager dataframe supported by Narwhals will work.
+    y
+        A series or a dataframe with one column per target.
+    kwargs
+        Extra keyword arguments are passed to the underlying call to `stream.iter_array`.
+
+    Examples
+    --------
+
+    >>> from river import stream
+
+    The same code works regardless of the dataframe library. With pandas:
+
+    >>> import pandas as pd
+    >>> X = pd.DataFrame({
+    ...     'x1': [1, 2, 3, 4],
+    ...     'x2': ['blue', 'yellow', 'yellow', 'blue'],
+    ...     'y': [True, False, False, True]
+    ... })
+    >>> y = X.pop('y')
+
+    >>> for xi, yi in stream.iter_frame(X, y):
+    ...     print(xi, yi)
+    {'x1': 1, 'x2': 'blue'} True
+    {'x1': 2, 'x2': 'yellow'} False
+    {'x1': 3, 'x2': 'yellow'} False
+    {'x1': 4, 'x2': 'blue'} True
+
+    And with polars:
+
+    >>> import polars as pl
+    >>> X = pl.DataFrame({
+    ...     'x1': [1, 2, 3, 4],
+    ...     'x2': ['blue', 'yellow', 'yellow', 'blue'],
+    ...     'y': [True, False, False, True]
+    ... })
+    >>> y = X.get_column('y')
+    >>> X = X.drop('y')
+
+    >>> for xi, yi in stream.iter_frame(X, y):
+    ...     print(xi, yi)
+    {'x1': 1, 'x2': 'blue'} True
+    {'x1': 2, 'x2': 'yellow'} False
+    {'x1': 3, 'x2': 'yellow'} False
+    {'x1': 4, 'x2': 'blue'} True
+
+    """
+    X = nw.from_native(X, eager_only=True)
+    if y is not None:
+        y = nw.from_native(y, eager_only=True, allow_series=True)
+
+    kwargs["feature_names"] = X.columns
+    if isinstance(y, nw.DataFrame):
+        kwargs["target_names"] = y.columns
+
+    yield from stream.iter_array(X=X.to_numpy(), y=None if y is None else y.to_numpy(), **kwargs)

--- a/river/stream/iter_frame.py
+++ b/river/stream/iter_frame.py
@@ -1,17 +1,22 @@
 from __future__ import annotations
 
+import random
 import typing
 
 import narwhals.stable.v2 as nw
 
-from river import base, stream
+from river import base
 
 if typing.TYPE_CHECKING:
-    from narwhals.stable.v2.typing import IntoDataFrame, IntoSeries
+    from narwhals.stable.v2.typing import IntoDataFrame, IntoFrame, IntoSeries
 
 
 def iter_frame(
-    X: IntoDataFrame, y: IntoSeries | IntoDataFrame | None = None, **kwargs
+    X: IntoFrame,
+    y: IntoSeries | IntoDataFrame | None = None,
+    *,
+    shuffle: bool = False,
+    seed: int | None = None,
 ) -> base.typing.Stream:
     """Iterates over the rows of a dataframe.
 
@@ -19,14 +24,25 @@ def iter_frame(
     [Narwhals](https://narwhals-dev.github.io/narwhals/) (pandas, polars, PyArrow, Modin, cuDF,
     ...). It supersedes `stream.iter_pandas` and `stream.iter_polars`.
 
+    Rows are read directly from the dataframe via Narwhals, so each cell keeps its native
+    per-column type (no conversion to a single `numpy` array, which would otherwise coerce a
+    mixed-type frame to a common dtype).
+
+    Note that vaex is *not* supported here: Narwhals only exposes it through the dataframe
+    interchange protocol, which cannot iterate rows without materializing the whole frame. Use
+    `stream.iter_vaex` instead, which streams a vaex dataframe lazily.
+
     Parameters
     ----------
     X
         A dataframe of features. Any eager dataframe supported by Narwhals will work.
     y
-        A series or a dataframe with one column per target.
-    kwargs
-        Extra keyword arguments are passed to the underlying call to `stream.iter_array`.
+        A series, or a dataframe with one column per target.
+    shuffle
+        Whether to shuffle the rows before iterating over them. This materializes the whole
+        stream in memory, as the order can only be permuted once every row is known.
+    seed
+        Random seed used for shuffling. Only used when `shuffle` is `True`.
 
     Examples
     --------
@@ -50,7 +66,7 @@ def iter_frame(
     {'x1': 3, 'x2': 'yellow'} False
     {'x1': 4, 'x2': 'blue'} True
 
-    And with polars:
+    With polars:
 
     >>> import polars as pl
     >>> X = pl.DataFrame({
@@ -68,13 +84,54 @@ def iter_frame(
     {'x1': 3, 'x2': 'yellow'} False
     {'x1': 4, 'x2': 'blue'} True
 
+    And with PyArrow:
+
+    >>> import pyarrow as pa
+    >>> X = pa.table({
+    ...     'x1': [1, 2, 3, 4],
+    ...     'x2': ['blue', 'yellow', 'yellow', 'blue'],
+    ...     'y': [True, False, False, True]
+    ... })
+    >>> y = X.column('y')
+    >>> X = X.drop(['y'])
+
+    >>> for xi, yi in stream.iter_frame(X, y):
+    ...     print(xi, yi)
+    {'x1': 1, 'x2': 'blue'} True
+    {'x1': 2, 'x2': 'yellow'} False
+    {'x1': 3, 'x2': 'yellow'} False
+    {'x1': 4, 'x2': 'blue'} True
+
     """
-    X = nw.from_native(X, eager_only=True)
-    if y is not None:
-        y = nw.from_native(y, eager_only=True, allow_series=True)
+    # Accept any frame so we can raise an explicit error for the lazy case, rather than letting
+    # Narwhals reject it with a generic message.
+    frame = nw.from_native(X, allow_series=False)
+    if isinstance(frame, nw.LazyFrame):
+        raise TypeError(
+            f"`stream.iter_frame` only supports eager dataframes, but got a lazy frame "
+            f"({type(X).__name__!r}). Iterating rows would force a full materialization, and most "
+            f"lazy backends do not guarantee row order. Collect it first (e.g. via `.collect()`) "
+            f"and pass the resulting eager frame."
+        )
 
-    kwargs["feature_names"] = X.columns
-    if isinstance(y, nw.DataFrame):
-        kwargs["target_names"] = y.columns
+    # Narwhals types row keys as `str`; River's `FeatureName` is the broader `Hashable`, and
+    # `dict` keys are invariant, hence the cast.
+    x_iter = typing.cast(
+        "typing.Iterator[dict[base.typing.FeatureName, typing.Any]]",
+        frame.iter_rows(named=True),
+    )
 
-    yield from stream.iter_array(X=X.to_numpy(), y=None if y is None else y.to_numpy(), **kwargs)
+    rows: typing.Iterable[tuple[dict[base.typing.FeatureName, typing.Any], typing.Any]]
+    if y is None:
+        rows = ((x_row, None) for x_row in x_iter)
+    else:
+        target = nw.from_native(y, eager_only=True, allow_series=True)
+        y_iter = target.iter_rows(named=True) if isinstance(target, nw.DataFrame) else target
+        rows = zip(x_iter, y_iter)
+
+    if shuffle:
+        # Permuting the order requires knowing every row, hence the materialization.
+        rows = list(rows)
+        random.Random(seed).shuffle(rows)
+
+    yield from rows

--- a/river/stream/iter_pandas.py
+++ b/river/stream/iter_pandas.py
@@ -12,7 +12,7 @@ if typing.TYPE_CHECKING:
 
 
 def iter_pandas(
-    X: pd.DataFrame, y: pd.Series | pd.DataFrame | None = None, **kwargs
+    X: pd.DataFrame, y: pd.Series | pd.DataFrame | None = None, **kwargs: typing.Any
 ) -> base.typing.Stream:
     """Iterates over the rows of a `pandas.DataFrame`.
 
@@ -27,7 +27,8 @@ def iter_pandas(
     y
         A series or a dataframe with one column per target.
     kwargs
-        Extra keyword arguments are passed to the underlying call to `stream.iter_array`.
+        Extra keyword arguments are passed to the underlying call to `stream.iter_frame`
+        (e.g. `shuffle` and `seed`).
 
     Examples
     --------

--- a/river/stream/iter_pandas.py
+++ b/river/stream/iter_pandas.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import typing
+import warnings
 
-from river import base, stream, utils
+import narwhals.stable.v2 as nw
+
+from river import base, stream
 
 if typing.TYPE_CHECKING:
     import pandas as pd
@@ -12,6 +15,10 @@ def iter_pandas(
     X: pd.DataFrame, y: pd.Series | pd.DataFrame | None = None, **kwargs
 ) -> base.typing.Stream:
     """Iterates over the rows of a `pandas.DataFrame`.
+
+    .. deprecated::
+        Use `stream.iter_frame` instead, which works with any eager dataframe (pandas, polars,
+        PyArrow, ...). `stream.iter_pandas` will be removed in a future release.
 
     Parameters
     ----------
@@ -43,9 +50,18 @@ def iter_pandas(
     {'x1': 4, 'x2': 'blue'} True
 
     """
-    pd = utils.pandas.import_pandas()
-    kwargs["feature_names"] = X.columns
-    if isinstance(y, pd.DataFrame):
-        kwargs["target_names"] = y.columns
+    warnings.warn(
+        "`stream.iter_pandas` is deprecated; use `stream.iter_frame` instead. "
+        "It will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
-    yield from stream.iter_array(X=X.to_numpy(), y=y if y is None else y.to_numpy(), **kwargs)
+    if not nw.dependencies.is_pandas_dataframe(X):
+        raise TypeError(f"Expected a pandas DataFrame, got {type(X)}")
+    if y is not None and not (
+        nw.dependencies.is_pandas_dataframe(y) or nw.dependencies.is_pandas_series(y)
+    ):
+        raise TypeError(f"Expected a pandas DataFrame or Series, got {type(y)}")
+
+    yield from stream.iter_frame(X, y, **kwargs)

--- a/river/stream/iter_polars.py
+++ b/river/stream/iter_polars.py
@@ -12,7 +12,7 @@ if typing.TYPE_CHECKING:
 
 
 def iter_polars(
-    X: pl.DataFrame, y: pl.Series | pl.DataFrame | None = None, **kwargs
+    X: pl.DataFrame, y: pl.Series | pl.DataFrame | None = None, **kwargs: typing.Any
 ) -> base.typing.Stream:
     """Iterates over the rows of a `polars.DataFrame`.
 
@@ -27,7 +27,8 @@ def iter_polars(
     y
         A series or a dataframe with one column per target.
     kwargs
-        Extra keyword arguments are passed to the underlying call to `stream.iter_array`.
+        Extra keyword arguments are passed to the underlying call to `stream.iter_frame`
+        (e.g. `shuffle` and `seed`).
 
     Examples
     --------

--- a/river/stream/iter_polars.py
+++ b/river/stream/iter_polars.py
@@ -1,14 +1,24 @@
 from __future__ import annotations
 
-import polars as pl
+import typing
+import warnings
+
+import narwhals.stable.v2 as nw
 
 from river import base, stream
+
+if typing.TYPE_CHECKING:
+    import polars as pl
 
 
 def iter_polars(
     X: pl.DataFrame, y: pl.Series | pl.DataFrame | None = None, **kwargs
 ) -> base.typing.Stream:
     """Iterates over the rows of a `polars.DataFrame`.
+
+    .. deprecated::
+        Use `stream.iter_frame` instead, which works with any eager dataframe (pandas, polars,
+        PyArrow, ...). `stream.iter_polars` will be removed in a future release.
 
     Parameters
     ----------
@@ -31,7 +41,7 @@ def iter_polars(
     ...     'y': [True, False, False, True]
     ... })
     >>> y = X.get_column('y')
-    >>> X=X.drop("y")
+    >>> X = X.drop('y')
 
     >>> for xi, yi in stream.iter_polars(X, y):
     ...     print(xi, yi)
@@ -41,9 +51,18 @@ def iter_polars(
     {'x1': 4, 'x2': 'blue'} True
 
     """
+    warnings.warn(
+        "`stream.iter_polars` is deprecated; use `stream.iter_frame` instead. "
+        "It will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
-    kwargs["feature_names"] = X.columns
-    if isinstance(y, pl.DataFrame):
-        kwargs["target_names"] = y.columns
+    if not nw.dependencies.is_polars_dataframe(X):
+        raise TypeError(f"Expected a polars DataFrame, got {type(X)}")
+    if y is not None and not (
+        nw.dependencies.is_polars_dataframe(y) or nw.dependencies.is_polars_series(y)
+    ):
+        raise TypeError(f"Expected a polars DataFrame or Series, got {type(y)}")
 
-    yield from stream.iter_array(X=X.to_numpy(), y=y if y is None else y.to_numpy(), **kwargs)
+    yield from stream.iter_frame(X, y, **kwargs)

--- a/river/stream/test_iter_frame.py
+++ b/river/stream/test_iter_frame.py
@@ -10,6 +10,7 @@ if typing.TYPE_CHECKING:
     from collections.abc import Callable
 
     from narwhals.stable.v2.typing import IntoDataFrame, IntoSeries
+
     from river.base.typing import FeatureName
 
     Data = dict[str, list[typing.Any]]
@@ -83,7 +84,7 @@ def test_no_target(backend: Backend) -> None:
     """When `y` is omitted the target is `None` for every row."""
     rows = stream.iter_frame(backend.frame(FEATURES))
     assert [(xi, yi) for xi, yi in rows] == [(xi, None) for xi, _ in EXPECTED]
-    
+
 
 def test_multioutput_target(backend: Backend) -> None:
     """A dataframe target yields one dict per row with a column per output."""
@@ -126,7 +127,7 @@ def test_different_seeds_give_different_orders(backend: Backend) -> None:
 
 def test_backends_agree() -> None:
     """All installed backends produce byte-for-byte identical streams."""
-    streams: list[typing.List[typing.Tuple[dict[FeatureName, typing.Any], typing.Any]]] = []
+    streams: list[list[tuple[dict[FeatureName, typing.Any], typing.Any]]] = []
     for backend_builder in BACKENDS.values():
         backend = backend_builder()
         streams.append([*stream.iter_frame(backend.frame(FEATURES), backend.series(TARGET))])

--- a/river/stream/test_iter_frame.py
+++ b/river/stream/test_iter_frame.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import typing
+
+import pytest
+
+from river import stream
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from narwhals.stable.v2.typing import IntoDataFrame, IntoSeries
+    from river.base.typing import FeatureName
+
+    Data = dict[str, list[typing.Any]]
+    Row = tuple[dict[str, typing.Any], bool]
+
+# Canonical example, expressed once and reused across every backend. The expected output is
+# backend-independent and made of plain Python scalars (no numpy/arrow scalar leaks).
+FEATURES: Data = {"x1": [1, 2, 3, 4], "x2": ["blue", "yellow", "yellow", "blue"]}
+TARGET: list[bool] = [True, False, False, True]
+EXPECTED: list[Row] = [
+    ({"x1": 1, "x2": "blue"}, True),
+    ({"x1": 2, "x2": "yellow"}, False),
+    ({"x1": 3, "x2": "yellow"}, False),
+    ({"x1": 4, "x2": "blue"}, True),
+]
+
+
+class Backend(typing.NamedTuple):
+    """Builds native frames and series for one dataframe library."""
+
+    frame: Callable[[Data], IntoDataFrame]
+    series: Callable[[list[typing.Any]], IntoSeries]
+
+
+def _pandas() -> Backend:
+    pd = pytest.importorskip("pandas")
+    return Backend(frame=pd.DataFrame, series=pd.Series)
+
+
+def _polars() -> Backend:
+    pl = pytest.importorskip("polars")
+    return Backend(frame=pl.DataFrame, series=pl.Series)
+
+
+def _pyarrow() -> Backend:
+    pa = pytest.importorskip("pyarrow")
+
+    def series(values: list[typing.Any]) -> IntoSeries:
+        return pa.chunked_array([values])
+
+    return Backend(frame=pa.table, series=series)
+
+
+BACKENDS: dict[str, Callable[[], Backend]] = {
+    "pandas": _pandas,
+    "polars": _polars,
+    "pyarrow": _pyarrow,
+}
+
+
+@pytest.fixture(params=list(BACKENDS))
+def backend(request: pytest.FixtureRequest) -> Backend:
+    """Yields one `Backend` per dataframe library, skipping those that are not installed."""
+    return BACKENDS[request.param]()
+
+
+def test_features_and_target(backend: Backend) -> None:
+    """Every supported backend yields the same rows from features + a target series."""
+    assert list(stream.iter_frame(backend.frame(FEATURES), backend.series(TARGET))) == EXPECTED
+
+
+def test_native_python_scalars(backend: Backend) -> None:
+    """Cells are plain Python scalars, not numpy/arrow scalars."""
+    xi, yi = next(iter(stream.iter_frame(backend.frame(FEATURES), backend.series(TARGET))))
+    assert type(xi["x1"]) is int
+    assert type(xi["x2"]) is str
+    assert type(yi) is bool
+
+
+def test_no_target(backend: Backend) -> None:
+    """When `y` is omitted the target is `None` for every row."""
+    rows = stream.iter_frame(backend.frame(FEATURES))
+    assert [(xi, yi) for xi, yi in rows] == [(xi, None) for xi, _ in EXPECTED]
+    
+
+def test_multioutput_target(backend: Backend) -> None:
+    """A dataframe target yields one dict per row with a column per output."""
+    X = backend.frame({"x1": [1, 2]})
+    Y = backend.frame({"y1": [True, False], "y2": [False, True]})
+    assert list(stream.iter_frame(X, Y)) == [
+        ({"x1": 1}, {"y1": True, "y2": False}),
+        ({"x1": 2}, {"y1": False, "y2": True}),
+    ]
+
+
+def test_mixed_dtypes_are_not_coerced(backend: Backend) -> None:
+    """Per-column dtypes are preserved: an int column next to a float column stays int.
+
+    Going through a single numpy array (the previous implementation) would upcast the whole
+    frame to a common dtype, turning ``1`` into ``1.0``.
+    """
+    xi, _ = next(iter(stream.iter_frame(backend.frame({"i": [1, 2], "f": [1.5, 2.5]}))))
+    assert xi == {"i": 1, "f": 1.5}
+    assert type(xi["i"]) is int
+    assert type(xi["f"]) is float
+
+
+def test_shuffle_is_seeded_and_preserves_rows(backend: Backend) -> None:
+    """Shuffling is reproducible for a given seed and only reorders the rows."""
+    X, y = backend.frame(FEATURES), backend.series(TARGET)
+    shuffled = list(stream.iter_frame(X, y, shuffle=True, seed=42))
+
+    assert shuffled == list(stream.iter_frame(X, y, shuffle=True, seed=42))  # same seed, same order
+    assert shuffled != EXPECTED  # seed=42 actually permutes these four rows
+    assert sorted(shuffled, key=lambda row: row[0]["x1"]) == EXPECTED  # same rows, different order
+
+
+def test_different_seeds_give_different_orders(backend: Backend) -> None:
+    X, y = backend.frame(FEATURES), backend.series(TARGET)
+    assert list(stream.iter_frame(X, y, shuffle=True, seed=0)) != list(
+        stream.iter_frame(X, y, shuffle=True, seed=1)
+    )
+
+
+def test_backends_agree() -> None:
+    """All installed backends produce byte-for-byte identical streams."""
+    streams: list[typing.List[typing.Tuple[dict[FeatureName, typing.Any], typing.Any]]] = []
+    for backend_builder in BACKENDS.values():
+        backend = backend_builder()
+        streams.append([*stream.iter_frame(backend.frame(FEATURES), backend.series(TARGET))])
+    if not streams:
+        pytest.skip("no dataframe backend installed")
+    assert all(s == streams[0] for s in streams)
+
+
+def test_lazy_frame_raises() -> None:
+    """Lazy frames are rejected with an explicit, River-specific error."""
+    pl = pytest.importorskip("polars")
+    with pytest.raises(TypeError, match="only supports eager dataframes"):
+        # iter_frame is a generator, so the error surfaces on first iteration.
+        next(iter(stream.iter_frame(pl.LazyFrame(FEATURES))))
+
+
+@pytest.mark.parametrize(
+    ("iter_fn", "make_backend"),
+    [(stream.iter_pandas, _pandas), (stream.iter_polars, _polars)],
+)
+def test_deprecated_wrapper_forwards_shuffle(
+    iter_fn: Callable[..., typing.Iterator[Row]], make_backend: Callable[[], Backend]
+) -> None:
+    """The deprecated wrappers forward `shuffle`/`seed` through to `iter_frame`."""
+    b = make_backend()
+    with pytest.warns(DeprecationWarning):
+        rows = list(iter_fn(b.frame(FEATURES), b.series(TARGET), shuffle=True, seed=42))
+    assert sorted(rows, key=lambda row: row[0]["x1"]) == EXPECTED

--- a/uv.lock
+++ b/uv.lock
@@ -2432,6 +2432,56 @@ wheels = [
 ]
 
 [[package]]
+name = "pyarrow"
+version = "24.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/c9/a47ab7ece0d86cbe6678418a0fbd1ac4bb493b9184a3891dfa0e7f287ae0/pyarrow-24.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:b0e131f880cda8d04e076cee175a46fc0e8bc8b65c99c6c09dff6669335fde74", size = 35068898, upload-time = "2026-04-21T10:46:36.599Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/bc/8db86617a9a58008acf8913d6fed68ea2a46acb6de928db28d724c891a68/pyarrow-24.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:1b2fe7f9a5566401a0ef2571f197eb92358925c1f0c8dba305d6e43ea0871bb3", size = 36679915, upload-time = "2026-04-21T10:46:42.602Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/8e/fb178720400ef69db251eb4a9c3ccf4af269bc1feb5055529b8fc87170d1/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:0b3537c00fb8d384f15ac1e79b6eb6db04a16514c8c1d22e59a9b95c8ba42868", size = 45697931, upload-time = "2026-04-21T10:46:48.403Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/27/99c42abe8e21b44f4917f62631f3aa31404882a2c41d8a4cd5c110e13d52/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:14e31a3c9e35f1ab6356c6378f6f72830e6d2d5f1791df3774a7b097d18a6a1e", size = 48837449, upload-time = "2026-04-21T10:46:55.329Z" },
+    { url = "https://files.pythonhosted.org/packages/36/b6/333749e2666e9032891125bf9c691146e92901bece62030ac1430e2e7c88/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b7d9a514e73bc42711e6a35aaccf3587c520024fe0a25d830a1a8a27c15f4f57", size = 49395949, upload-time = "2026-04-21T10:47:01.869Z" },
+    { url = "https://files.pythonhosted.org/packages/17/25/c5201706a2dd374e8ba6ee3fd7a8c89fb7ffc16eed5217a91fd2bd7f7626/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b196eb3f931862af3fa84c2a253514d859c08e0d8fe020e07be12e75a5a9780c", size = 51912986, upload-time = "2026-04-21T10:47:09.872Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d2/4d1bbba65320b21a49678d6fbdc6ff7c649251359fdcfc03568c4136231d/pyarrow-24.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:35405aecb474e683fb36af650618fd5340ee5471fc65a21b36076a18bbc6c981", size = 27255371, upload-time = "2026-04-21T10:47:15.943Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a9/9686d9f07837f91f775e8932659192e02c74f9d8920524b480b85212cc68/pyarrow-24.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:6233c9ed9ab9d1db47de57d9753256d9dcffbf42db341576099f0fd9f6bf4810", size = 34981559, upload-time = "2026-04-21T10:47:22.17Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b6/0ddf0e9b6ead3474ab087ae598c76b031fc45532bf6a63f3a553440fb258/pyarrow-24.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:f7616236ec1bc2b15bfdec22a71ab38851c86f8f05ff64f379e1278cf20c634a", size = 36663654, upload-time = "2026-04-21T10:47:28.315Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3b/926382efe8ce27ba729071d3566ade6dfb86bdf112f366000196b2f5780a/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1617043b99bd33e5318ae18eb2919af09c71322ef1ca46566cdafc6e6712fb66", size = 45679394, upload-time = "2026-04-21T10:47:34.821Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/829f7d9dfd37c207206081d6dad474d81dde29952401f07f2ba507814818/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6165461f55ef6314f026de6638d661188e3455d3ec49834556a0ebbdbace18bb", size = 48863122, upload-time = "2026-04-21T10:47:42.056Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e8/f88ce625fe8babaae64e8db2d417c7653adb3019b08aae85c5ed787dc816/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3b13dedfe76a0ad2d1d859b0811b53827a4e9d93a0bcb05cf59333ab4980cc7e", size = 49376032, upload-time = "2026-04-21T10:47:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/36/7a/82c363caa145fff88fb475da50d3bf52bb024f61917be5424c3392eaf878/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:25ea65d868eb04015cd18e6df2fbe98f07e5bda2abefabcb88fce39a947716f6", size = 51929490, upload-time = "2026-04-21T10:47:55.981Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1c/e3e72c8014ad2743ca64a701652c733cc5cbcee15c0463a32a8c55518d9e/pyarrow-24.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:295f0a7f2e242dabd513737cf076007dc5b2d59237e3eca37b05c0c6446f3826", size = 27355660, upload-time = "2026-04-21T10:48:01.718Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d3/a1abf004482026ddc17f4503db227787fa3cfe41ec5091ff20e4fea55e57/pyarrow-24.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:02b001b3ed4723caa44f6cd1af2d5c86aa2cf9971dacc2ffa55b21237713dfba", size = 34976759, upload-time = "2026-04-21T10:48:07.258Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4a/34f0a36d28a2dd32225301b79daad44e243dc1a2bb77d43b60749be255c4/pyarrow-24.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:04920d6a71aabd08a0417709efce97d45ea8e6fb733d9ca9ecffb13c67839f68", size = 36658471, upload-time = "2026-04-21T10:48:13.347Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/78/543b94712ae8bb1a6023bcc1acf1a740fbff8286747c289cd9468fced2a5/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a964266397740257f16f7bb2e4f08a0c81454004beab8ff59dd531b73610e9f2", size = 45675981, upload-time = "2026-04-21T10:48:20.201Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9f/8fb7c222b100d314137fa40ec050de56cd8c6d957d1cfff685ce72f15b17/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f066b179d68c413374294bc1735f68475457c933258df594443bb9d88ddc2a0", size = 48859172, upload-time = "2026-04-21T10:48:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/1ea72538e6c8b3b475ed78d1049a2c518e655761ea50fe1171fc855fcab7/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1183baeb14c5f587b1ec52831e665718ce632caab84b7cd6b85fd44f96114495", size = 49385733, upload-time = "2026-04-21T10:48:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/be/c3d8b06a1ba35f2260f8e1f771abbee7d5e345c0937aab90675706b1690a/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:806f24b4085453c197a5078218d1ee08783ebbba271badd153d1ae22a3ee804f", size = 51934335, upload-time = "2026-04-21T10:48:42.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/62/89e07a1e7329d2cde3e3c6994ba0839a24977a2beda8be6005ea3d860b99/pyarrow-24.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:e4505fc6583f7b05ab854934896bcac8253b04ac1171a77dfb73efef92076d91", size = 27271748, upload-time = "2026-04-21T10:49:42.532Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1a/cff3a59f80b5b1658549d46611b67163f65e0664431c076ad728bf9d5af4/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:1a4e45017efbf115032e4475ee876d525e0e36c742214fbe405332480ecd6275", size = 35238554, upload-time = "2026-04-21T10:48:48.526Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/99/cce0f42a327bfef2c420fb6078a3eb834826e5d6697bf3009fe11d2ad051/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:7986f1fa71cee060ad00758bcc79d3a93bab8559bf978fab9e53472a2e25a17b", size = 36782301, upload-time = "2026-04-21T10:48:55.181Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/66/8e560d5ff6793ca29aca213c53eec0dd482dd46cb93b2819e5aab52e4252/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d3e0b61e8efb24ed38898e5cdc5fffa9124be480008d401a1f8071500494ae42", size = 45721929, upload-time = "2026-04-21T10:49:03.676Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0c/a26e25505d030716e078d9f16eb74973cbf0b33b672884e9f9da1c83b871/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:55a3bc1e3df3b5567b7d27ef551b2283f0c68a5e86f1cd56abc569da4f31335b", size = 48825365, upload-time = "2026-04-21T10:49:11.714Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/771f9ecb0c65e73fe9dccdd1717901b9594f08c4515d000c7c62df573811/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:641f795b361874ac9da5294f8f443dfdbee355cf2bd9e3b8d97aaac2306b9b37", size = 49451819, upload-time = "2026-04-21T10:49:21.474Z" },
+    { url = "https://files.pythonhosted.org/packages/48/da/61ae89a88732f5a785646f3ec6125dbb640fa98a540eb2b9889caa561403/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8adc8e6ce5fccf5dc707046ae4914fd537def529709cc0d285d37a7f9cd442ca", size = 51909252, upload-time = "2026-04-21T10:49:31.164Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1a/8dd5cafab7b66573fa91c03d06d213356ad4edd71813aa75e08ce2b3a844/pyarrow-24.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:9b18371ad2f44044b81a8d23bc2d8a9b6a6226dca775e8e16cfee640473d6c5d", size = 27388127, upload-time = "2026-04-21T10:49:37.334Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/d022a34ff05d2cbedd8ccf841fc1f532ecfa9eb5ed1711b56d0e0ea71fc9/pyarrow-24.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:1cc9057f0319e26333b357e17f3c2c022f1a83739b48a88b25bfd5fa2dc18838", size = 35007997, upload-time = "2026-04-21T10:49:48.796Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ff/f01485fda6f4e5d441afb8dd5e7681e4db18826c1e271852f5d3957d6a80/pyarrow-24.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e6f1278ee4785b6db21229374a1c9e54ec7c549de5d1efc9630b6207de7e170b", size = 36678720, upload-time = "2026-04-21T10:49:55.858Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c2/2d2d5fea814237923f71b36495211f20b43a1576f9a4d6da7e751a64ec6f/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:adbbedc55506cbdabb830890444fb856bfb0060c46c6f8026c6c2f2cf86ae795", size = 45741852, upload-time = "2026-04-21T10:50:04.624Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3a/28ba9c1c1ebdbb5f1b94dfebb46f207e52e6a554b7fe4132540fde29a3a0/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ae8a1145af31d903fa9bb166824d7abe9b4681a000b0159c9fb99c11bc11ad26", size = 48889852, upload-time = "2026-04-21T10:50:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/df/51/4a389acfd31dca009f8fb82d7f510bb4130f2b3a8e18cf00194d0687d8ac/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d7027eba1df3b2069e2e8d80f644fa0918b68c46432af3d088ddd390d063ecde", size = 49445207, upload-time = "2026-04-21T10:50:20.677Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/0bab2b23d2ae901b1b9a03c0efd4b2d070256f8ce3fc43f6e58c167b2081/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e56a1ffe9bf7b727432b89104cc0849c21582949dd7bdcb34f17b2001a351a76", size = 51954117, upload-time = "2026-04-21T10:50:29.14Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/f4e9145da0417b3d2c12035a8492b35ff4a3dbc653e614fcfb51d9dedb38/pyarrow-24.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:38be1808cdd068605b787e6ca9119b27eb275a0234e50212c3492331680c3b1e", size = 28001155, upload-time = "2026-04-21T10:51:22.337Z" },
+    { url = "https://files.pythonhosted.org/packages/79/4f/46a49a63f43526da895b1a45bbb51d5baf8e4d77159f8528fc3e5490007f/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:418e48ce50a45a6a6c73c454677203a9c75c966cb1e92ca3370959185f197a05", size = 35250387, upload-time = "2026-04-21T10:50:35.552Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/da/d5e0cd5ef00796922404806d5f00325cdadc3441ce2c13fe7115f2df9a64/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:2f16197705a230a78270cdd4ea8a1d57e86b2fdcbc34a1f6aebc72e65c986f9a", size = 36797102, upload-time = "2026-04-21T10:50:42.417Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c7/5904145b0a593a05236c882933d439b5720f0a145381179063722fbfc123/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fb24ac194bfc5e86839d7dcd52092ee31e5fe6733fe11f5e3b06ef0812b20072", size = 45745118, upload-time = "2026-04-21T10:50:49.324Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d3/cca42fe166d1c6e4d5b80e530b7949104d10e17508a90ae202dac205ce2a/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9700ebd9a51f5895ce75ff4ac4b3c47a7d4b42bc618be8e713e5d56bacf5f931", size = 48844765, upload-time = "2026-04-21T10:50:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
+    { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
+    { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2830,6 +2880,7 @@ dev = [
     { name = "pandas" },
     { name = "polars" },
     { name = "prek" },
+    { name = "pyarrow" },
     { name = "pytest" },
     { name = "pytest-xdist", extra = ["psutil"] },
     { name = "ruff" },
@@ -2886,6 +2937,7 @@ dev = [
     { name = "pandas", specifier = ">=2.2,<3" },
     { name = "polars", specifier = ">=1.1.0" },
     { name = "prek", specifier = ">=0.2" },
+    { name = "pyarrow", specifier = ">=11.0.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-xdist", extras = ["psutil"], specifier = ">=3.3.1" },
     { name = "ruff", specifier = ">=0.15.8" },

--- a/uv.lock
+++ b/uv.lock
@@ -2801,6 +2801,7 @@ version = "0.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "altair" },
+    { name = "narwhals" },
     { name = "numpy" },
     { name = "scipy" },
 ]
@@ -2859,6 +2860,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "altair", specifier = ">=5.0.0" },
+    { name = "narwhals", specifier = ">=2.18.1" },
     { name = "numpy", specifier = ">=2.3.4,<3" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.2,<3" },
     { name = "scipy", specifier = ">=1.16,<2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2860,7 +2860,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "altair", specifier = ">=5.0.0" },
-    { name = "narwhals", specifier = ">=2.18.1" },
+    { name = "narwhals", specifier = ">=2.0.0" },
     { name = "numpy", specifier = ">=2.3.4,<3" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.2,<3" },
     { name = "scipy", specifier = ">=1.16,<2" },


### PR DESCRIPTION
Part of #1881. Adds `stream.iter_frame`, a single [Narwhals](https://narwhals-dev.github.io/narwhals/)-powered row iterator that works with any eager backend (pandas, polars, PyArrow, Modin, cuDF, ...).

`iter_pandas`/`iter_polars` become deprecated thin wrappers that delegate to it.

This covers input iteration only for now; dataframe-agnostic mini-batch methods are a follow-up.

**Notes**:

* `iter_vaex` is left untouched: Narwhals only supports vaex at the interchange level, which would force materialization and kill its design.
* Backward compatible: old functions still work, just warn.

**Open questions**:

* Testing: I tried to address only the direct changes. In practice there are not direct tests for `iter_pandas`/`iter_polars`. Should I add direct tests for it, including pyarrow?
* Docs: Anything I need to change in the API? I am a bit lost for how the API reference is generated 🙈
