### PR TITLE
Fix TFIDF mini-batch transforms for DataFrame input

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,5 +29,5 @@ repos:
           - "--implicit-optional"
         additional_dependencies:
           - "narwhals"
-          - "numpy"
+          - "numpy==2.4.3" # keep in sync with uv.lock; newer stubs use 3.12 `type` syntax mypy rejects at --python-version=3.11
           - "pytest"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,28 +6,26 @@ repos:
       - id: check-json
       - id: check-yaml
 
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version, should be the same as in uv.lock
-    rev: v0.15.8
+  # ruff and mypy run from the uv environment (`uv run`), so their versions and the
+  # dependencies they type-check against (narwhals, numpy, pytest, ...) come from the uv
+  # dev group / uv.lock — no `rev` pins or `additional_dependencies` to keep in sync here.
+  - repo: local
     hooks:
-      # Run the linter.
       - id: ruff-check
+        name: ruff-check
+        entry: uv run ruff check --fix
+        language: system
         types_or: [python, pyi, jupyter]
-        args: [--fix]
-      # Run the formatter.
+        require_serial: true
       - id: ruff-format
+        name: ruff-format
+        entry: uv run ruff format
+        language: system
         types_or: [python, pyi, jupyter]
-
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    # MyPy version, should be the same as in uv.lock
-    rev: v1.19.1
-    hooks:
+        require_serial: true
       - id: mypy
-        args:
-          - "--config-file=pyproject.toml"
-          - "--python-version=3.11"
-          - "--implicit-optional"
-        additional_dependencies:
-          - "narwhals"
-          - "numpy==2.4.3" # keep in sync with uv.lock; newer stubs use 3.12 `type` syntax mypy rejects at --python-version=3.11
-          - "pytest"
+        name: mypy
+        entry: uv run mypy --config-file=pyproject.toml --python-version=3.11 --implicit-optional
+        language: system
+        types_or: [python, pyi]
+        require_serial: true

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -35,6 +35,10 @@
 - Sped up `learn_one` for all factorization-machine models by vectorizing the per-factor latent updates with NumPy instead of looping in Python. On MovieLens 100K: ~1.4× faster for `FFMRegressor`/`FFMClassifier`, ~1.8× for `FwFMRegressor`/`FwFMClassifier` and `HOFMRegressor`/`HOFMClassifier`. Outputs are unchanged.
 - The factorization-machine models are now covered by the automated estimator checks (`utils.check_estimator`).
 
