### PR TITLE
Fix optimizers that crash on array-backed or cloned estimators + add optimizer×estimator test

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -37,6 +37,9 @@
 ## optim
 
 - Exposed `optim.Newton` (Online Newton Step), which was implemented but never exported, and fixed an initialisation bug (the inverse Hessian started at `eps * I` instead of `(1 / eps) * I`) that crippled learning. Reworked around NumPy-backed dense state.
+- Fixed `optim.AdaBound` raising `TypeError` after being cloned (its base learning rate was captured as a scheduler instead of a number), which broke it inside `evaluate`, ensembles, model selection, and anywhere else estimators are cloned.
+- Fixed `optim.NesterovMomentum` and `optim.FTRLProximal` raising when used to optimise estimators whose weights are stored as NumPy arrays, such as the factorization machines (`facto`).
+- Added a test covering every optimizer against every estimator that accepts one, so optimizer/estimator incompatibilities are caught going forward.
 
 ## preprocessing
 

--- a/river/optim/ada_bound.py
+++ b/river/optim/ada_bound.py
@@ -56,7 +56,9 @@ class AdaBound(optim.base.Optimizer):
 
     def __init__(self, lr=1e-3, beta_1=0.9, beta_2=0.999, eps=1e-8, gamma=1e-3, final_lr=0.1):
         super().__init__(lr)
-        self.base_lr = lr
+        # Capture the base learning rate as a float. Reading it back from `lr` directly would
+        # break on clone (where `lr` arrives as a `Constant` scheduler rather than a number).
+        self.base_lr = self.learning_rate
         self.final_lr = final_lr
         self.beta_1 = beta_1
         self.beta_2 = beta_2

--- a/river/optim/ftrl.py
+++ b/river/optim/ftrl.py
@@ -74,9 +74,12 @@ class FTRLProximal(optim.base.Optimizer):
             if abs(z[i]) > l1:
                 w[i] = -(((beta + n[i] ** 0.5) / alpha + l2) ** -1) * (z[i] - np.sign(z[i]) * l1)
 
+        # `w` may be a dict-like (use `.get`) or a NumPy array, in which case every index in `g`
+        # is a valid position and can be read directly.
+        w_is_array = isinstance(w, np.ndarray)
         for i, gi in g.items():
             s = ((self.n[i] + gi**2) ** 0.5 - self.n[i] ** 0.5) / self.alpha
-            self.z[i] += gi - s * w.get(i, 0)
+            self.z[i] += gi - s * (w[i] if w_is_array else w.get(i, 0))
             self.n[i] += gi**2
 
         return w

--- a/river/optim/nesterov.py
+++ b/river/optim/nesterov.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import collections
 
+import numpy as np
+
 from river import optim
 from river.optim.base import DictLike
 
@@ -45,14 +47,15 @@ class NesterovMomentum(optim.base.Optimizer):
         self.s = collections.defaultdict(float)
 
     def look_ahead(self, w):
-        for i in w:
+        # `w` may be a dict-like (iterating yields keys) or a NumPy array (iterate its indices).
+        for i in range(len(w)) if isinstance(w, np.ndarray) else w:
             w[i] -= self.rho * self.s[i]
 
         return w
 
     def _step_with_dict(self, w: DictLike, g: DictLike) -> DictLike:
         # Move w back to it's initial position
-        for i in w:
+        for i in range(len(w)) if isinstance(w, np.ndarray) else w:
             w[i] += self.rho * self.s[i]
 
         for i, gi in g.items():

