### PR TITLE
Add PerOutputRegressor

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -17,6 +17,10 @@
 - Sped up the mini-batch gradient in `LinearRegression`/`LogisticRegression.learn_many` by contracting the sample axis directly inside the `np.einsum` call instead of building the intermediate `(n, p)` matrix and averaging it afterwards. ~2-3× faster on that step, no semantic change.
 - Stabilised `BayesianLinearRegression` across BLAS implementations and sped it up further. `learn_one` now accumulates an exact natural mean `_eta_arr = beta * sum_i(y_i * x_i)` alongside the existing Sherman-Morrison rank-1 update of `_ss_inv_arr`, and the posterior mean is recovered lazily as `_ss_inv_arr @ _eta_arr` (cached and invalidated on `learn_one`). Previously the posterior mean was propagated through `m_new = ss_inv @ (ss_old @ m_old + bx*y)`, which compounded BLAS rounding multiplicatively across rank-1 updates and caused a ~0.6% relative drift between macOS Accelerate and Linux OpenBLAS on `TrumpApproval` with imputation. The new path keeps `learn_one` ~20% faster than before and the full `predict`+`learn` cycle ~10% faster.
 
+## multioutput
+
+- Added `multioutput.PerOutputRegressor`, the streaming equivalent of scikit-learn's `MultiOutputRegressor`. Trains one independent regressor per target output, with no inter-output dependencies.
+
 ## optim
 
 - Exposed `optim.Newton`, the Online Newton Step optimizer, which was previously implemented but never exported. Fixed a correctness bug whereby the inverse Hessian was initialized to `eps * I` instead of `(1 / eps) * I`, which crippled learning (the maintained inverse could only ever shrink from a tiny starting value). Reworked the internals to use NumPy-backed dense state and `utils.math.sherman_morrison` (the same BLAS rank-1 update used by `BayesianLinearRegression`) instead of a bespoke dict-based reimplementation.

--- a/river/multioutput/__init__.py
+++ b/river/multioutput/__init__.py
@@ -9,11 +9,13 @@ from .chain import (
     RegressorChain,
 )
 from .encoder import MultiClassEncoder
+from .per_output import PerOutputRegressor
 
 __all__ = [
     "ClassifierChain",
     "MonteCarloClassifierChain",
     "MultiClassEncoder",
+    "PerOutputRegressor",
     "ProbabilisticClassifierChain",
     "RegressorChain",
 ]

--- a/river/multioutput/per_output.py
+++ b/river/multioutput/per_output.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import collections
+import copy
+
+from river import base, linear_model
+
+__all__ = ["PerOutputRegressor"]
+
+
+class PerOutputRegressor(base.Wrapper, base.MultiTargetRegressor, collections.UserDict):  # type:ignore[misc]
+    """A multi-output model that trains one independent regressor per output.
+
+    This model does not use the prediction of one output as a
+    feature for the next. Each output is modelled by its own copy of the base regressor,
+    trained independently. (This is the streaming equivalent of scikit-learn's
+    `MultiOutputRegressor`).
+
+    The set of outputs isn't known from the start in a streaming setting, new regressors are
+    instantiated on the fly, one per output key encountered in `y`.
+
+    Parameters
+    ----------
+    model
+        The regression model used to make predictions for each target.
+
+    Examples
+    --------
+
+    >>> from river import evaluate
+    >>> from river import linear_model
+    >>> from river import metrics
+    >>> from river import multioutput
+    >>> from river import preprocessing
+    >>> from river import stream
+
+    >>> from sklearn import datasets
+
+    >>> dataset = stream.iter_sklearn_dataset(
+    ...     dataset=datasets.load_linnerud(),
+    ...     shuffle=True,
+    ...     seed=42
+    ... )
+
+    >>> model = multioutput.PerOutputRegressor(
+    ...     model=(
+    ...         preprocessing.StandardScaler() |
+    ...         linear_model.LinearRegression(intercept_lr=0.3)
+    ...     )
+    ... )
+
+    >>> metric = metrics.multioutput.MicroAverage(metrics.MAE())
+
+    >>> evaluate.progressive_val_score(dataset, model, metric)
+    MicroAverage(MAE): 12.68377
+
+    """
+
+    def __init__(self, model: base.Regressor):
+        super().__init__()
+        self.model = model
+
+    @property
+    def _wrapped_model(self):
+        return self.model
+
+    def __getitem__(self, key):
+        try:
+            return collections.UserDict.__getitem__(self, key)
+        except KeyError:
+            collections.UserDict.__setitem__(self, key, copy.deepcopy(self.model))
+            return self[key]
+
+    @classmethod
+    def _unit_test_params(cls):
+        yield {"model": linear_model.LinearRegression()}
+
+    def learn_one(self, x, y, **kwargs):
+        for o, y_o in y.items():
+            self[o].learn_one(x, y_o, **kwargs)
+
+    def predict_one(self, x, **kwargs):
+        return {o: reg.predict_one(x, **kwargs) for o, reg in self.items()}


### PR DESCRIPTION
Closes #1409.

Adds PerOutputRegressor to river.multioutput, the streaming equivalent of scikit-learn's MultiOutputRegressor. Trains one independent regressor per output, no inter-output dependencies. Reuses the lazy-deepcopy UserDict pattern from BaseChain. Docstring example uses load_linnerud to match the pattern already in RegressorChain.