### PR TITLE
Speed up the linear models and FeatureHasher

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,5 +70,9 @@ All estimators inherit from `base.Estimator` (which inherits from `base.Base`). 
 
 ### Making changes
 
-- When you're done, add a entry to `unreleased.md` if its relevant to end users.
+- When you're done, add an entry to `docs/releases/unreleased.md` if it's relevant to end users, under the section for the relevant module (alphabetical).
+  - Use `-` for list items, not `*`.
+  - Keep entries concise: one to three sentences. Lead with what changed and its user-facing effect.
+  - Include performance numbers (e.g. "~7× faster") and call out behavior changes explicitly, but omit deep implementation mechanics (internal variable names, algebra, marshalling details) — those belong in the code/PR, not the changelog.
+  - Example: "Sped up `learn_one` for the linear models: updates now scale with the number of active features instead of the total number of features ever seen. Outputs are unchanged."
 - Performance matters: if you make a significant change, run a benchmark.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,11 +106,21 @@ From the root of the repository, you can then run the `make livedoc` command to 
 
 All classes and function are automatically picked up and added to the documentation. The only thing you have to do is to add an entry to the relevant file in the [`docs/releases` directory](docs/releases).
 
-## Build Cython and Rust extensions
+## Build the Rust extensions
+
+River's Rust extensions (under `rust_src/`) are built automatically by `uv sync`:
 
 ```sh
 uv sync
 ```
+
+When iterating on the Rust code, rebuilding the whole project with `uv sync` is slower than necessary. Use `maturin develop` for a tighter inner loop. Note that `maturin` is not installed in the environment, so run it through `uv run --with`:
+
+```sh
+uv run --with maturin maturin develop --release
+```
+
+(Plain `uv run maturin ...` fails with "Failed to spawn: maturin" because the binary isn't on the environment's path.)
 
 ## Testing
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,14 +1,14 @@
 # Unreleased
 