--- a/river/optim/test_estimator_compat.py
+++ b/river/optim/test_estimator_compat.py
@@ -1,0 +1,142 @@
+"""Every optimizer should work with every estimator that accepts one.
+
+These estimators expose the optimizer as a hyperparameter, so any concrete optimizer ought
+to be able to drive any of them. This used to silently break for estimators whose weights are
+stored as NumPy arrays (e.g. the factorization machines): some optimizers assumed dict-like
+weights and raised at ``learn_one`` time. This test runs the full ``optimizer`` x ``estimator``
+matrix on a small dummy stream to guard against that.
+
+A handful of combinations are genuinely unsupported (see ``_xfail_reason``) and are marked as
+strict xfails, so the matrix stays exhaustive and we get told if one ever starts working.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import random
+
+import pytest
+
+from river import base, optim
+from river.anomaly.base import AnomalyDetector
+from river.reco.base import Ranker
+
+# __init__ parameters through which an optimizer can be injected.
+OPTIMIZER_PARAMS = frozenset(
+    {"optimizer", "weight_optimizer", "latent_optimizer", "int_weight_optimizer"}
+)
+
+# Optimizers whose updates rely on scalar-only operations (element-wise max/clamp/threshold, or a
+# Hessian). They cannot drive models that keep a *vector* of weights per key, such as the
+# recommenders.
+SCALAR_ONLY_OPTIMIZERS = frozenset({"AdaBound", "AdaMax", "AMSGrad", "FTRLProximal", "Newton"})
+
+
+def iter_optimizers():
+    """All concrete optimizers, instantiated with their default hyperparameters."""
+    for name in sorted(dir(optim)):
+        obj = getattr(optim, name)
+        if not (inspect.isclass(obj) and issubclass(obj, optim.base.Optimizer)):
+            continue
+        if obj is optim.base.Optimizer:
+            continue
+        try:
+            yield obj()
+        except TypeError:
+            # Meta-optimizers (e.g. Averager) wrap another optimizer.
+            yield obj(optim.SGD())
+
+
+def iter_optimizer_estimators():
+    """All concrete estimators that accept an optimizer, with their optimizer params."""
+    seen: set[type] = set()
+    for submodule in importlib.import_module("river.api").__all__:
+        module = importlib.import_module(f"river.{submodule}")
+        for _, cls in inspect.getmembers(module, inspect.isclass):
+            if not issubclass(cls, base.Estimator) or inspect.isabstract(cls):
+                continue
+            if cls in seen:
+                continue
+            # MLPRegressor is deprecated and requires an explicit architecture; skip it.
+            if cls.__name__ == "MLPRegressor":
+                continue
+            try:
+                params = set(inspect.signature(cls.__init__).parameters)
+            except (TypeError, ValueError):
+                continue
+            optimizer_params = OPTIMIZER_PARAMS & params
+            if optimizer_params:
+                seen.add(cls)
+                yield cls, optimizer_params
+
+
+def _xfail_reason(optimizer, estimator_cls) -> str | None:
+    """Reason a given (optimizer, estimator) pair is expected to fail, or None if it should work."""
+    name = optimizer.__class__.__name__
+    is_factorization_machine = estimator_cls.__module__.startswith("river.facto")
+    # Models with latent factors keep a vector of weights per key (the recommenders apart from the
+    # bias-only `Baseline`, which works with every optimizer).
+    has_latent_vectors = "n_factors" in inspect.signature(estimator_cls.__init__).parameters
+    keeps_vector_weights_per_key = issubclass(estimator_cls, Ranker) and has_latent_vectors
+
+    if name == "Averager" and is_factorization_machine:
+        return (
+            "Averager keeps a single running average of the weights and returns it, so it cannot "
+            "drive the many independent latent vectors a factorization machine updates through "
+            "one shared optimizer instance."
+        )
+    if keeps_vector_weights_per_key and (name in SCALAR_ONLY_OPTIMIZERS or name == "Averager"):
+        return (
+            "Recommenders update a vector of weights per key; this optimizer only supports "
+            "scalar-valued weights."
+        )
+    return None
+
+
+def _exercise(model):
+    """Run ``model`` on a small dummy stream appropriate to its kind."""
+    rng = random.Random(42)
+
+    if isinstance(model, Ranker):
+        users, items = ["Alice", "Bob", "Carol"], ["x", "y", "z"]
+        for _ in range(20):
+            user, item = rng.choice(users), rng.choice(items)
+            model.predict_one(user, item)
+            model.learn_one(user, item, rng.uniform(0, 5))
+        return
+
+    if isinstance(model, AnomalyDetector):
+        for _ in range(20):
+            x = {f"f{j}": rng.uniform(-1, 1) for j in range(5)}
+            model.score_one(x)
+            model.learn_one(x)
+        return
+
+    is_classifier = isinstance(model, base.Classifier)
+    for _ in range(20):
+        x = {f"f{j}": rng.uniform(-1, 1) for j in range(5)}
+        y = rng.choice([False, True]) if is_classifier else rng.uniform(-1, 1)
+        model.predict_one(x)
+        model.learn_one(x, y)
+
+
+def _matrix():
+    for estimator_cls, optimizer_params in iter_optimizer_estimators():
+        for optimizer in iter_optimizers():
+            reason = _xfail_reason(optimizer, estimator_cls)
+            marks = [pytest.mark.xfail(reason=reason, strict=True)] if reason else []
+            yield pytest.param(
+                estimator_cls,
+                optimizer_params,
+                optimizer,
+                id=f"{optimizer.__class__.__name__}-{estimator_cls.__name__}",
+                marks=marks,
+            )
+
+
+@pytest.mark.parametrize("estimator_cls, optimizer_params, optimizer", list(_matrix()))
+def test_optimizer_works_with_estimator(estimator_cls, optimizer_params, optimizer):
+    kwargs = {param: optimizer.clone() for param in optimizer_params}
+    model = estimator_cls(**kwargs)
+    _exercise(model)


### PR DESCRIPTION
## What & why

While adding factorization machines to the estimator checks (#1915), `NesterovMomentum` turned out to crash on them. Investigating with a full **optimizer × estimator** matrix surfaced three genuine optimizer bugs, plus several architectural limits worth documenting.

### Fixes

- **`AdaBound` crashed after being cloned.** It captured its base learning rate from the raw `lr` argument, which arrives as a `Constant` scheduler after a clone, so `learning_rate / base_lr` became `float / Constant` → `TypeError`. Since River clones estimators throughout (`evaluate`, ensembles, `model_selection`, …), `AdaBound` was effectively unusable outside a freshly hand-built model. It now reads the base rate as a float via the `learning_rate` property.
- **`NesterovMomentum` crashed on array-backed weights.** It iterated `for i in w`, assuming dict-like weights; for NumPy-array weights (the factorization machines) that yields *values* instead of indices → `IndexError`.
- **`FTRLProximal` crashed on array-backed weights.** It called `w.get(i, 0)`, which NumPy arrays don't have.

The dict / `VectorDict` code paths are untouched, so linear-model behaviour and each optimizer's own doctest (`F1: 84.22%` / `87.56%` / `88.06%`) are unchanged.

### New test

`river/optim/test_estimator_compat.py` runs **every optimizer against every estimator that accepts one** on a small dummy stream — this would have caught all three bugs. Genuinely unsupported combinations are recorded as **strict xfails** (so the matrix stays exhaustive and we're alerted if one ever starts passing):

- `Averager` driving a factorization machine — it keeps a single running average and returns it, so it can't represent the many independent latent vectors a FM updates through one shared optimizer instance.
- Scalar-only optimizers (`AdaBound`, `AdaMax`, `AMSGrad`, `FTRLProximal`, `Newton`, `Averager`) driving recommenders (`BiasedMF`, `FunkMF`), which keep a *vector* of weights per key.

`MLPRegressor` is excluded (deprecated).

## Testing

- New matrix: **190 passed, 20 xfailed**.
- `river/optim` + `river/linear_model`: 340 passed, no regressions.
- `mypy river/optim` clean; optimizer doctests unchanged.

## Follow-up (not in this PR)

Making the scalar-only optimizers support vector-valued (per-key) weights would let the recommenders use them; that's a larger, separate change. The xfails document exactly which combinations it would cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)