+## feature_extraction
+
+- Added proper mini-batch support to `feature_extraction.TFIDF`: `learn_many` now updates document frequencies, and `transform_many` now returns TF-IDF weights for both `Series` input and `DataFrame` input when `on` is set. Fixes [#1576](https://github.com/online-ml/river/issues/1576).
+
 ## linear_model
 
 - Added `linear_model.AdPredictor`, the Bayesian online probit-regression classifier Microsoft used for click-through-rate prediction in Bing's sponsored search (Graepel et al., 2010). It keeps a Gaussian belief over each feature weight and yields well-calibrated probabilities.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -23,7 +23,7 @@
 - Added weighted sample support to `EmpiricalCovariance.update` and `EmpiricalCovariance.revert` by accepting an optional `w` parameter and propagating it to the underlying `stats.Cov` and `stats.Var` statistics.
 - Sped up `EmpiricalCovariance.update`/`revert` (~40% faster at 30 features) by caching the sorted feature list and pair iteration in the hot path. No semantic change.
 - Restructured `EmpiricalPrecision` around NumPy-backed dense state, removing the per-update dict ↔ numpy marshalling. ~7× faster on 2000 × 20 sample streams.
-- Fixed an `EmpiricalPrecision` asymmetry where features introduced at different times left the stored matrix skewed (e.g. `prec[a, b]` ≠ `prec[b, a]`).      
+- Fixed an `EmpiricalPrecision` asymmetry where features introduced at different times left the stored matrix skewed (e.g. `prec[a, b]` ≠ `prec[b, a]`).
 
 ## datasets
 
@@ -37,7 +37,7 @@
 
 ## feature_extraction
 
-- Added proper mini-batch support to `feature_extraction.TFIDF`: `learn_many` now updates document frequencies, and `transform_many` now returns TF-IDF weights for both `Series` input and `DataFrame` input when `on` is set. Fixes [#1576](https://github.com/online-ml/river/issues/1576).
+- Added proper mini-batch support to `feature_extraction.TFIDF`: `learn_many` now updates document frequencies, and `transform_many` returns TF-IDF weights. Both `feature_extraction.BagOfWords.transform_many` and `TFIDF.transform_many` now accept any narwhals-supported dataframe backend (pandas, polars, pyarrow, ...), as either a series of documents or a dataframe with the `on` parameter, and return the same backend (a sparse dataframe for pandas).
 
 ## linear_model
 
@@ -46,7 +46,7 @@
 - `BayesianLinearRegression` now handles features arriving and disappearing after training begins (it passes `check_emerging_features` and `check_shuffle_features_no_impact`, previously skipped).
 - Fixed `BayesianLinearRegression` coefficients diverging to `inf`/`nan` under emerging/disappearing features; `learn_one` now updates the full state with a zero-padded `x`. Behavior change: features absent from `x` are treated as observed 0s (matching the other linear models) rather than skipped — identical to before when every call sees the same features.
 - Sped up the `LinearRegression`/`LogisticRegression.learn_many` mini-batch gradient (~2-3×) by contracting the sample axis inside the `np.einsum`. No semantic change.
-- Sped up `learn_one` for the linear models (`LinearRegression`, `LogisticRegression`, `Perceptron`, ...): updates now scale with the number of active features instead of the total number of features ever seen. Outputs are unchanged.       
+- Sped up `learn_one` for the linear models (`LinearRegression`, `LogisticRegression`, `Perceptron`, ...): updates now scale with the number of active features instead of the total number of features ever seen. Outputs are unchanged.
 - Stabilised `BayesianLinearRegression` across BLAS implementations and sped it up (~10-20%) by accumulating an exact natural mean and recovering the posterior mean lazily, instead of propagating it through compounding rank-1 updates (which drifted ~0.6% between macOS Accelerate and Linux OpenBLAS).
 - `linear_model.LinearRegression` and `linear_model.LogisticRegression` mini-batch methods (`learn_many`, `predict_many`, `predict_proba_many`) now accept and return any [narwhals](https://github.com/narwhals-dev/narwhals)-supported eager backend (pandas, polars, pyarrow, ...) instead of being pandas-only. The input backend is preserved on output, including the pandas index. These methods no longer require `pandas` to be installed.
 - `linear_model.BayesianLinearRegression` is now a `MiniBatchRegressor`: it gained a `learn_many` method, equivalent to looping `learn_one` over the rows (exact without smoothing, and the matching closed-form geometric weighting with smoothing). Its `learn_many`/`predict_many` accept and return any [narwhals](https://github.com/narwhals-dev/narwhals)-supported eager backend (pandas, polars, pyarrow, ...), preserving the input backend and pandas index, and no longer require `pandas`.
@@ -95,7 +95,7 @@
 
 ## rules
 
-- Fixed `RecursionError` in `AMRules` on long streams: the `EBSTSplitter`, `TEBSTSplitter`, and `ExhaustiveSplitter` now traverse and deep-copy their search trees iteratively, so deeply-skewed trees no longer blow Python's recursion limit. 
+- Fixed `RecursionError` in `AMRules` on long streams: the `EBSTSplitter`, `TEBSTSplitter`, and `ExhaustiveSplitter` now traverse and deep-copy their search trees iteratively, so deeply-skewed trees no longer blow Python's recursion limit.
 - Fixed an `AMRules` memory leak where `HoeffdingRule.expand` appended a redundant `NumericLiteral` when a new split shared a feature and direction with an existing literal without tightening the threshold.
 
 ## stats

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,25 +188,51 @@ files = "river"
 strict = true
 
 [[tool.mypy.overrides]]
+# Both the bare top-level name and the `.*` submodule glob are listed: under the uv dev env
+# (where prek now runs mypy) these libraries are installed without a py.typed marker, so a bare
+# `import pandas` reports `import-untyped` unless the top-level name is ignored too.
 module = [
+    "mmh3",
     "mmh3.*",
+    "numpy",
     "numpy.*",
+    "sklearn",
     "sklearn.*",
+    "pytest",
     "pytest.*",
+    "pandas",
     "pandas.*",
+    "scipy",
     "scipy.*",
+    "graphviz",
     "graphviz.*",
+    "vaex",
     "vaex.*",
+    "torch",
     "torch.*",
+    "sqlalchemy",
     "sqlalchemy.*",
+    "requests",
     "requests.*",
+    "gymnasium",
     "gymnasium.*",
+    "sympy",
     "sympy.*",
+    "polars",
     "polars.*",
+    "pyarrow",
     "pyarrow.*",
     "river._river_rust",
     "river._river_rust.*",
 ]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# `numpydoc` (used by docs/parse for docstring scraping) hard-depends on Sphinx, whose source
+# uses 3.12 `type` syntax that mypy rejects under `--python-version=3.11`. We build docs with
+# mkdocs/zensical, never Sphinx, and never type-check it, so don't follow imports into it.
+module = ["sphinx.*", "numpydoc.*"]
+follow_imports = "skip"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/river/feature_extraction/test_vectorize.py
+++ b/river/feature_extraction/test_vectorize.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
+import math
+import typing
+
+import narwhals.stable.v2 as nw
 import pandas as pd
 import pandas.testing as pdt
 import pytest
 from sklearn.feature_extraction.text import TfidfVectorizer
 
 from river import feature_extraction
+from river.conftest import FRAME_BACKENDS
+
+if typing.TYPE_CHECKING:
+    from river.conftest import FrameBackend
 
 
 @pytest.mark.parametrize(
@@ -220,3 +228,133 @@ def test_vectorizers_transform_many_accept_empty_documents(transformer, X):
 
     assert Xt.index.tolist() == ["empty"]
     assert Xt.shape == (1, 0)
+
+
+# Dataframe-agnostic mini-batching (narwhals): the tests above pin down pandas behaviour; the
+# ones below re-run the core equivalences across every supported backend (pandas, polars,
+# pyarrow, ...) via the `frame_backend` fixture from `river/conftest.py`.
+
+DOCS = ["foo foo bar", "foo baz", "spam spam eggs", ""]
+
+
+def _make_input(backend: FrameBackend, docs: list[str], *, on: str | None):
+    """Build the native input: a series of documents when `on is None`, else a dataframe."""
+    return backend.series(docs) if on is None else backend.frame({on: docs})
+
+
+def _native_columns(native) -> dict[str, list[float]]:
+    """Normalise any backend's `transform_many` output to `{str(term): [float, ...]}`."""
+    frame = nw.from_native(native, eager_only=True)
+    return {str(col): [float(v) for v in frame[col].to_list()] for col in frame.columns}
+
+
+def _one_columns(transformer, docs: list[str], *, on: str | None) -> dict[str, list[float]]:
+    """The same mapping, built from a row-by-row `transform_one` loop (the reference)."""
+    rows = [transformer.transform_one(doc if on is None else {on: doc}) for doc in docs]
+    terms = {term for row in rows for term in row}
+    return {str(term): [float(row.get(term, 0.0)) for row in rows] for term in terms}
+
+
+def _assert_columns_close(actual: dict, expected: dict) -> None:
+    assert actual.keys() == expected.keys()
+    for term, values in expected.items():
+        assert all(
+            math.isclose(a, e, rel_tol=1e-9, abs_tol=1e-12) for a, e in zip(actual[term], values)
+        )
+
+
+@pytest.mark.parametrize("on", [None, "text"])
+@pytest.mark.parametrize("normalize", [True, False])
+def test_tfidf_transform_many_matches_transform_one_across_backends(
+    frame_backend: FrameBackend, on: str | None, normalize: bool
+) -> None:
+    """`transform_many` equals a row-by-row `transform_one` loop on every backend."""
+    X = _make_input(frame_backend, DOCS, on=on)
+
+    tfidf = feature_extraction.TFIDF(normalize=normalize, on=on)
+    tfidf.learn_many(X)
+
+    _assert_columns_close(
+        _native_columns(tfidf.transform_many(X)),
+        _one_columns(tfidf, DOCS, on=on),
+    )
+
+
+@pytest.mark.parametrize("on", [None, "text"])
+def test_bow_transform_many_matches_transform_one_across_backends(
+    frame_backend: FrameBackend, on: str | None
+) -> None:
+    """`BagOfWords.transform_many` equals a `transform_one` loop on every backend (issue #1576)."""
+    X = _make_input(frame_backend, DOCS, on=on)
+    bow = feature_extraction.BagOfWords(on=on)
+
+    _assert_columns_close(
+        _native_columns(bow.transform_many(X)),
+        _one_columns(bow, DOCS, on=on),
+    )
+
+
+@pytest.mark.parametrize("on", [None, "text"])
+def test_tfidf_transform_many_matches_sklearn_across_backends(
+    frame_backend: FrameBackend, on: str | None
+) -> None:
+    """Normalised `transform_many` matches scikit-learn's `TfidfVectorizer` on every backend."""
+    docs = ["foo foo bar", "foo baz", "spam spam eggs"]
+    X = _make_input(frame_backend, docs, on=on)
+
+    tfidf = feature_extraction.TFIDF(on=on)
+    tfidf.learn_many(X)
+    actual = _native_columns(tfidf.transform_many(X))
+
+    vectorizer = TfidfVectorizer(token_pattern=r"(?u)\b\w[\w\-]+\b")
+    matrix = vectorizer.fit_transform(docs).toarray()
+    expected = {
+        term: [float(matrix[i, j]) for i in range(len(docs))]
+        for j, term in enumerate(vectorizer.get_feature_names_out())
+    }
+
+    _assert_columns_close(actual, expected)
+
+
+@pytest.mark.parametrize("on", [None, "text"])
+def test_tfidf_learn_many_matches_learn_one_across_backends(
+    frame_backend: FrameBackend, on: str | None
+) -> None:
+    """`learn_many` accumulates the same document frequencies as a `learn_one` loop."""
+    X = _make_input(frame_backend, DOCS, on=on)
+
+    batch = feature_extraction.TFIDF(on=on)
+    batch.learn_many(X)
+
+    online = feature_extraction.TFIDF(on=on)
+    for doc in DOCS:
+        online.learn_one(doc if on is None else {on: doc})
+
+    assert batch.n == online.n
+    assert batch.dfs == online.dfs
+
+
+@pytest.mark.parametrize(
+    "transformer",
+    [feature_extraction.BagOfWords(on="text"), feature_extraction.TFIDF(on="text")],
+    ids=["bow", "tfidf"],
+)
+def test_transform_many_returns_input_backend(frame_backend: FrameBackend, transformer) -> None:
+    """The output frame's native type matches the input dataframe's backend."""
+    X = frame_backend.frame({"text": DOCS})
+    if isinstance(transformer, feature_extraction.TFIDF):
+        transformer.learn_many(X)
+
+    assert type(transformer.transform_many(X)) is type(X)
+
+
+def test_tfidf_learn_many_is_backend_agnostic(frame_backend: FrameBackend) -> None:
+    """`learn_many` accumulates identical state regardless of the input backend."""
+    reference = feature_extraction.TFIDF(on="text")
+    reference.learn_many(FRAME_BACKENDS["pandas"]().frame({"text": DOCS}))
+
+    model = feature_extraction.TFIDF(on="text")
+    model.learn_many(frame_backend.frame({"text": DOCS}))
+
+    assert model.n == reference.n
+    assert model.dfs == reference.dfs

--- a/river/feature_extraction/test_vectorize.py
+++ b/river/feature_extraction/test_vectorize.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import pandas as pd
+import pandas.testing as pdt
 import pytest
+from sklearn.feature_extraction.text import TfidfVectorizer
 
 from river import feature_extraction
 
@@ -48,3 +51,172 @@ def test_ngrams(params, text, expected_ngrams):
     bow = feature_extraction.BagOfWords(**params)
     ngrams = list(bow.process_text(text))
     assert expected_ngrams == ngrams
+
+
+def _dense_transform_many(transformer, X):
+    return transformer.transform_many(X).sparse.to_dense().sort_index(axis=1)
+
+
+def _dense_transform_one(transformer, X):
+    if transformer.on is None:
+        records = X
+    else:
+        records = X.to_dict(orient="records")
+
+    return (
+        pd.DataFrame([transformer.transform_one(x) for x in records], index=X.index)
+        .fillna(0.0)
+        .sort_index(axis=1)
+    )
+
+
+def _sklearn_tfidf(X):
+    if isinstance(X, pd.DataFrame):
+        documents = X["text"]
+    else:
+        documents = X
+
+    sklearn = TfidfVectorizer(token_pattern=r"(?u)\b\w[\w\-]+\b")
+    return pd.DataFrame(
+        sklearn.fit_transform(documents).toarray(),
+        index=X.index,
+        columns=sklearn.get_feature_names_out(),
+    ).sort_index(axis=1)
+
+
+def test_bow_transform_many_accepts_dataframe_with_on():
+    X = pd.DataFrame(
+        {"text": ["Hello world", "Hello River"]},
+        index=["river", "rocks"],
+    )
+    bow = feature_extraction.BagOfWords(on="text")
+
+    pdt.assert_frame_equal(
+        _dense_transform_many(bow, X),
+        _dense_transform_one(bow, X),
+        check_dtype=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "X, params",
+    [
+        pytest.param(
+            pd.Series(
+                ["foo bar bat baz", "foo bar spam eggs"],
+                index=["first", "second"],
+            ),
+            {},
+            id="series",
+        ),
+        pytest.param(
+            pd.DataFrame(
+                {"text": ["foo bar bat baz", "foo bar spam eggs"]},
+                index=["first", "second"],
+            ),
+            {"on": "text"},
+            id="dataframe-on",
+        ),
+    ],
+)
+def test_tfidf_transform_many_matches_transform_one(X, params):
+    tfidf = feature_extraction.TFIDF(**params)
+    tfidf.learn_many(X)
+
+    pdt.assert_frame_equal(
+        _dense_transform_many(tfidf, X),
+        _dense_transform_one(tfidf, X),
+        check_dtype=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "X, params",
+    [
+        pytest.param(
+            pd.Series(
+                ["foo foo bar", "foo baz", "spam spam eggs"],
+                index=["a", "b", "c"],
+            ),
+            {},
+            id="series",
+        ),
+        pytest.param(
+            pd.DataFrame(
+                {"text": ["foo foo bar", "foo baz", "spam spam eggs"]},
+                index=["a", "b", "c"],
+            ),
+            {"on": "text"},
+            id="dataframe-on",
+        ),
+    ],
+)
+def test_tfidf_transform_many_matches_sklearn_when_normalized(X, params):
+    tfidf = feature_extraction.TFIDF(**params)
+    tfidf.learn_many(X)
+
+    pdt.assert_frame_equal(
+        _dense_transform_many(tfidf, X),
+        _sklearn_tfidf(X),
+        check_dtype=False,
+    )
+
+
+def test_tfidf_learn_many_matches_learn_one_with_on():
+    X = pd.DataFrame(
+        {"text": ["foo foo bar", "foo baz", ""]},
+        index=["a", "b", "c"],
+    )
+    batch = feature_extraction.TFIDF(on="text")
+    online = feature_extraction.TFIDF(on="text")
+
+    batch.learn_many(X)
+    for x in X.to_dict(orient="records"):
+        online.learn_one(x)
+
+    assert batch.n == online.n
+    assert batch.dfs == online.dfs
+
+
+def test_tfidf_transform_many_without_normalization():
+    X = pd.Series(["foo foo bar", "foo baz"], index=["a", "b"])
+    tfidf = feature_extraction.TFIDF(normalize=False)
+    tfidf.learn_many(X)
+
+    pdt.assert_frame_equal(
+        _dense_transform_many(tfidf, X),
+        _dense_transform_one(tfidf, X),
+        check_dtype=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "transformer, X",
+    [
+        pytest.param(
+            feature_extraction.BagOfWords(),
+            pd.Series([""], index=["empty"]),
+            id="bow-series",
+        ),
+        pytest.param(
+            feature_extraction.BagOfWords(on="text"),
+            pd.DataFrame({"text": [""]}, index=["empty"]),
+            id="bow-dataframe-on",
+        ),
+        pytest.param(
+            feature_extraction.TFIDF(),
+            pd.Series([""], index=["empty"]),
+            id="tfidf-series",
+        ),
+        pytest.param(
+            feature_extraction.TFIDF(on="text"),
+            pd.DataFrame({"text": [""]}, index=["empty"]),
+            id="tfidf-dataframe-on",
+        ),
+    ],
+)
+def test_vectorizers_transform_many_accept_empty_documents(transformer, X):
+    Xt = transformer.transform_many(X)
+
+    assert Xt.index.tolist() == ["empty"]
+    assert Xt.shape == (1, 0)

--- a/river/feature_extraction/vectorize.py
+++ b/river/feature_extraction/vectorize.py
@@ -9,6 +9,7 @@ import re
 import typing
 import unicodedata
 
+import numpy as np
 from scipy import sparse
 
 from river import base, utils
@@ -520,29 +521,27 @@ class TFIDF(BagOfWords):
         indptr, indices, data = [0], [], []
         index: dict[int, int] = {}
 
+        # Build the document-term count matrix in a single pass.
         for terms in self.process_many(X):
-            term_counts = collections.Counter(terms)
-            n_terms = sum(term_counts.values())
-
-            if n_terms:
-                weights = {}
-                for term, count in term_counts.items():
-                    tf = count / n_terms
-                    idf = math.log((1 + self.n) / (1 + self.dfs[term])) + 1
-                    weights[term] = tf * idf
-
-                if self.normalize:
-                    norm = math.sqrt(sum(weight**2 for weight in weights.values()))
-                    weights = {term: weight / norm for term, weight in weights.items()}
-
-                for term, weight in weights.items():
-                    indices.append(index.setdefault(term, len(index)))
-                    data.append(weight)
-
+            for term, count in collections.Counter(terms).items():
+                indices.append(index.setdefault(term, len(index)))
+                data.append(count)
             indptr.append(len(data))
+        counts = sparse.csr_matrix((data, indices, indptr), shape=(len(indptr) - 1, len(index)))
 
-        return pd.DataFrame.sparse.from_spmatrix(
-            sparse.csr_matrix((data, indices, indptr), shape=(len(indptr) - 1, len(index))),
-            index=X.index,
-            columns=index.keys(),
-        )
+        # Term frequency: scale each document (row) by its total token count.
+        n_terms = np.asarray(counts.sum(axis=1)).ravel().astype(float)
+        inv_n_terms = np.divide(1.0, n_terms, out=np.zeros_like(n_terms), where=n_terms != 0)
+        tfidf = sparse.diags(inv_n_terms) @ counts
+
+        # Inverse document frequency from the current online state.
+        dfs = np.array([self.dfs[term] for term in index], dtype=float)
+        idf = np.log((1 + self.n) / (1 + dfs)) + 1
+        tfidf = tfidf @ sparse.diags(idf)
+
+        if self.normalize:
+            norms = np.sqrt(np.asarray(tfidf.multiply(tfidf).sum(axis=1)).ravel())
+            inv_norms = np.divide(1.0, norms, out=np.zeros_like(norms), where=norms != 0)
+            tfidf = sparse.diags(inv_norms) @ tfidf
+
+        return pd.DataFrame.sparse.from_spmatrix(tfidf.tocsr(), index=X.index, columns=list(index))

--- a/river/feature_extraction/vectorize.py
+++ b/river/feature_extraction/vectorize.py
@@ -222,6 +222,18 @@ class VectorizerMixin:
             x = step(x)
         return x
 
+    def process_many(self, X):
+        processing_steps = self.processing_steps
+
+        if self.on is not None:
+            X = X[self.on]
+            processing_steps = self.processing_steps[1:]
+
+        for x in X:
+            for step in processing_steps:
+                x = step(x)
+            yield x
+
     def _more_tags(self):
         if self.on is None:
             return {base.tags.TEXT_INPUT}
@@ -347,16 +359,16 @@ class BagOfWords(base.Transformer, VectorizerMixin):
         indptr, indices, data = [0], [], []
         index: dict[int, int] = {}
 
-        for d in X:
+        for d in self.process_many(X):
             t: int
-            for t, f in collections.Counter(self.process_text(d)).items():
+            for t, f in collections.Counter(d).items():
                 indices.append(index.setdefault(t, len(index)))
                 data.append(f)
 
             indptr.append(len(data))
 
         return pd.DataFrame.sparse.from_spmatrix(
-            sparse.csr_matrix((data, indices, indptr)),
+            sparse.csr_matrix((data, indices, indptr), shape=(len(indptr) - 1, len(index))),
             index=X.index,
             columns=index.keys(),
         )
@@ -497,11 +509,40 @@ class TFIDF(BagOfWords):
             return {term: tfidf / norm for term, tfidf in tfidfs.items()}
         return tfidfs
 
-    # Mini-batch methods should be done well™ and not just be a loop over the *_one equivalent.
     def learn_many(self, X):
-        "Not available, will raise an exception."
-        raise NotImplementedError
+        for terms in self.process_many(X):
+            self.dfs.update(set(terms))
+            self.n += 1
 
     def transform_many(self, X):
-        "Not available, will raise an exception."
-        raise NotImplementedError
+        """Transform text into a TF-IDF pandas sparse dataframe."""
+        pd = utils.pandas.import_pandas()
+        indptr, indices, data = [0], [], []
+        index: dict[int, int] = {}
+
+        for terms in self.process_many(X):
+            term_counts = collections.Counter(terms)
+            n_terms = sum(term_counts.values())
+
+            if n_terms:
+                weights = {}
+                for term, count in term_counts.items():
+                    tf = count / n_terms
+                    idf = math.log((1 + self.n) / (1 + self.dfs[term])) + 1
+                    weights[term] = tf * idf
+
+                if self.normalize:
+                    norm = math.sqrt(sum(weight**2 for weight in weights.values()))
+                    weights = {term: weight / norm for term, weight in weights.items()}
+
+                for term, weight in weights.items():
+                    indices.append(index.setdefault(term, len(index)))
+                    data.append(weight)
+
+            indptr.append(len(data))
+
+        return pd.DataFrame.sparse.from_spmatrix(
+            sparse.csr_matrix((data, indices, indptr), shape=(len(indptr) - 1, len(index))),
+            index=X.index,
+            columns=index.keys(),
+        )

--- a/river/feature_extraction/vectorize.py
+++ b/river/feature_extraction/vectorize.py
@@ -15,7 +15,7 @@ from scipy import sparse
 from river import base, utils
 
 if typing.TYPE_CHECKING:
-    import pandas as pd
+    from narwhals.stable.v2.typing import IntoDataFrame, IntoSeries
 
 __all__ = ["BagOfWords", "TFIDF"]
 
@@ -227,10 +227,16 @@ class VectorizerMixin:
         processing_steps = self.processing_steps
 
         if self.on is not None:
-            X = X[self.on]
+            # `X` is a dataframe: pull out the text column up front (handles any narwhals
+            # backend) so each document is a string, not a row. The leading itemgetter step is
+            # therefore already applied and is skipped below.
+            docs = utils.dataframe.into_frame(X)[self.on].to_list()
             processing_steps = self.processing_steps[1:]
+        else:
+            # `X` is a series of documents.
+            docs = utils.dataframe.into_series(X).to_list()
 
-        for x in X:
+        for x in docs:
             for step in processing_steps:
                 x = step(x)
             yield x
@@ -354,9 +360,18 @@ class BagOfWords(base.Transformer, VectorizerMixin):
     def transform_one(self, x):
         return dict(collections.Counter(self.process_text(x)))
 
-    def transform_many(self, X: pd.Series) -> pd.DataFrame:
-        """Transform pandas series of string into term-frequency pandas sparse dataframe."""
-        pd = utils.pandas.import_pandas()
+    def transform_many(self, X: IntoSeries | IntoDataFrame) -> IntoDataFrame:
+        """Transform a column of text into a term-frequency dataframe.
+
+        Accepts any narwhals-supported eager backend (pandas, polars, pyarrow, ...), either as
+        a series of strings or as a dataframe whose `on` column holds the text. The output
+        matches the input backend: a sparse dataframe for pandas, a dense one otherwise.
+        """
+        like = (
+            utils.dataframe.into_frame(typing.cast("IntoDataFrame", X))
+            if self.on is not None
+            else utils.dataframe.into_series(typing.cast("IntoSeries", X))
+        )
         indptr, indices, data = [0], [], []
         index: dict[int, int] = {}
 
@@ -368,11 +383,8 @@ class BagOfWords(base.Transformer, VectorizerMixin):
 
             indptr.append(len(data))
 
-        return pd.DataFrame.sparse.from_spmatrix(
-            sparse.csr_matrix((data, indices, indptr), shape=(len(indptr) - 1, len(index))),
-            index=X.index,
-            columns=index.keys(),
-        )
+        matrix = sparse.csr_matrix((data, indices, indptr), shape=(len(indptr) - 1, len(index)))
+        return utils.dataframe.sparse_to_native_frame(matrix, columns=index.keys(), like=like)
 
     def learn_many(self, X):
         return
@@ -458,6 +470,25 @@ class TFIDF(BagOfWords):
     {'and': 0.497, 'this': 0.293, 'is': 0.293, 'the': 0.293, 'third': 0.497, 'one': 0.497}
     {'is': 0.384, 'this': 0.384, 'the': 0.384, 'first': 0.580, 'document': 0.469}
 
+    In a mini-batch setting, `learn_many` updates the document frequencies from a column of text,
+    and `transform_many` builds a TF-IDF dataframe. The input may be a series of documents, or a
+    dataframe together with the `on` parameter, and any narwhals-supported backend works (pandas,
+    polars, pyarrow, ...). The output matches the input's backend; for pandas it is a memory-
+    efficient sparse dataframe, shown densified here for readability:
+
+    >>> import pandas as pd
+    >>> X = pd.Series(
+    ...     ['This is the first document', 'This document is the second document'],
+    ...     index=['doc1', 'doc2'],
+    ... )
+
+    >>> tfidf = feature_extraction.TFIDF()
+    >>> tfidf.learn_many(X)
+    >>> tfidf.transform_many(X).sparse.to_dense().round(3)
+           this     is    the  first  document  second
+    doc1  0.409  0.409  0.409  0.575     0.409   0.000
+    doc2  0.334  0.334  0.334  0.000     0.668   0.469
+
     """
 
     def __init__(
@@ -510,14 +541,23 @@ class TFIDF(BagOfWords):
             return {term: tfidf / norm for term, tfidf in tfidfs.items()}
         return tfidfs
 
-    def learn_many(self, X):
+    def learn_many(self, X: IntoSeries | IntoDataFrame) -> None:
         for terms in self.process_many(X):
             self.dfs.update(set(terms))
             self.n += 1
 
-    def transform_many(self, X):
-        """Transform text into a TF-IDF pandas sparse dataframe."""
-        pd = utils.pandas.import_pandas()
+    def transform_many(self, X: IntoSeries | IntoDataFrame) -> IntoDataFrame:
+        """Transform a column of text into a TF-IDF dataframe.
+
+        Accepts any narwhals-supported eager backend (pandas, polars, pyarrow, ...), either as
+        a series of strings or as a dataframe whose `on` column holds the text. The output
+        matches the input backend: a sparse dataframe for pandas, a dense one otherwise.
+        """
+        like = (
+            utils.dataframe.into_frame(typing.cast("IntoDataFrame", X))
+            if self.on is not None
+            else utils.dataframe.into_series(typing.cast("IntoSeries", X))
+        )
         indptr, indices, data = [0], [], []
         index: dict[int, int] = {}
 
@@ -544,4 +584,6 @@ class TFIDF(BagOfWords):
             inv_norms = np.divide(1.0, norms, out=np.zeros_like(norms), where=norms != 0)
             tfidf = sparse.diags(inv_norms) @ tfidf
 
-        return pd.DataFrame.sparse.from_spmatrix(tfidf.tocsr(), index=X.index, columns=list(index))
+        return utils.dataframe.sparse_to_native_frame(
+            tfidf.tocsr(), columns=index.keys(), like=like
+        )

--- a/river/utils/dataframe.py
+++ b/river/utils/dataframe.py
@@ -18,7 +18,7 @@ import narwhals.stable.v2 as nw
 import numpy as np
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Iterable, Mapping, Sequence
     from typing import Any
 
     from narwhals.stable.v2.typing import (
@@ -28,8 +28,16 @@ if typing.TYPE_CHECKING:
         IntoSeriesT,
     )
     from numpy.typing import NDArray
+    from scipy import sparse
 
-__all__ = ["into_frame", "into_series", "to_native_frame", "to_native_series", "to_numpy"]
+__all__ = [
+    "into_frame",
+    "into_series",
+    "sparse_to_native_frame",
+    "to_native_frame",
+    "to_native_series",
+    "to_numpy",
+]
 
 
 def to_numpy(frame: nw.DataFrame[Any]) -> NDArray[np.float64]:
@@ -103,6 +111,44 @@ def to_native_frame(
     if not impl.is_pandas_like():
         data = {str(key): value for key, value in data.items()}
     frame = nw.from_dict(data, backend=impl).to_native()
+    # Carry over the pandas index; no-op for non-pandas backends (maybe_get_index -> None).
+    if (index := nw.maybe_get_index(like)) is not None:
+        frame.index = index
+    return typing.cast("IntoDataFrame", frame)
+
+
+def sparse_to_native_frame(
+    matrix: sparse.spmatrix, *, columns: Iterable[Any], like: nw.DataFrame[Any] | nw.Series[Any]
+) -> IntoDataFrame:
+    """Build a native frame from a scipy sparse matrix, matching the backend of `like`.
+
+    Term-document matrices (e.g. from `feature_extraction.BagOfWords`/`TFIDF`) are very
+    sparse, but only pandas exposes a per-column sparse dtype: Arrow's sparse types are
+    standalone tensors rather than table columns, and polars has no sparse encoding. So
+    pandas-like backends keep the memory-efficient sparse representation, while every other
+    backend is densified.
+
+    Parameters
+    ----------
+    matrix
+        A `scipy.sparse` matrix (typically CSR) produced by the numpy core, shaped
+        `(n_documents, n_terms)`.
+    columns
+        The term labels, in column order. May contain n-gram tuples; non-pandas backends
+        require string column names, so labels are stringified for them.
+    like
+        The narwhals frame or series the call received as input. Its backend determines the
+        return type, and its index (pandas only) is carried over to the result.
+    """
+    impl = like.implementation
+    if impl.is_pandas_like():
+        # Use the input's own pandas namespace so pandas[nullable]/pandas[pyarrow] are honoured.
+        ns = nw.get_native_namespace(like)
+        frame = ns.DataFrame.sparse.from_spmatrix(matrix, columns=list(columns))
+    else:
+        dense = matrix.toarray()
+        data = {str(col): dense[:, j] for j, col in enumerate(columns)}
+        frame = nw.from_dict(data, backend=impl).to_native()
     # Carry over the pandas index; no-op for non-pandas backends (maybe_get_index -> None).
     if (index := nw.maybe_get_index(like)) is not None:
         frame.index = index


### PR DESCRIPTION
## Summary

- Add `TFIDF.learn_many` so mini-batch learning updates document frequencies.
- Add `TFIDF.transform_many` to return TF-IDF sparse DataFrame output.
- Support `DataFrame` input when vectorizers use `on=...`.
- Add regression tests for Series, DataFrame, non-normalized TF-IDF, and empty documents.

Fixes #1576.

## Tests

- `uv run  pytest river/feature_extraction/test_vectorize.py`
- `uv run  ruff check river/feature_extraction/vectorize.py river/feature_extraction/test_vectorize.py`
- `git diff --check`