-* Add `ppc64le` architecture to Linux wheel builds.
-* Dropped `altair` from River's runtime dependencies. It was never imported by the package itself (it is only used to draw plots in the documentation notebooks), so it has been moved to the `docs`/`dev` dependency groups. Installing River no longer pulls in `altair` and its transitive dependencies.
-* Publish Pyodide/WebAssembly wheels (CPython 3.13 and 3.14) so River can be installed in the browser, e.g. via [JupyterLite](https://jupyterlite.readthedocs.io/) or `micropip`. The minimum `numpy` and `scipy` versions were lowered to `2.2.5` and `1.14.1` to match the versions bundled with Pyodide.
+- Add `ppc64le` architecture to Linux wheel builds.
+- Moved `altair` from the runtime dependencies to the `docs`/`dev` groups; it was only used to draw plots in the docs, so installing River no longer pulls it in.
+- Publish Pyodide/WebAssembly wheels (CPython 3.13 and 3.14) so River can run in the browser, e.g. via [JupyterLite](https://jupyterlite.readthedocs.io/) or `micropip`. The minimum `numpy` and `scipy` versions were lowered to `2.2.5` and `1.14.1` to match Pyodide.
 
 ## covariance
 
-- Sped up `EmpiricalCovariance.update`/`revert` by caching the sorted feature list and pair iteration and by removing the `__getitem__`/`matrix` indirection in the hot path. ~40% faster at 30 features, no semantic change (pairwise-deletion semantics preserved).
-- Restructured `EmpiricalPrecision` to use NumPy-backed dense state indexed by a feature → integer map, eliminating the dict ↔ numpy marshalling on every `update`/`update_many`. ~7× faster on 2000 × 20 sample streams.
-- Fixed a latent asymmetry in `EmpiricalPrecision` under emerging features: the per-feature `w` scaling left the stored matrix skewed (e.g. `prec[a, b]` ≠ `prec[b, a]`) when features were introduced at different times.
+- Sped up `EmpiricalCovariance.update`/`revert` (~40% faster at 30 features) by caching the sorted feature list and pair iteration in the hot path. No semantic change.
+- Restructured `EmpiricalPrecision` around NumPy-backed dense state, removing the per-update dict ↔ numpy marshalling. ~7× faster on 2000 × 20 sample streams.
+- Fixed an `EmpiricalPrecision` asymmetry where features introduced at different times left the stored matrix skewed (e.g. `prec[a, b]` ≠ `prec[b, a]`).
 
 ## datasets
 
@@ -16,12 +16,13 @@
 
 ## linear_model
 
-- Added `linear_model.AdPredictor`, the Bayesian online probit-regression classifier Microsoft used for click-through-rate prediction in Bing's sponsored search (Graepel et al., 2010). It keeps a Gaussian belief over each feature weight, yields well-calibrated probabilities, and its per-example cost scales only with the number of active features.
-- Restructured `BayesianLinearRegression` to use the same NumPy-backed storage as `EmpiricalPrecision`. ~11× faster `learn_one` at 20 features, ~24× at 50 features. Speeds up `bandit.LinUCB` as a side effect.
-- `BayesianLinearRegression` now passes `check_emerging_features` and `check_shuffle_features_no_impact` (the two checks previously skipped via `_unit_test_skips`). It now handles features arriving and disappearing after training begins.
-- Fixed `BayesianLinearRegression` coefficient blow-up under emerging/disappearing features. The previous submatrix-only update broke the `_ss_inv ≈ inv(_ss)` invariant once different feature subsets were touched across calls (the submatrix of an inverse is generally not the inverse of the submatrix), causing coefficients to diverge to `inf`/`nan` on `check_emerging_features`-style streams. `learn_one` now updates the full state with a zero-padded `x`. Behavior change: features absent from `learn_one`'s `x` are now treated as observed values of 0 (matching `LinearRegression` and the rest of the online-learning estimators), rather than being silently skipped. Identical to the previous behavior to floating-point roundoff when every call sees the same feature set.
-- Sped up the mini-batch gradient in `LinearRegression`/`LogisticRegression.learn_many` by contracting the sample axis directly inside the `np.einsum` call instead of building the intermediate `(n, p)` matrix and averaging it afterwards. ~2-3× faster on that step, no semantic change.
-- Stabilised `BayesianLinearRegression` across BLAS implementations and sped it up further. `learn_one` now accumulates an exact natural mean `_eta_arr = beta * sum_i(y_i * x_i)` alongside the existing Sherman-Morrison rank-1 update of `_ss_inv_arr`, and the posterior mean is recovered lazily as `_ss_inv_arr @ _eta_arr` (cached and invalidated on `learn_one`). Previously the posterior mean was propagated through `m_new = ss_inv @ (ss_old @ m_old + bx*y)`, which compounded BLAS rounding multiplicatively across rank-1 updates and caused a ~0.6% relative drift between macOS Accelerate and Linux OpenBLAS on `TrumpApproval` with imputation. The new path keeps `learn_one` ~20% faster than before and the full `predict`+`learn` cycle ~10% faster.
+- Added `linear_model.AdPredictor`, the Bayesian online probit-regression classifier Microsoft used for click-through-rate prediction in Bing's sponsored search (Graepel et al., 2010). It keeps a Gaussian belief over each feature weight and yields well-calibrated probabilities.
+- Restructured `BayesianLinearRegression` around NumPy-backed storage. ~11× faster `learn_one` at 20 features, ~24× at 50 features. Speeds up `bandit.LinUCB` too.
+- `BayesianLinearRegression` now handles features arriving and disappearing after training begins (it passes `check_emerging_features` and `check_shuffle_features_no_impact`, previously skipped).
+- Fixed `BayesianLinearRegression` coefficients diverging to `inf`/`nan` under emerging/disappearing features; `learn_one` now updates the full state with a zero-padded `x`. Behavior change: features absent from `x` are treated as observed 0s (matching the other linear models) rather than skipped — identical to before when every call sees the same features.
+- Sped up the `LinearRegression`/`LogisticRegression.learn_many` mini-batch gradient (~2-3×) by contracting the sample axis inside the `np.einsum`. No semantic change.
+- Sped up `learn_one` for the linear models (`LinearRegression`, `LogisticRegression`, `Perceptron`, ...): updates now scale with the number of active features instead of the total number of features ever seen. Outputs are unchanged.
+- Stabilised `BayesianLinearRegression` across BLAS implementations and sped it up (~10-20%) by accumulating an exact natural mean and recovering the posterior mean lazily, instead of propagating it through compounding rank-1 updates (which drifted ~0.6% between macOS Accelerate and Linux OpenBLAS).
 
 ## multioutput
 
@@ -29,25 +30,27 @@
 
 ## optim
 
-- Exposed `optim.Newton`, the Online Newton Step optimizer, which was previously implemented but never exported. Fixed a correctness bug whereby the inverse Hessian was initialized to `eps * I` instead of `(1 / eps) * I`, which crippled learning (the maintained inverse could only ever shrink from a tiny starting value). Reworked the internals to use NumPy-backed dense state and `utils.math.sherman_morrison` (the same BLAS rank-1 update used by `BayesianLinearRegression`) instead of a bespoke dict-based reimplementation.
+- Exposed `optim.Newton` (Online Newton Step), which was implemented but never exported, and fixed an initialisation bug (the inverse Hessian started at `eps * I` instead of `(1 / eps) * I`) that crippled learning. Reworked around NumPy-backed dense state.
+
 ## preprocessing
 
-- Added `window_size` parameter to `preprocessing.StandardScaler`, `preprocessing.MinMaxScaler`, and `preprocessing.MaxAbsScaler`. When set, the scaler tracks its statistics over the last `window_size` observations instead of the entire stream.
-- Added `_from_state` classmethod to `preprocessing.MinMaxScaler`, `preprocessing.MaxAbsScaler`, and `preprocessing.StandardScaler` so a scaler can be warm-started from offline-computed statistics or resumed from a checkpoint without replaying past observations.
+- Added a `window_size` parameter to `preprocessing.StandardScaler`, `preprocessing.MinMaxScaler`, and `preprocessing.MaxAbsScaler`. When set, the scaler tracks its statistics over the last `window_size` observations instead of the whole stream.
+- Added a `_from_state` classmethod to `preprocessing.MinMaxScaler`, `preprocessing.MaxAbsScaler`, and `preprocessing.StandardScaler` so a scaler can be warm-started from precomputed statistics without replaying past observations.
+- `preprocessing.FeatureHasher` now hashes with MurmurHash3 in Rust, making it much faster. It gains an `alternate_sign` parameter (default `True`, matching scikit-learn) and returns a plain `dict`. Hashed feature indices differ from previous versions.
 
 ## reco
 
-- Corrected the type annotations of the weight/latent `defaultdict`s in `BiasedMF`, `Baseline`, and `FunkMF`: their values are floats/arrays (not `Initializer` objects), and their keys are hashable IDs. Removed the bespoke `reco.base.ID` alias in favour of the built-in `typing.Hashable` (matching `base.typing.FeatureName`). Typing-only; no behavioral change.
+- Corrected the type annotations of the weight/latent `defaultdict`s in `BiasedMF`, `Baseline`, and `FunkMF`, and dropped the bespoke `reco.base.ID` alias in favour of `typing.Hashable`. Typing-only; no behavioral change.
 
 ## utils
 
 - Added `utils.math.norm_cdf` and `utils.math.norm_pdf`, the CDF and PDF of the standard normal distribution (used by `linear_model.AdPredictor`).
-- `utils.Rolling` and `utils.TimeRolling` now accept a class as their first argument and forward extra keyword arguments to its constructor, e.g. `utils.Rolling(stats.Mean, window_size=3)` or `utils.Rolling(stats.Var, window_size=3, ddof=0)`. This avoids a footgun when using these wrappers as `collections.defaultdict` factories, where the previous instance form silently shared state across keys. Passing a pre-built instance still works but now emits a `DeprecationWarning` and will be removed in a future release.
+- `utils.Rolling` and `utils.TimeRolling` now accept a class plus constructor keyword arguments, e.g. `utils.Rolling(stats.Mean, window_size=3)`. This avoids silently sharing state when they are used as `collections.defaultdict` factories. Passing a pre-built instance still works but is deprecated and will be removed in a future release.
 
 ## rules
 
-- Fixed `RecursionError` in `AMRules` on long streams: `tree.splitter.EBSTSplitter` (and `TEBSTSplitter`) now traverses its binary search tree iteratively and the BST nodes carry a custom iterative `__deepcopy__`, so deeply-skewed trees no longer blow Python's recursion limit when rules are cloned during expansion. `tree.splitter.ExhaustiveSplitter` received the same treatment (iterative split-search, iterative node insertion, and iterative `__deepcopy__`).
-- Fixed an `AMRules` memory leak where `HoeffdingRule.expand` appended a redundant `NumericLiteral` whenever a new split shared the feature and direction of an existing literal but did not tighten the threshold.
+- Fixed `RecursionError` in `AMRules` on long streams: the `EBSTSplitter`, `TEBSTSplitter`, and `ExhaustiveSplitter` now traverse and deep-copy their search trees iteratively, so deeply-skewed trees no longer blow Python's recursion limit.
+- Fixed an `AMRules` memory leak where `HoeffdingRule.expand` appended a redundant `NumericLiteral` when a new split shared a feature and direction with an existing literal without tightening the threshold.
 
 ## stats
 

--- a/river/linear_model/ad_predictor.py
+++ b/river/linear_model/ad_predictor.py
@@ -35,9 +35,9 @@ class AdPredictor(base.Classifier):
     [^1], keeps a Gaussian belief over each feature weight rather than a point estimate. It
     predicts via a probit link and learns in a single pass, scaling each weight's step size by its
     own uncertainty. It shines on the sparse, high-cardinality, categorical data of ad logs: it
-    yields well-calibrated probabilities, exposes uncertainty for exploration, and its cost per
-    example depends only on the number of active features. Plain logistic regression is simpler and
-    just as good on dense, low-dimensional numeric data.
+    yields well-calibrated probabilities and exposes uncertainty for exploration. Like the other
+    linear models, its cost per example scales only with the number of active features. Plain
+    logistic regression is simpler and just as good on dense, low-dimensional numeric data.
 
     Features are expected to be a sparse active set: a key in `x` is active when its value is
     truthy (its magnitude is otherwise ignored), so one-hot encode or bucket

--- a/river/preprocessing/feature_hasher.py
+++ b/river/preprocessing/feature_hasher.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-import collections
-import hashlib
-
 import numpy as np
 
 from river import base
+from river._river_rust.feature_hashing import feature_hash
 
 __all__ = ["FeatureHasher"]
 
@@ -13,18 +11,26 @@ __all__ = ["FeatureHasher"]
 class FeatureHasher(base.Transformer):
     """Implements the hashing trick.
 
-    Each pair of (name, value) features is hashed into a random integer. A module operator is then
-    used to make sure the hash is in a certain range. We use the Murmurhash implementation from
-    scikit-learn.
+    Each pair of (name, value) features is hashed into a random integer in `[0, n_features)`,
+    using the signed 32-bit MurmurHash3 of the feature's token. String values are hashed as
+    `"name=value"` tokens and contribute `1`; numeric values are hashed under `"name"` and
+    contribute the value itself.
+
+    The hashing is performed in Rust, so the whole transform of an example happens in a single
+    native call.
 
     Parameters
     ----------
     n_features
         The number by which each hash will be moduloed by.
     alternate_sign
-        Whether or not half of the hashes will be negated.
+        When `True` (the default), the sign bit of the hash is used to negate half of the
+        contributions. This keeps the expected value of each bucket at zero, so hash collisions
+        between unrelated features tend to cancel out rather than accumulate, which is especially
+        helpful for small `n_features`. This matches scikit-learn's `FeatureHasher`.
     seed
-        Set the seed to produce identical results.
+        Set the seed to produce identical results. When `None`, a random seed is drawn, so two
+        instances will hash features to different buckets.
 
     Examples
     --------
@@ -39,33 +45,23 @@ class FeatureHasher(base.Transformer):
     ... ]
     >>> for x in X:
     ...     print(hasher.transform_one(x))
-    Counter({1: 4, 9: 2, 8: 1})
-    Counter({4: 5, 8: 2})
+    {5: -3, 7: 2}
+    {5: 2, 9: -5}
 
     References
     ----------
     [^1]: [Wikipedia article on feature vectorization using the hashing trick](https://www.wikiwand.com/en/Feature_hashing#/Feature_vectorization_using_hashing_trick)
+    [^2]: [Weinberger et al. (2009), Feature Hashing for Large Scale Multitask Learning](https://arxiv.org/abs/0902.2206)
 
     """
 
-    def __init__(self, n_features=1048576, seed: int | None = None):
+    def __init__(self, n_features=1048576, seed: int | None = None, alternate_sign: bool = True):
         self.n_features = n_features
         self.seed = seed
-        self._salt = np.random.RandomState(seed).bytes(hashlib.blake2s.SALT_SIZE)
-
-    def _hash(self, x):
-        hexa = hashlib.blake2s(bytes(x, encoding="utf8"), salt=self._salt).hexdigest()
-        return int(hexa, 16)
+        self.alternate_sign = alternate_sign
+        # MurmurHash3 takes a 32-bit seed. Deriving it through NumPy preserves the previous
+        # behaviour: a fixed `seed` is reproducible, while `seed=None` draws a fresh seed.
+        self._seed = int(np.random.RandomState(seed).randint(0, 2**32, dtype=np.uint32))
 
     def transform_one(self, x):
-        x_hashed = collections.Counter()
-
-        for feature, value in x.items():
-            if isinstance(value, str):
-                feature = f"{feature}={value}"
-                value = 1
-
-            i = self._hash(feature) % self.n_features
-            x_hashed[i] += value
-
-        return x_hashed
+        return feature_hash(x, self.n_features, self._seed, self.alternate_sign)

--- a/rust_src/adwin.rs
+++ b/rust_src/adwin.rs
@@ -1,4 +1,4 @@
-// ADaptive WINdowing (ADWIN) drift detector. Port of river/drift/adwin_c.pyx.
+// ADaptive WINdowing (ADWIN) drift detector.
 //
 // The implementation follows Bifet & Gavaldà (2007) "Learning from time-changing
 // data with adaptive windowing" and Babcock et al. (2003) for the streaming
@@ -10,7 +10,7 @@
 // On every update (modulated by `clock`), all possible cut points of the window
 // are checked: if `|mean(W0) - mean(W1)| > epsilon_cut` the oldest bucket is
 // dropped and the algorithm reports drift. The exact arithmetic order matters
-// for parity with the Cython baseline, so the implementation is a near-line port.
+// for reproducibility, so the operation order is preserved precisely.
 
 use serde::{Deserialize, Serialize};
 
@@ -154,8 +154,8 @@ impl AdaptiveWindowing {
             self.max_n_buckets = self.n_buckets;
         }
 
-        // Welford-style streaming variance update. Order of operations mirrors
-        // the Cython code so f64 rounding lines up bit-for-bit.
+        // Welford-style streaming variance update. Order of operations is fixed
+        // so f64 rounding is deterministic across runs.
         self.width += 1.0;
         let mut incremental_variance = 0.0;
         if self.width > 1.0 {
@@ -198,7 +198,7 @@ impl AdaptiveWindowing {
         let mut idx = 0usize;
         loop {
             let k = self.bucket_list[idx].current_idx;
-            // Cython's loop-exit condition: stop when this bucket is not yet full
+            // loop-exit condition: stop when this bucket is not yet full
             if k != self.max_buckets + 1 {
                 break;
             }

--- a/rust_src/expected_mutual_info.rs
+++ b/rust_src/expected_mutual_info.rs
@@ -1,6 +1,5 @@
-// Expected Mutual Information between two clusterings, ported from the Cython
-// implementation in `river/metrics/expected_mutual_info.pyx` (which itself
-// follows scikit-learn's `expected_mutual_information`).
+// Expected Mutual Information between two clusterings, following
+// scikit-learn's `expected_mutual_information`.
 //
 // Inputs are the contingency table's row sums (`a`) and column sums (`b`)
 // after dropping zero entries, plus the sample count `n_samples`. EMI is

--- a/rust_src/feature_hashing.rs
+++ b/rust_src/feature_hashing.rs
@@ -1,0 +1,112 @@
+// Feature hashing (the "hashing trick").
+//
+// Hashes each feature's UTF-8 token with MurmurHash3 (x86 32-bit, signed) — the
+// same hash scikit-learn's `FeatureHasher` uses — and folds it into a bucket in
+// `[0, n_features)`. With `alternate_sign` the hash's sign bit decides the sign
+// of the contributed value, so collisions tend to cancel rather than accumulate
+// (Weinberger et al., 2009). Doing the whole transform in one Rust call avoids a
+// per-feature Python loop, an `isinstance` check, and a `Counter` build.
+
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyString};
+use pyo3::IntoPyObjectExt;
+
+/// MurmurHash3 x86_32 — the canonical 32-bit variant (Austin Appleby, public
+/// domain). Returns the raw `u32`; callers reinterpret it as `i32` when they
+/// need the sign bit.
+fn murmurhash3_x86_32(data: &[u8], seed: u32) -> u32 {
+    const C1: u32 = 0xcc9e_2d51;
+    const C2: u32 = 0x1b87_3593;
+    let mut h1 = seed;
+
+    let nblocks = data.len() / 4;
+    for i in 0..nblocks {
+        let j = i * 4;
+        let mut k1 = u32::from_le_bytes([data[j], data[j + 1], data[j + 2], data[j + 3]]);
+        k1 = k1.wrapping_mul(C1);
+        k1 = k1.rotate_left(15);
+        k1 = k1.wrapping_mul(C2);
+        h1 ^= k1;
+        h1 = h1.rotate_left(13);
+        h1 = h1.wrapping_mul(5).wrapping_add(0xe654_6b64);
+    }
+
+    // Tail (the canonical fall-through switch on `len & 3`).
+    let tail = &data[nblocks * 4..];
+    let mut k1: u32 = 0;
+    if tail.len() == 3 {
+        k1 ^= (tail[2] as u32) << 16;
+    }
+    if tail.len() >= 2 {
+        k1 ^= (tail[1] as u32) << 8;
+    }
+    if !tail.is_empty() {
+        k1 ^= tail[0] as u32;
+        k1 = k1.wrapping_mul(C1);
+        k1 = k1.rotate_left(15);
+        k1 = k1.wrapping_mul(C2);
+        h1 ^= k1;
+    }
+
+    // Finalization.
+    h1 ^= data.len() as u32;
+    h1 ^= h1 >> 16;
+    h1 = h1.wrapping_mul(0x85eb_ca6b);
+    h1 ^= h1 >> 13;
+    h1 = h1.wrapping_mul(0xc2b2_ae35);
+    h1 ^= h1 >> 16;
+    h1
+}
+
+/// Apply the hashing trick to a single example.
+///
+/// Mirrors the previous Python implementation's feature encoding: a string
+/// value `v` under key `k` is hashed as the token `"k=v"` and contributes `1`;
+/// any other value is hashed under the token `"k"` and contributes the value
+/// itself. Contributions are summed per bucket. The accumulator preserves the
+/// Python value types (int stays int, float stays float).
+#[pyfunction]
+pub fn feature_hash<'py>(
+    py: Python<'py>,
+    x: &Bound<'py, PyDict>,
+    n_features: i64,
+    seed: u32,
+    alternate_sign: bool,
+) -> PyResult<Bound<'py, PyDict>> {
+    let res = PyDict::new(py);
+    let neg_one = (-1i64).into_bound_py_any(py)?;
+
+    for (key, value) in x.iter() {
+        let is_str = value.is_instance_of::<PyString>();
+        let token: String = if is_str {
+            let v = value.cast::<PyString>()?;
+            format!("{}={}", key.str()?.to_cow()?, v.to_cow()?)
+        } else {
+            key.str()?.to_cow()?.into_owned()
+        };
+
+        let h = murmurhash3_x86_32(token.as_bytes(), seed) as i32;
+        let idx = (h as i64).rem_euclid(n_features);
+
+        // String features contribute 1; numeric features contribute their value.
+        let val: Bound<'py, PyAny> = if is_str {
+            1i64.into_bound_py_any(py)?
+        } else {
+            value.clone()
+        };
+        // `alternate_sign` flips the contribution when the signed hash is negative.
+        let val = if alternate_sign && h < 0 {
+            val.mul(&neg_one)?
+        } else {
+            val
+        };
+
+        let key_obj = idx.into_bound_py_any(py)?;
+        match res.get_item(&key_obj)? {
+            Some(existing) => res.set_item(key_obj, existing.add(val)?)?,
+            None => res.set_item(key_obj, val)?,
+        }
+    }
+
+    Ok(res)
+}

--- a/rust_src/lib.rs
+++ b/rust_src/lib.rs
@@ -6,6 +6,7 @@ pub mod covariance;
 pub mod ewmean;
 pub mod ewvariance;
 pub mod expected_mutual_info;
+pub mod feature_hashing;
 pub mod iqr;
 pub mod iter;
 pub mod kurtosis;

--- a/rust_src/mondrian.rs
+++ b/rust_src/mondrian.rs
@@ -1,13 +1,12 @@
-// Mondrian tree numerical helpers — port of river/tree/mondrian/_mondrian_ops.pyx.
+// Mondrian tree numerical helpers.
 //
 // All exported functions are PyO3 wrappers that operate on plain Python objects
 // (dicts, lists, MondrianNode instances) so they're a drop-in replacement for
-// the Cython entry points the Python code already imports.
+// the entry points the Python code already imports.
 //
 // The hot inner loops touch Python objects through the standard PyO3 attribute
-// and dict APIs. Cython compiles `node.attr` on a `cdef object` to the same
-// `PyObject_GetAttr` call, so per-attribute cost lines up — the win comes from
-// avoiding the Cython glue plus structural simplifications:
+// and dict APIs. The win over a pure-Python implementation comes from doing the
+// traversal in Rust plus structural simplifications:
 //   - the leaf-to-root `_go_upwards` walk is now a single Rust call instead of
 //     N Python frame setups;
 //   - prediction descends + aggregates entirely in Rust (no Python loop);
@@ -307,17 +306,16 @@ fn update_downwards_regressor_inner<'py>(
     Ok(())
 }
 
