### PR TITLE
Added mini-batch support to GaussianNB

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -27,6 +27,10 @@
 
 - Added `multioutput.PerOutputRegressor`, the streaming equivalent of scikit-learn's `MultiOutputRegressor`. Trains one independent regressor per target output, with no inter-output dependencies.
 
+## naive_bayes
+
+- Added mini-batch support to `GaussianNB` via `learn_many`, `predict_many`, and `predict_proba_many`.
+
 ## optim
 
 - Exposed `optim.Newton`, the Online Newton Step optimizer, which was previously implemented but never exported. Fixed a correctness bug whereby the inverse Hessian was initialized to `eps * I` instead of `(1 / eps) * I`, which crippled learning (the maintained inverse could only ever shrink from a tiny starting value). Reworked the internals to use NumPy-backed dense state and `utils.math.sherman_morrison` (the same BLAS rank-1 update used by `BayesianLinearRegression`) instead of a bespoke dict-based reimplementation.

--- a/river/naive_bayes/gaussian.py
+++ b/river/naive_bayes/gaussian.py
@@ -5,17 +5,22 @@ import functools
 import math
 import typing
 
-from scipy import special
+import numpy as np
 
-from river import base, proba
+from river import proba, utils
+
+from . import base
 
 if typing.TYPE_CHECKING:
     import pandas as pd
 
 __all__ = ["GaussianNB"]
 
+_PDF_EPS = 10e-10
+_LOG_PDF_EPS = math.log(_PDF_EPS)
 
-class GaussianNB(base.Classifier):
+
+class GaussianNB(base.BaseNB):
     """Gaussian Naive Bayes.
 
     A Gaussian distribution $G_{cf}$ is maintained for each class $c$ and each feature $f$. Each
@@ -41,6 +46,17 @@ class GaussianNB(base.Classifier):
     >>> model.predict_one({0: -0.8, 1: -1})
     1
 
+    You can also train the model and make predictions in mini-batch mode.
+
+    >>> import pandas as pd
+
+    >>> model = naive_bayes.GaussianNB()
+    >>> model.learn_many(pd.DataFrame(X), pd.Series(Y))
+    >>> model.predict_many(pd.DataFrame([[-0.8, -1], [2.8, 1.5]]))
+    0    1
+    1    2
+    dtype: int64
+
     """
 
     def __init__(self):
@@ -55,27 +71,110 @@ class GaussianNB(base.Classifier):
         for i, xi in x.items():
             self.gaussians[y][i].update(xi)
 
-    def predict_proba_one(self, x):
-        """Return probabilities using the log-likelihoods."""
-        jll = self.joint_log_likelihood(x)
-        if not jll:
-            return {}
-        lse = special.logsumexp(list(jll.values()))
-        return {label: math.exp(ll - lse) for label, ll in jll.items()}
-
     def p_class(self, c):
         return self.class_counts[c] / sum(self.class_counts.values())
 
+    @staticmethod
+    def _log_gaussian_pdf(gaussian: proba.Gaussian | None, x) -> float:
+        if gaussian is None:
+            return _LOG_PDF_EPS
+        return math.log(_PDF_EPS + gaussian(x))
+
     def joint_log_likelihood(self, x):
+        if not self.class_counts:
+            return {}
+
         return {
             c: math.log(self.p_class(c))
-            + sum(math.log(10e-10 + gaussians[i](xi)) for i, xi in x.items())
-            for c, gaussians in self.gaussians.items()
+            + sum(
+                self._log_gaussian_pdf(self.gaussians.get(c, {}).get(i), xi) for i, xi in x.items()
+            )
+            for c in self.class_counts
         }
 
