### PR TITLE
Make transformer base classes properly abstract

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -4,6 +4,10 @@
 - Moved `altair` from the runtime dependencies to the `docs`/`dev` groups; it was only used to draw plots in the docs, so installing River no longer pulls it in.
 - Publish Pyodide/WebAssembly wheels (CPython 3.13 and 3.14) so River can run in the browser, e.g. via [JupyterLite](https://jupyterlite.readthedocs.io/) or `micropip`. The minimum `numpy` and `scipy` versions were lowered to `2.2.5` and `1.14.1` to match Pyodide.
 
+## base
+
+- `base.Transformer` and `base.SupervisedTransformer` are now properly abstract: their `transform_one` abstract method is registered with `abc`, so a subclass that forgets to implement it raises `TypeError` at instantiation instead of failing later. This also restores estimator-check coverage for all concrete transformers, which were unintentionally excluded from the automated test suite.
+
 ## covariance
 
 - Sped up `EmpiricalCovariance.update`/`revert` (~40% faster at 30 features) by caching the sorted feature list and pair iteration in the hot path. No semantic change.

--- a/river/base/transformer.py
+++ b/river/base/transformer.py
@@ -12,7 +12,7 @@ if typing.TYPE_CHECKING:
     from river import compose
 
 
-class BaseTransformer:
+class BaseTransformer(abc.ABC):
     def __add__(self, other: BaseTransformer) -> compose.TransformerUnion:
         """Fuses with another Transformer into a TransformerUnion."""
         from river import compose

--- a/river/test_estimators.py
+++ b/river/test_estimators.py
@@ -45,12 +45,6 @@ def iter_estimators():
 def iter_estimators_which_can_be_tested():
     ignored = (
         River2SKLBase,
-        # base.Transformer / base.SupervisedTransformer are not marked abstract
-        # by Python (their abstract `transform_one` sits on the BaseTransformer
-        # mixin, which is not an ABC), but they are not meant to be tested
-        # directly.
-        base.Transformer,
-        base.SupervisedTransformer,
         anomaly.LocalOutlierFactor,  # needs warm-start to work correctly
         compose.FuncTransformer,
         compose.Grouper,


### PR DESCRIPTION
## What

Makes `base.Transformer` and `base.SupervisedTransformer` properly abstract, and restores estimator-check coverage for all concrete transformers.

## The bug

`BaseTransformer` declares `transform_one` with `@abc.abstractmethod`, but `BaseTransformer` itself is a plain class (metaclass `type`) — so `abc` never collects the abstract method (`BaseTransformer` doesn't even have an `__abstractmethods__` attribute). When `Transformer(base.Estimator, BaseTransformer)` is built via `EstimatorMeta` (an `ABCMeta` subclass), the abstract `transform_one` isn't inherited as abstract, so:

- `inspect.isabstract(base.Transformer)` returned `False`, and
- an incomplete transformer subclass (no `transform_one`) only failed when `transform_one` was eventually *called*, not at instantiation.

By contrast `MiniBatchTransformer` / `MiniBatchSupervisedTransformer` were already correctly abstract, because their abstract methods are declared directly on classes with the ABC-aware metaclass.

## Fix

Make `BaseTransformer` inherit `abc.ABC`. No metaclass conflict (`EstimatorMeta` already subclasses `ABCMeta`). Now `transform_one` is registered, the base classes are abstract, and incomplete subclasses raise `TypeError` at construction.

## Knock-on cleanup

`iter_estimators_which_can_be_tested` listed `base.Transformer` / `base.SupervisedTransformer` in its `ignored` tuple (added in #1878) to skip the then-non-abstract base classes. But `can_be_tested` filters with `issubclass(estimator, ignored)`, so this **excluded every concrete transformer** — `StandardScaler`, `RobustScaler`, `TFIDF`, `PolynomialExtender`, … (22 estimators that were auto-tested before #1878). Now that the base classes are genuinely abstract, `inspect.isabstract` excludes them and those two entries can be dropped, restoring coverage.

## Result

- Testable estimators: **103 → 125**.
- All of them pass `check_estimator` (full `test_estimators.py`: 4250 passed).
- No behavior change for correctly-implemented transformers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)