### PR TITLE
Make altair an optional (docs-only) dependency

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Add `ppc64le` architecture to Linux wheel builds.
+* Dropped `altair` from River's runtime dependencies. It was never imported by the package itself (it is only used to draw plots in the documentation notebooks), so it has been moved to the `docs`/`dev` dependency groups. Installing River no longer pulls in `altair` and its transitive dependencies.
 
 ## covariance
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ license = "BSD-3-Clause"
 dependencies = [
     "scipy>=1.16,<2",
     "numpy>=2.3.4,<3",
-    "altair>=5.0.0",
     "narwhals>=2.0.0",
 ]
 
@@ -67,6 +66,7 @@ docs = [
     "jupyter-client",
     "mike @ git+https://github.com/squidfunk/mike.git",
     "pygments",
+    "altair>=5.0.0",
     "TA-Lib",
     "zensical>=0.0.40",
     "nbconvert",

--- a/uv.lock
+++ b/uv.lock
@@ -2850,7 +2850,6 @@ name = "river"
 version = "0.25.0"
 source = { editable = "." }
 dependencies = [
-    { name = "altair" },
     { name = "narwhals" },
     { name = "numpy" },
     { name = "scipy" },
@@ -2889,6 +2888,7 @@ dev = [
     { name = "sympy" },
 ]
 docs = [
+    { name = "altair" },
     { name = "dominate" },
     { name = "flask" },
     { name = "jupyter-client" },
@@ -2910,7 +2910,6 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "altair", specifier = ">=5.0.0" },
     { name = "narwhals", specifier = ">=2.0.0" },
     { name = "numpy", specifier = ">=2.3.4,<3" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.2,<3" },
@@ -2946,6 +2945,7 @@ dev = [
     { name = "sympy", specifier = ">=1.12.1" },
 ]
 docs = [
+    { name = "altair", specifier = ">=5.0.0" },
     { name = "dominate" },
     { name = "flask" },
     { name = "jupyter-client" },


### PR DESCRIPTION
## Why

`altair` is currently a required runtime dependency of River, but it is **not imported anywhere in the `river` package** (`grep -rln "altair" river/` returns nothing). The HTML reprs in `river/base/viz.py` and `river/tree/viz.py` use `xml.etree.ElementTree`.

It landed in the core `dependencies` list via #1819 (*"Remove matplotlib dependency and replace with Altair in notebooks"*), which only needed it for the plots in the `docs/` Jupyter notebooks but added it to `[project].dependencies` (and redundantly to the `dev` group) rather than scoping it to docs/dev.

## What

- Remove `altair>=5.0.0` from `[project].dependencies`.
- Add it to the `docs` dependency group (the docs build executes the notebooks that `import altair`; `docs` previously lacked it and relied on the core dep). It was already present in `dev`.
- Regenerate `uv.lock`.
- Add an `unreleased.md` entry.

A plain `pip install river` no longer pulls in `altair` and its transitive dependencies (vega, jsonschema, ...).

🤖 Generated with [Claude Code](https://claude.com/claude-code)