-/// Sample a feature from `extensions` weighted by extension size. Mirrors
-/// the deterministic Cython path: keys are sorted, then `rng.choices` is
-/// invoked with the corresponding weights.
+/// Sample a feature from `extensions` weighted by extension size. Deterministic:
+/// keys are sorted, then `rng.choices` is invoked with the corresponding weights.
 fn weighted_choice<'py>(
     py: Python<'py>,
     extensions: &Bound<'py, PyDict>,
     rng_choices: &Bound<'py, PyAny>,
 ) -> PyResult<Bound<'py, PyAny>> {
     // `extensions.keys()` already returns an owned PyList we can sort in place,
-    // matching `sorted(extensions.keys())` from the original Cython without
-    // re-importing `builtins.sorted` on every call.
+    // matching `sorted(extensions.keys())` without re-importing `builtins.sorted`
+    // on every call.
     let keys = extensions.keys();
     keys.sort()?;
 
@@ -398,7 +396,7 @@ pub fn go_downwards_classifier<'py>(
         let mut range_bounds: Option<(Bound<'py, PyDict>, Bound<'py, PyDict>)> = None;
 
         // Skip the (expensive) range_extension call for pure non-split nodes
-        // (matches the Cython optimisation introduced in #1841).
+        // (optimisation introduced in #1841).
         let mut do_split_check = split_pure;
         if !do_split_check {
             let counts = current

--- a/rust_src/pyo3_bindings.rs
+++ b/rust_src/pyo3_bindings.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     adwin::AdaptiveWindowing, ewmean::EWMean, ewvariance::EWVariance,
     expected_mutual_info::expected_mutual_info as compute_expected_mutual_info,
+    feature_hashing::feature_hash,
     iqr::RollingIQR, iqr::IQR, kurtosis::Kurtosis,
     mondrian::{
         go_downwards_classifier, go_downwards_regressor, go_upwards, log_sum_2_exp,
@@ -523,6 +524,7 @@ fn _river_rust(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     register_submodule(py, m, "drift", register_drift)?;
     register_submodule(py, m, "tree", register_tree)?;
     register_submodule(py, m, "vectordict", register_vectordict)?;
+    register_submodule(py, m, "feature_hashing", register_feature_hashing)?;
     Ok(())
 }
 
@@ -588,5 +590,11 @@ fn register_vectordict(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(euclidean_distance_dict, m)?)?;
     m.add_function(wrap_pyfunction!(euclidean_distance_tuple, m)?)?;
     m.add_function(wrap_pyfunction!(lazy_search_euclidean, m)?)?;
+    Ok(())
+}
+
+
+fn register_feature_hashing(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(feature_hash, m)?)?;
     Ok(())
 }