-    def joint_log_likelihood_many(self, X: pd.DataFrame):
-        pass
+    def learn_many(self, X: pd.DataFrame, y: pd.Series):
+        """Learn from a batch of feature vectors.
 
-    @property
-    def _multiclass(self):
-        return True
+        Parameters
+        ----------
+        X
+            Feature vectors.
+        y
+            Target classes.
+
+        """
+        if hasattr(X, "sparse"):
+            X = X.sparse.to_dense()
+
+        self.class_counts.update(y)
+
+        for c in y.unique():
+            X_c = X.iloc[(y == c).to_numpy()]
+
+            for i in X_c.columns:
+                values = X_c[i].dropna()
+                if values.empty:
+                    continue
+                self.gaussians[c][i]._var.update_many(values.to_numpy(dtype=float))
+
+    @staticmethod
+    def _log_gaussian_pdf_many(gaussian: proba.Gaussian | None, values: np.ndarray) -> np.ndarray:
+        if gaussian is None:
+            return np.full(values.shape, _LOG_PDF_EPS)
+
+        var = gaussian._var
+        n = var.mean.n
+        if n > var.ddof:
+            variance = var._S / (n - var.ddof)
+            if variance > 0.0:
+                mu = var.mean._mean
+                with np.errstate(over="ignore", under="ignore", invalid="ignore"):
+                    pdf = np.exp((values - mu) ** 2 / (-2.0 * variance)) / math.sqrt(
+                        math.tau * variance
+                    )
+                return np.log(_PDF_EPS + pdf)
+
+        return np.full(values.shape, _LOG_PDF_EPS)
+
+    def joint_log_likelihood_many(self, X: pd.DataFrame) -> pd.DataFrame:
+        """Compute the joint log-likelihoods for a batch of feature vectors.
+
+        Parameters
+        ----------
+        X
+            Feature vectors.
+
+        Returns
+        -------
+        Input samples joint log-likelihoods.
+
+        """
+        pd = utils.pandas.import_pandas()
+        index = X.index
+
+        if not self.class_counts:
+            return pd.DataFrame(index=index)
+
+        if hasattr(X, "sparse"):
+            X = X.sparse.to_dense()
+
+        jll = pd.DataFrame(index=index)
+
+        for c in self.class_counts:
+            ll = pd.Series(math.log(self.p_class(c)), index=index, dtype=float)
+            gaussians = self.gaussians.get(c, {})
+
+            for i in X.columns:
+                values = X[i].dropna()
+                if values.empty:
+                    continue
+                ll.loc[values.index] += self._log_gaussian_pdf_many(
+                    gaussians.get(i), values.to_numpy(dtype=float)
+                )
+
+            jll[c] = ll
+
+        return jll
+
+    def _unit_test_skips(self):
+        return set()

--- a/river/naive_bayes/test_naive_bayes.py
+++ b/river/naive_bayes/test_naive_bayes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import numpy as np
 import pandas as pd
 import pytest
 from sklearn import naive_bayes as sk_naive_bayes
@@ -238,3 +239,124 @@ def test_river_vs_sklearn(model, sk_model, bag):
     ):
         for sk_pred, river_pred in zip(sk_preds, river_preds):
             assert river_pred == pytest.approx(1 - sk_pred) or river_pred == pytest.approx(sk_pred)
