### PR TITLE
Fix union display

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Add `ppc64le` architecture to Linux wheel builds.
+* Display `compose.TransformerUnion` elements vertically in HTML representations.
 * Dropped `altair` from River's runtime dependencies. It was never imported by the package itself (it is only used to draw plots in the documentation notebooks), so it has been moved to the `docs`/`dev` dependency groups. Installing River no longer pulls in `altair` and its transitive dependencies.
 * Publish Pyodide/WebAssembly wheels (CPython 3.13 and 3.14) so River can be installed in the browser, e.g. via [JupyterLite](https://jupyterlite.readthedocs.io/) or `micropip`. The minimum `numpy` and `scipy` versions were lowered to `2.2.5` and `1.14.1` to match the versions bundled with Pyodide.
 

--- a/river/base/test_viz.py
+++ b/river/base/test_viz.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import re
+
+from river.base import viz
+
+
+def _css_rule(selector: str) -> str:
+    match = re.search(rf"{re.escape(selector)}\s*\{{(?P<body>.*?)\n\}}", viz.CSS, re.S)
+    assert match is not None
+    return match.group("body")
+
+
+def test_union_elements_are_displayed_vertically() -> None:
+    assert "flex-direction: column;" in _css_rule(".river-union")
+
+    union_spacing = _css_rule(".river-union > .river-component + .river-component")
+    assert "margin-top: 1em;" in union_spacing
+    assert "margin-left" not in union_spacing

--- a/river/base/viz.py
+++ b/river/base/viz.py
@@ -56,6 +56,16 @@ def pipeline_to_html(pipeline: compose.Pipeline) -> ET.Element:
 def union_to_html(union: compose.TransformerUnion) -> ET.Element:
     div = ET.Element("div", attrib={"class": "river-component river-union"})
 
+    details = ET.Element("details", attrib={"class": "river-details"})
+    div.append(details)
+
+    summary = ET.Element("summary", attrib={"class": "river-summary"})
+    details.append(summary)
+
+    pre = ET.Element("pre", attrib={"class": "river-estimator-name"})
+    pre.text = "TransformerUnion"
+    summary.append(pre)
+
     for transformer in union.transformers.values():
         div.append(to_html(transformer))
 
@@ -101,12 +111,13 @@ CSS = """
 
 .river-union {
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
     padding: 1em;
     border-style: solid;
     background: white;
+    max-width: max-content;
 }
 
 .river-wrapper {
@@ -129,22 +140,14 @@ CSS = """
     margin-top: 2em;
 }
 
-.river-union > .river-estimator {
-    margin-top: 0;
-}
-
-.river-union > .river-component {
-    margin-top: 0;
-}
-
-.river-union > .pipeline {
-    margin-top: 0;
-}
-
 /* Spacing within a union of estimators */
 
+.river-union > .river-estimator {
+    margin-top: 1em;
+}
+
 .river-union > .river-component + .river-component {
-    margin-left: 1em;
+    margin-top: 1em;
 }
 
 /* Typography */


### PR DESCRIPTION
## Summary

- Display `TransformerUnion` elements vertically in HTML representations
- Add a focused regression test for the union CSS layout
- Update the unreleased notes

## Related issue

- Fixes https://github.com/online-ml/river/issues/1398

## Tests

- `uv run pytest river/base/test_viz.py`
- `uv run ruff check river/base/viz.py river/base/test_viz.py`