### PR TITLE
ci: partition pandas tests to avoid running the suite twice

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  ubuntu:
+  tests:
     name: Tests + prek
     runs-on: ubuntu-latest
     steps:
@@ -33,14 +33,21 @@ jobs:
       - name: Download datasets
         run: uv run make download-datasets
 
-      - name: Run tests
-        run: uv run pytest
-
+      # prek runs while pandas is still installed (mypy etc. type-check against it).
       - name: Run prek
         uses: j178/prek-action@v2
 
-  no-pandas:
-    name: Tests without pandas
+      # The bulk of the suite runs without pandas, which also guards the
+      # optional-dependency contract. The pandas subset runs in the companion
+      # job below, so nothing is tested twice.
+      - name: Uninstall pandas
+        run: uv pip uninstall pandas
+
+      - name: Run tests
+        run: uv run --no-sync pytest
+
+  pandas:
+    name: Tests with pandas
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -62,11 +69,12 @@ jobs:
       - name: Download datasets
         run: uv run make download-datasets
 
-      - name: Uninstall pandas
-        run: uv pip uninstall pandas
-
-      - name: Run tests
-        run: uv run --no-sync pytest
+      # RIVER_PANDAS_ONLY restricts collection to the pandas-dependent modules
+      # (see river/conftest.py).
+      - name: Run pandas tests
+        env:
+          RIVER_PANDAS_ONLY: "1"
+        run: uv run pytest
 
   build-sdist:
     name: Build sdist and wheel from sdist
@@ -81,4 +89,3 @@ jobs:
 
       - name: Build sdist and wheel from sdist
         run: uv build
-

--- a/river/conftest.py
+++ b/river/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import pathlib
 
 collect_ignore = []
@@ -20,20 +21,35 @@ try:
 except ImportError:
     collect_ignore.append("stream/iter_vaex.py")
 
-try:
-    import pandas  # noqa: F401
-except ImportError:
-    # `pandas` is an optional extra. When it is absent, skip collection of every
-    # test module and doctest source that references pandas — they all need
-    # `pip install "river[pandas]"` to run. Detection is text-based; we match
-    # both direct pandas usage (`import pandas`, `>>> pd.`) and indirect uses
-    # via sklearn's `fetch_openml`, which sklearn itself routes through pandas.
-    _root = pathlib.Path(__file__).parent
-    _NEEDLES = ("import pandas", ">>> pd.", "fetch_openml")
-    for _path in _root.rglob("*.py"):
-        try:
-            _text = _path.read_text(encoding="utf-8", errors="ignore")
-        except OSError:
-            continue
-        if any(needle in _text for needle in _NEEDLES):
-            collect_ignore.append(str(_path.relative_to(_root)))
+# Text-based detection of pandas usage, matching both direct pandas usage
+# (`import pandas`, `>>> pd.`) and indirect uses via sklearn's `fetch_openml`,
+# which sklearn itself routes through pandas.
+_ROOT = pathlib.Path(__file__).parent
+_PANDAS_NEEDLES = ("import pandas", ">>> pd.", "fetch_openml")
+
+
+def _uses_pandas(path: pathlib.Path) -> bool:
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+    return any(needle in text for needle in _PANDAS_NEEDLES)
+
+
+if os.environ.get("RIVER_PANDAS_ONLY") == "1":
+    # Companion CI job: pandas IS installed and we run *only* the pandas subset,
+    # so the main (no-pandas) job doesn't have to re-run everything else. Ignore
+    # every source/test module that does not touch pandas.
+    for _path in _ROOT.rglob("*.py"):
+        if _path.name != "conftest.py" and not _uses_pandas(_path):
+            collect_ignore.append(str(_path.relative_to(_ROOT)))
+else:
+    try:
+        import pandas  # noqa: F401
+    except ImportError:
+        # `pandas` is an optional extra. When it is absent, skip collection of
+        # every test module and doctest source that references pandas — they all
+        # need `pip install "river[pandas]"` to run.
+        for _path in _ROOT.rglob("*.py"):
+            if _uses_pandas(_path):
+                collect_ignore.append(str(_path.relative_to(_ROOT)))


### PR DESCRIPTION
## What

The `code-quality` workflow had two jobs that overlapped:
- **Tests + prek** — ran the *full* suite with pandas installed
- **Tests without pandas** — ran the non-pandas subset with pandas uninstalled

So the ~430-module non-pandas majority ran in **both** jobs. This splits them into a true partition where each test runs exactly once.

## How

- `river/conftest.py`: added an `RIVER_PANDAS_ONLY=1` branch that inverts the existing text-scan — instead of *skipping* pandas modules when pandas is absent, it *keeps only* pandas modules when the flag is set. Shared detection factored into a `_uses_pandas()` helper; default and no-pandas behavior unchanged.
- `.github/workflows/code-quality.yml`:
  - **Tests + prek** — runs prek while pandas is present (so mypy still type-checks against it), then uninstalls pandas and runs the ~430-module majority. Doubles as the optional-dependency guarantee.
  - **Tests with pandas** — runs with `RIVER_PANDAS_ONLY=1`, collecting only the ~48 pandas-touching modules.

## Gain

Stops re-running the non-pandas majority twice: roughly halves total test compute, and shortens the critical-path wall-clock since the pandas job is now small.

## Verification

- `RIVER_PANDAS_ONLY=1` collects 48 modules (291 tests) with no collection errors; default mode collect_ignore is unchanged.
- Partition is exhaustive: 48 pandas modules + 434 others = full suite, no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)