+
+
+def test_gaussian_learn_many_vs_learn_one():
+    X = pd.DataFrame(
+        [
+            {-1: -1.0, 1: -1.0},
+            {-1: -2.0, 1: -1.0},
+            {-1: -3.0},
+            {-1: 1.0, 1: 1.0},
+            {-1: 2.0, 1: 1.0},
+            {-1: 3.0, 1: 2.0},
+        ]
+    )
+    y = pd.Series([1, 1, 1, 2, 2, 2])
+
+    model = naive_bayes.GaussianNB()
+    batch_model = naive_bayes.GaussianNB()
+
+    for _, row in X.iterrows():
+        x = row.dropna().to_dict()
+        model.learn_one(x, y.loc[row.name])
+
+    batch_model.learn_many(X, y)
+
+    assert batch_model.class_counts == model.class_counts
+    assert batch_model.gaussians.keys() == model.gaussians.keys()
+
+    for c, gaussians in model.gaussians.items():
+        assert batch_model.gaussians[c].keys() == gaussians.keys()
+        for i, gaussian in gaussians.items():
+            batch_gaussian = batch_model.gaussians[c][i]
+            assert batch_gaussian.n_samples == gaussian.n_samples
+            assert batch_gaussian.mu == pytest.approx(gaussian.mu)
+            assert batch_gaussian.sigma == pytest.approx(gaussian.sigma)
+
+    X_unseen = pd.DataFrame(
+        [
+            {-1: -0.8, 1: -1.0},
+            {-1: 2.8, 1: 1.5},
+            {1: -1.0},
+            {-1: 4.0, 2: 10.0},
+        ],
+        index=["a", "b", "c", "d"],
+    )
+
+    batch_proba = batch_model.predict_proba_many(X_unseen)
+
+    assert batch_proba.index.tolist() == X_unseen.index.tolist()
+    assert batch_proba.columns.tolist() == [1, 2]
+    assert batch_model.predict_many(X_unseen).tolist() == [
+        batch_model.predict_one(row.dropna().to_dict()) for _, row in X_unseen.iterrows()
+    ]
+
+    for i, row in X_unseen.iterrows():
+        proba_one = model.predict_proba_one(row.dropna().to_dict())
+        assert batch_proba.loc[i, 1] == pytest.approx(proba_one[1])
+        assert batch_proba.loc[i, 2] == pytest.approx(proba_one[2])
+
+
+def test_gaussian_learn_many_sparse():
+    X = pd.DataFrame({0: [-1.0, -2.0, 1.0, 2.0], 1: [-1.0, -1.0, 1.0, 1.0]}).astype(
+        pd.SparseDtype(float, 0.0)
+    )
+    y = pd.Series(["a", "a", "b", "b"])
+
+    model = naive_bayes.GaussianNB()
+    batch_model = naive_bayes.GaussianNB()
+
+    for x, yi in zip(X.sparse.to_dense().to_dict(orient="records"), y):
+        model.learn_one(x, yi)
+
+    batch_model.learn_many(X, y)
+
+    assert batch_model.predict_proba_many(X).equals(model.predict_proba_many(X.sparse.to_dense()))
+
+
+def test_gaussian_learn_many_sklearn_partial_fit():
+    rng = np.random.default_rng(42)
+    X = pd.DataFrame(
+        np.vstack(
+            [
+                rng.normal(loc=[-1.0, 0.0], scale=[1.2, 0.8], size=(200, 2)),
+                rng.normal(loc=[1.0, 0.5], scale=[1.2, 0.8], size=(200, 2)),
+            ]
+        )
+    )
+    y = pd.Series(["a"] * 200 + ["b"] * 200)
+    classes = np.array(["a", "b"])
+    order = rng.permutation(len(X))
+    X = X.iloc[order].reset_index(drop=True)
+    y = y.iloc[order].reset_index(drop=True)
+    X_test = pd.DataFrame([[-1.0, 0.0], [1.0, 0.5], [0.0, 0.25], [-0.2, 0.1], [0.2, 0.3]])
+
+    model = naive_bayes.GaussianNB()
+    sk_model = sk_naive_bayes.GaussianNB(var_smoothing=0.0)
+
+    for start in range(0, len(X), 50):
+        X_batch = X.iloc[start : start + 50]
+        y_batch = y.iloc[start : start + 50]
+        model.learn_many(X_batch, y_batch)
+        sk_model.partial_fit(X_batch, y_batch, classes=classes)
+
+        river_means = np.array([[model.gaussians[c][i].mu for i in X.columns] for c in classes])
+        river_priors = np.array([model.p_class(c) for c in classes])
+
+        np.testing.assert_allclose(river_means, sk_model.theta_)
+        np.testing.assert_allclose(river_priors, sk_model.class_prior_)
+        assert model.predict_many(X_test).tolist() == sk_model.predict(X_test).tolist()
+        np.testing.assert_allclose(
+            model.predict_proba_many(X_test)[classes].to_numpy(),
+            sk_model.predict_proba(X_test),
+            atol=2e-2,
+        )
+
+
+def test_gaussian_learn_many_not_fit():
+    model = naive_bayes.GaussianNB()
+    X = pd.DataFrame([{0: 1.0}, {0: 2.0}], index=["river", "rocks"])
+
+    assert model.predict_proba_many(X).equals(pd.DataFrame(index=["river", "rocks"]))
+    assert model.predict_many(X).equals(pd.DataFrame(index=["river", "rocks"]))


### PR DESCRIPTION
## Summary

- Add mini-batch support to `naive_bayes.GaussianNB`
- Implement batch learning and batch joint log-likelihood computation
- Add tests covering dense, sparse, missing-feature, and unfitted mini-batch behavior

## Tests

- `uv run pytest river/naive_bayes/test_naive_bayes.py`
- `uv run pytest river/proba/test_gaussian.py`
- `uv run pytest river/naive_bayes/test_naive_bayes.py river/proba/test_gaussian.py river/test_estimators.py -k "GaussianNB or test_univariate_multivariate_consistency"`
- `uv run pre-commit run --files river/naive_bayes/gaussian.py river/naive_bayes/test_naive_bayes.py river/proba/gaussian.py docs/releases/unreleased.md`