--- a/rust_src/vectordict.rs
+++ b/rust_src/vectordict.rs
@@ -1,13 +1,11 @@
-// VectorDict — port of river/utils/vectordict.pyx.
+// VectorDict — a dict-like container with element-wise arithmetic.
 //
-// A dict-like container with element-wise arithmetic that supports an optional
-// `mask` (treat keys outside the mask as missing) and an optional
-// `default_factory` (insert + return a factory value when an unmasked key is
-// looked up).
+// Supports an optional `mask` (treat keys outside the mask as missing) and an
+// optional `default_factory` (insert + return a factory value when an unmasked
+// key is looked up).
 //
-// Storage is `Py<PyDict>` so keys/values stay arbitrary Python objects, exactly
-// matching the Cython interface. Hot inner loops use `pyo3::ffi` directly so
-// per-element overhead stays at the same level as Cython's compiled output.
+// Storage is `Py<PyDict>` so keys/values stay arbitrary Python objects. Hot
+// inner loops use `pyo3::ffi` directly to keep per-element overhead minimal.
 
 use pyo3::exceptions::{PyKeyError, PyTypeError, PyValueError};
 use pyo3::ffi;
@@ -133,36 +131,63 @@ impl VectorDict {
         Ok(res)
     }
 
-    /// Iterate keys (masked or not) — caller must drive the loop.
-    fn iter_keys<'py>(
-        &self,
-        py: Python<'py>,
-        f: &mut dyn FnMut(&Bound<'py, PyAny>) -> PyResult<()>,
-    ) -> PyResult<()> {
+    /// Iterate keys (masked or not) — caller must drive the loop. Generic over
+    /// the callback so it monomorphizes and inlines (no `dyn` vtable per key).
+    fn iter_keys<'py, F>(&self, py: Python<'py>, mut f: F) -> PyResult<()>
+    where
+        F: FnMut(&Bound<'py, PyAny>) -> PyResult<()>,
+    {
         let data = self.data.bind(py);
-        if self.lazy_mask {
-            let mask = self.mask.as_ref().unwrap().bind(py);
+        if !self.lazy_mask {
             for (k, _) in data.iter() {
-                if mask.contains(&k)? {
+                f(&k)?;
+            }
+            return Ok(());
+        }
+        let mask = self.mask.as_ref().unwrap().bind(py);
+        // The masked key set is `data ∩ mask`, and which side we scan to produce
+        // it is purely a cost decision — the yielded set is identical either way.
+        // During learning a model masks its full weight vector down to the
+        // handful of features in the current example, so `mask` is tiny while
+        // `data` holds every weight ever seen; scanning the mask then turns an
+        // O(|data|) walk into O(|mask|). We only switch when the mask is the
+        // smaller side (and exposes a length); otherwise we keep scanning data.
+        // Only the iteration order changes, which downstream key-wise writes
+        // ignore and scalar accumulations (the dot product) treat as a no-op up
+        // to floating-point rounding.
+        let scan_mask = matches!(mask.len(), Ok(mask_len) if mask_len < data.len());
+        if scan_mask {
+            // `data` is always a PyDict, so test membership with the raw
+            // `PyDict_Contains` (no Bound/err-path overhead per key).
+            let data_ptr = data.as_ptr();
+            for k in mask.try_iter()? {
+                let k = k?;
+                let present = unsafe { ffi::PyDict_Contains(data_ptr, k.as_ptr()) };
+                if present < 0 {
+                    return Err(PyErr::fetch(py));
+                }
+                if present == 1 {
                     f(&k)?;
                 }
             }
         } else {
             for (k, _) in data.iter() {
-                f(&k)?;
+                if mask.contains(&k)? {
+                    f(&k)?;
+                }
             }
         }
         Ok(())
     }
 
-    /// `get_union_keys` from the Cython code, returned as a fresh Vec for simplicity.
+    /// Union of both operands' (masked) keys, returned as a fresh Vec for simplicity.
     fn union_keys<'py>(
         &self,
         py: Python<'py>,
         other: &VectorDict,
     ) -> PyResult<Vec<Bound<'py, PyAny>>> {
         let mut out = Vec::new();
-        self.iter_keys(py, &mut |k| {
+        self.iter_keys(py, |k| {
             out.push(k.clone());
             Ok(())
         })?;
@@ -191,7 +216,7 @@ impl VectorDict {
         Ok(out)
     }
 
-    /// `get_intersection_keys` from the Cython code.
+    /// Intersection of both operands' (masked) keys.
     fn intersection_keys<'py>(
         &self,
         py: Python<'py>,
@@ -607,7 +632,7 @@ impl VectorDict {
             // 2) apply update
             data.as_any().call_method("update", &args, kwargs.as_ref())?;
             // 3) snapshot masked-out items (newly inserted ones we shouldn't keep visible —
-            // but the original Cython actually keeps them in _data; we mirror that)
+            // but they are intentionally retained in _data to preserve mask semantics)
             let keep2 = PyDict::new(py);
             for (k, v) in data.iter() {
                 if !mask.contains(&k)? {
@@ -1165,11 +1190,10 @@ unsafe fn dict_iop_scalar(
 
 type UnaryOp = unsafe extern "C" fn(*mut ffi::PyObject) -> *mut ffi::PyObject;
 
-// Build a fresh PyDict. The previous implementation called the private
-// CPython _PyDict_NewPresized to preallocate `n` slots, but pyo3 0.28
-// stopped re-exporting that symbol. PyDict::new() falls back to the public
-// PyDict_New, which doesn't preallocate; the amortised rehash cost is
-// O(n) and dominated by the per-key set_item work the caller does next.
+// Build a fresh PyDict. PyDict::new() doesn't preallocate, so the dict grows
+// and rehashes as keys are inserted; the amortised rehash cost is O(n) and
+// dominated by the per-key set_item work the caller does next. The `_n` size
+// hint is accepted for call-site clarity but currently unused.
 unsafe fn fresh_dict_for<'py>(py: Python<'py>, _n: usize) -> PyResult<Bound<'py, PyDict>> {
     Ok(PyDict::new(py))
 }
@@ -1214,10 +1238,9 @@ fn unary_into_new<'py>(
 
 // Convenience: read self's data (filtered by mask if any), apply `value OP scalar`
 // (or `scalar OP value` when `REV=true`), write into a fresh PyDict. Single-pass
-// — avoids the dict.copy()+overwrite that the Cython baseline does. The result
-// dict is pre-sized via `_PyDict_NewPresized` so large outputs don't pay the
-// resize/rehash cost. Direction is a const generic so monomorphization gives
-// each direction its own specialized loop body.
+// — avoids a dict.copy()+overwrite double pass by reading the source and
+// writing a fresh dict in one go. Direction is a const generic so
+// monomorphization gives each direction its own specialized loop body.
 fn scalar_op_into_new<'py, const REV: bool>(
     py: Python<'py>,
     left: &VectorDict,
@@ -1233,23 +1256,48 @@ fn scalar_op_into_new<'py, const REV: bool>(
         }
     } else {
         let mask = left.mask.as_ref().unwrap().bind(py);
-        unsafe {
-            let mut pos: ffi::Py_ssize_t = 0;
-            let mut key: *mut ffi::PyObject = std::ptr::null_mut();
-            let mut val: *mut ffi::PyObject = std::ptr::null_mut();
-            while ffi::PyDict_Next(src.as_ptr(), &mut pos, &mut key, &mut val) != 0 {
-                let in_mask = ffi::PySequence_Contains(mask.as_ptr(), key);
-                if in_mask < 0 {
-                    return Err(PyErr::fetch(py));
+        // Same mask/data scan choice as `iter_keys`: when the mask is the
+        // smaller side (e.g. a model's active features vs. its full weight
+        // vector), walk the mask and look each key up in `data` instead of
+        // scanning every stored entry. The result dict is bit-identical either
+        // way — its keys are `data ∩ mask` and each value `op(data[k], scalar)`
+        // is computed independently per key, so only insertion order (which is
+        // numerically irrelevant) differs.
+        let scan_mask = matches!(mask.len(), Ok(mask_len) if mask_len < src.len());
+        if scan_mask {
+            for k in mask.try_iter()? {
+                let k = k?;
+                unsafe {
+                    let val = dict_get_or_null(src.as_ptr(), k.as_ptr());
+                    if val.is_null() {
+                        continue;
+                    }
+                    let raw = if REV { op(scalar, val) } else { op(val, scalar) };
+                    let new_val = ffi_check(py, raw)?;
+                    let r = ffi::PyDict_SetItem(res.as_ptr(), k.as_ptr(), new_val);
+                    ffi::Py_DECREF(new_val);
+                    ffi_status(py, r)?;
                 }
-                if in_mask == 0 {
-                    continue;
+            }
+        } else {
+            unsafe {
+                let mut pos: ffi::Py_ssize_t = 0;
+                let mut key: *mut ffi::PyObject = std::ptr::null_mut();
+                let mut val: *mut ffi::PyObject = std::ptr::null_mut();
+                while ffi::PyDict_Next(src.as_ptr(), &mut pos, &mut key, &mut val) != 0 {
+                    let in_mask = ffi::PySequence_Contains(mask.as_ptr(), key);
+                    if in_mask < 0 {
+                        return Err(PyErr::fetch(py));
+                    }
+                    if in_mask == 0 {
+                        continue;
+                    }
+                    let raw = if REV { op(scalar, val) } else { op(val, scalar) };
+                    let new_val = ffi_check(py, raw)?;
+                    let r = ffi::PyDict_SetItem(res.as_ptr(), key, new_val);
+                    ffi::Py_DECREF(new_val);
+                    ffi_status(py, r)?;
                 }
-                let raw = if REV { op(scalar, val) } else { op(val, scalar) };
-                let new_val = ffi_check(py, raw)?;
-                let r = ffi::PyDict_SetItem(res.as_ptr(), key, new_val);
-                ffi::Py_DECREF(new_val);
-                ffi_status(py, r)?;
             }
         }
     }
@@ -1272,8 +1320,8 @@ fn binop_add<'py>(
             VectorDict::from_dict(add_dict_dict(py, left, &right_inner)?),
         );
     }
-    // vec + scalar — single-pass: read source, write fresh result. Saves the
-    // dict.copy()+overwrite double-pass that the Cython does.
+    // vec + scalar — single-pass: read source, write fresh result, avoiding a
+    // dict.copy()+overwrite double pass.
     let res = scalar_op_into_new::<false>(py, left, right.as_ptr(), ffi::PyNumber_Add)?;
     Py::new(py, VectorDict::from_dict(res))
 }
@@ -1665,7 +1713,7 @@ fn div_dict_dict<'py>(
                 let new_val = if !right_val.is_null() {
                     ffi_check(py, ffi::PyNumber_TrueDivide(left_val, right_val))?
                 } else {
-                    // matches Cython: `left_value / 0` raises ZeroDivisionError
+                    // matches Python semantics: `left_value / 0` raises ZeroDivisionError
                     ffi_check(py, ffi::PyNumber_TrueDivide(left_val, zero.as_ptr()))?
                 };
                 let r = ffi::PyDict_SetItem(res.as_ptr(), key, new_val);
@@ -1777,6 +1825,28 @@ fn matmul<'py>(
 ) -> PyResult<Bound<'py, PyAny>> {
     let mut acc: Bound<'py, PyAny> = 0i64.into_bound_py_any(py)?;
     if left.use_factory || right.use_factory {
+        // Fast path: when one operand is "simple" (no mask, no factory), iterate
+        // its data and pull the other operand's value via `get_value`. Keys
+        // absent from the simple side contribute 0 to the dot and are skipped,
+        // which avoids materialising the union and re-looking-up every key. This
+        // is the GLM learn path (`weights_masked_factory @ VectorDict(x)`). The
+        // factory initialisation on the non-simple side is preserved: `get_value`
+        // touches exactly the keys the union path would have.
+        if right.is_simple() {
+            for (k, rv) in right.data.bind(py).iter() {
+                let lv = left.get_value(py, &k)?;
+                acc = acc.add(lv.mul(rv)?)?;
+            }
+            return Ok(acc);
+        }
+        if left.is_simple() {
+            for (k, lv) in left.data.bind(py).iter() {
+                let rv = right.get_value(py, &k)?;
+                acc = acc.add(lv.mul(rv)?)?;
+            }
+            return Ok(acc);
+        }
+        // Both operands carry a mask/factory: fall back to the full union.
         for k in left.union_keys(py, right)? {
             let lv = left.get_value(py, &k)?;
             let rv = right.get_value(py, &k)?;
@@ -1962,8 +2032,8 @@ pub fn lazy_search_euclidean<'py>(
     let qx = qx.cast::<PyDict>()?;
     let k = n_neighbors.max(0) as usize;
 
-    // The Cython path uses the C-level `_heapify_max` / `_heapreplace_max` from
-    // `heapq`. We mirror that exactly for byte-identical behavior on ties.
+    // Use the C-level `_heapify_max` / `_heapreplace_max` from `heapq` so tie
+    // behavior is byte-identical to the equivalent pure-Python implementation.
     let heapq = py.import("heapq")?;
     let heapify_max = heapq.getattr("_heapify_max")?;
     let heapreplace_max = heapq.getattr("_heapreplace_max")?;


### PR DESCRIPTION
## What

Two performance fixes for sparse, high-cardinality workloads (e.g. CTR-style data), plus doc cleanups.

### Linear models: sparse updates
`learn_one` for the generalized linear models (`LinearRegression`, `LogisticRegression`, `Perceptron`, ...) previously cost **O(total features ever seen)** per example, because the masked weight `VectorDict` scanned the full backing dictionary in its dot product and update. It now scans the (small) mask instead when that's the smaller side, so updates cost **O(active features)**.

- Output-preserving: the masked key set is unchanged; only the dot-product summation order shifts (to floating-point roundoff), which already matched what `predict` did.
- On a 100k-row hashed Criteo stream, `LogisticRegression` learn+predict went from ~290 ex/s (degrading as the weight vector grew) to a flat ~10.7k ex/s.

### FeatureHasher: MurmurHash3 in Rust
`preprocessing.FeatureHasher` hashed every token with `blake2s` (a cryptographic hash) plus a hex-string/bigint round-trip — ~40% of a hashed pipeline's time. It now hashes with **MurmurHash3 (x86 32-bit)** in Rust, doing the whole `transform_one` in one native call (~16× faster).

- The Rust hash is verified bit-for-bit identical to scikit-learn's `murmurhash3_32` (no new dependency — sklearn and VW both vendor their own murmur for the same reason).
- Gains an `alternate_sign` parameter (default `True`, matching scikit-learn) and returns a plain `dict`.
- **Behavior change**: hashed feature indices differ from previous versions, and `alternate_sign=True` negates ~half of contributions by default. The docstring previously *claimed* murmurhash + `alternate_sign` but did neither.

### Docs
- Restyled all `unreleased.md` entries to be concise (lead with the change + user-facing effect, drop deep internals) and documented that style in `CLAUDE.md`.
- Dropped stale "ported from Cython" comments in the Rust sources (River no longer uses Cython).
- Fixed the `AdPredictor` docstring's now-outdated implication that plain linear models do a full per-example update.
- Documented the `maturin develop` inner-loop build command in `CONTRIBUTING.md`.

## Verification
- `river/linear_model`, `river/utils`, `river/optim`, `river/facto`, `river/preprocessing` tests + doctests pass (including the exact-value FTRL/SGD doctests, which confirm the linear-model outputs are unchanged).
- `check_estimator(FeatureHasher())` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)