### PR TITLE
feat(preprocessing): Make `OrdinalEncoder` mini-batching dataframe-agnostic

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -39,6 +39,7 @@
 - Added a `window_size` parameter to `preprocessing.StandardScaler`, `preprocessing.MinMaxScaler`, and `preprocessing.MaxAbsScaler`. When set, the scaler tracks its statistics over the last `window_size` observations instead of the whole stream.
 - Added a `_from_state` classmethod to `preprocessing.MinMaxScaler`, `preprocessing.MaxAbsScaler`, and `preprocessing.StandardScaler` so a scaler can be warm-started from precomputed statistics without replaying past observations.
 - `preprocessing.FeatureHasher` now hashes with MurmurHash3 in Rust, making it much faster. It gains an `alternate_sign` parameter (default `True`, matching scikit-learn) and returns a plain `dict`. Hashed feature indices differ from previous versions.
+- `preprocessing.OrdinalEncoder` mini-batch methods (`learn_many`, `predict_many`, `predict_proba_many`) now accept and return any [narwhals](https://github.com/narwhals-dev/narwhals)-supported eager backend (pandas, polars, pyarrow, ...) instead of being pandas-only. The input backend is preserved on output, including the pandas index. These methods no longer require `pandas` to be installed.
 
 ## reco
 

--- a/river/preprocessing/ordinal.py
+++ b/river/preprocessing/ordinal.py
@@ -182,8 +182,9 @@ class OrdinalEncoder(base.MiniBatchTransformer):
 
         """
         X_nw = utils.dataframe.into_frame(X)
+        schema = X_nw.schema
         exprs: list[nw.Expr] = []
-        for col in X_nw.columns:
+        for col, dtype in schema.items():
             mapping = self.values[col]
             # `replace_strict` maps each known category to its code and everything else to
             # `unknown_value` in one vectorised pass. An empty mapping (a column never seen during
@@ -198,10 +199,16 @@ class OrdinalEncoder(base.MiniBatchTransformer):
                 )
             else:
                 encoded = nw.lit(self.unknown_value, dtype=nw.Int64)
-            # Nulls (Python ``None`` / ``pd.NA`` / float ``NaN``) are mapped to ``none_value``
-            # separately, since `replace_strict` leaves unmatched nulls untouched.
+            # Missing cells map to `none_value` separately, since `replace_strict` leaves them
+            # untouched. A numeric `NaN` is missing too, but polars/pyarrow keep it distinct from
+            # null, so it is folded in explicitly (mirroring `learn_many`, which also skips it).
+            # `is_nan` errors on non-numeric dtypes, hence the guard.
+            is_missing = nw.col(col).is_null()
+            if dtype.is_numeric():
+                is_missing = is_missing | nw.col(col).is_nan()
+
             exprs.append(
-                nw.when(nw.col(col).is_null())  # type:ignore[arg-type]
+                nw.when(is_missing)  # type:ignore[arg-type]
                 .then(nw.lit(self.none_value, dtype=nw.Int64))
                 .otherwise(encoded)
                 .alias(col)

--- a/river/preprocessing/ordinal.py
+++ b/river/preprocessing/ordinal.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import collections
 import typing
 
-import numpy as np
+import narwhals.stable.v2 as nw
 
 from river import base, utils
 
 if typing.TYPE_CHECKING:
-    pass
+    from narwhals.stable.v2.typing import IntoDataFrame, IntoDataFrameT, IntoSeries
 
 
 class OrdinalEncoder(base.MiniBatchTransformer):
@@ -112,14 +112,17 @@ class OrdinalEncoder(base.MiniBatchTransformer):
 
     def __init__(
         self,
-        categories: dict | None = None,
+        categories: dict[base.typing.FeatureName, dict[typing.Hashable, int]] | None = None,
         unknown_value: int | None = 0,
         none_value: int = -1,
     ):
         self.unknown_value = unknown_value
         self.none_value = none_value
         self.categories = categories
-        self.values: collections.defaultdict | dict | None = None
+        self.values: (
+            collections.defaultdict[base.typing.FeatureName, dict[typing.Hashable, int]]
+            | dict[base.typing.FeatureName, dict[typing.Hashable, int]]
+        )
 
         if self.categories is None:
             # We're going to store the categories in a dict of dicts. The outer dict will map each
@@ -146,7 +149,7 @@ class OrdinalEncoder(base.MiniBatchTransformer):
         reserved values (``unknown_value`` and ``none_value``).
 
         """
-        code = len(self.values[feature])  # type: ignore[index]
+        code = len(self.values[feature])
         for reserved in self._reserved_category_codes:
             if reserved <= code:
                 code += 1
@@ -155,7 +158,7 @@ class OrdinalEncoder(base.MiniBatchTransformer):
     def _encode_value(self, feature: typing.Hashable, value):
         if value is None:
             return self.none_value
-        return self.values[feature].get(value, self.unknown_value)  # type: ignore[index]
+        return self.values[feature].get(value, self.unknown_value)
 
     def transform_one(self, x):
         return {i: self._encode_value(i, xi) for i, xi in x.items()}
@@ -166,22 +169,65 @@ class OrdinalEncoder(base.MiniBatchTransformer):
                 if xi is not None and xi not in self.values[i]:
                     self.values[i][xi] = self._next_category_code(i)
 
-    def transform_many(self, X):
-        pd = utils.pandas.import_pandas()
-        return pd.DataFrame(
-            {
-                i: pd.Series(
-                    (self._encode_value(i, value) for value in X[i]),
-                    index=X.index,
-                    dtype=np.int64,
-                )
-                for i in X.columns
-            }
-        )
+    def transform_many(self, X: IntoDataFrameT) -> IntoDataFrameT:
+        """Encode a mini-batch of features into integer codes.
 
-    def learn_many(self, X, y=None):
+        Missing cells (``None``/``NaN``/``pd.NA``) are mapped to ``none_value`` consistently
+        across backends; values absent from the learned categories map to ``unknown_value``.
+
+        Parameters
+        ----------
+        X
+            A dataframe where each column is a categorical feature.
+
+        """
+        X_nw = utils.dataframe.into_frame(X)
+        exprs: list[nw.Expr] = []
+        for col in X_nw.columns:
+            mapping = self.values[col]
+            # `replace_strict` maps each known category to its code and everything else to
+            # `unknown_value` in one vectorised pass. An empty mapping (a column never seen during
+            # `learn_many`) has no categories to match, so the whole column collapses to
+            # `unknown_value`.
+            if mapping:
+                encoded = nw.col(col).replace_strict(
+                    list(mapping.keys()),
+                    list(mapping.values()),
+                    default=self.unknown_value,
+                    return_dtype=nw.Int64,
+                )
+            else:
+                encoded = nw.lit(self.unknown_value, dtype=nw.Int64)
+            # Nulls (Python ``None`` / ``pd.NA`` / float ``NaN``) are mapped to ``none_value``
+            # separately, since `replace_strict` leaves unmatched nulls untouched.
+            exprs.append(
+                nw.when(nw.col(col).is_null())  # type:ignore[arg-type]
+                .then(nw.lit(self.none_value, dtype=nw.Int64))
+                .otherwise(encoded)
+                .alias(col)
+            )
+        return X_nw.select(exprs).to_native()
+
+    def learn_many(self, X: IntoDataFrame, y: IntoSeries | None = None) -> None:
         if self.categories is None:
-            for i in X.columns:
-                for xi in X[i].dropna().unique():
-                    if xi not in self.values[i]:
-                        self.values[i][xi] = self._next_category_code(i)
+            X_nw = utils.dataframe.into_frame(X)
+            schema = X_nw.schema
+            # Skip missing cells before registering categories: numeric columns can carry NaN
+            # (not caught by `is_null` on every backend), so exclude both for numeric dtypes.
+            finite_masks = X_nw.select(
+                [
+                    ~(nw.col(name).is_nan() | nw.col(name).is_null())
+                    if dtype.is_numeric()
+                    else ~nw.col(name).is_null()
+                    for name, dtype in schema.items()
+                ]
+            )
+            for col_name in schema.names():
+                # `maintain_order=True` assigns codes in first-appearance order on every backend,
+                # matching `learn_one` and keeping the encoding reproducible across backends
+                # (polars' default `unique` does not preserve order).
+                for value in (
+                    X_nw[col_name].filter(finite_masks[col_name]).unique(maintain_order=True)
+                ):
+                    if value not in self.values[col_name]:
+                        self.values[col_name][value] = self._next_category_code(col_name)

--- a/river/preprocessing/test_ordinal.py
+++ b/river/preprocessing/test_ordinal.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import random
+import string
+import typing
+
+import narwhals.stable.v2 as nw
+import pytest
+
+from river import preprocessing
+from river.conftest import FRAME_BACKENDS
+
+if typing.TYPE_CHECKING:
+    from typing import Any
+
+    from narwhals.stable.v2.typing import IntoDataFrame
+
+    from river.conftest import FrameBackend
+
+# `OrdinalEncoder.learn_many`/`transform_many` are routed through narwhals so any eager backend
+# works. `learn_many` assigns codes in first-appearance order (`unique(maintain_order=True)`),
+# which makes the encoding reproducible across backends and consistent with `learn_one`. The
+# parametrization below pins this for several `unknown_value`/`none_value` combinations, which
+# drive both the reserved-code bookkeeping (`learn_many`) and the encoded output (`transform_many`).
+
+ENCODER_PARAMS = (
+    pytest.param({}, id="defaults"),
+    pytest.param({"unknown_value": None}, id="unknown_none"),
+    pytest.param({"unknown_value": 5, "none_value": 10}, id="reserved_5_10"),
+    pytest.param({"unknown_value": -1, "none_value": -2}, id="both_negative"),
+    pytest.param({"unknown_value": 1, "none_value": 2}, id="reserved_1_2"),
+)
+
+
+def _categorical_batch(n: int = 40) -> tuple[dict[str, list[str]], list[dict[str, str]]]:
+    """Build a reproducible batch of two categorical columns as (columns, row dicts)."""
+    rng = random.Random(42)
+    alphabet = list(string.ascii_lowercase[:5])
+    rows = [{"c1": rng.choice(alphabet), "c2": rng.choice(alphabet)} for _ in range(n)]
+    data = {"c1": [r["c1"] for r in rows], "c2": [r["c2"] for r in rows]}
+    return data, rows
+
+
+def _unknowns_batch() -> tuple[
+    dict[str, list[str | None]], dict[str, list[str | None]], list[dict[str, str | None]]
+]:
+    """Return (learn batch, transform batch, transform rows).
+
+    The transform batch deliberately mixes learned categories, an unseen category, and a null
+    per column, so encoding exercises code lookup, ``unknown_value``, and ``none_value`` together.
+    """
+    learn: dict[str, list[str | None]] = {
+        "c1": ["a", "b", "a", "c", "b", "c"],
+        "c2": ["x", "y", "z", "x", "y", "z"],
+    }
+    trans: dict[str, list[str | None]] = {
+        "c1": ["a", "d", "b", None, "c", "e"],
+        "c2": ["x", "w", None, "y", "z", "x"],
+    }
+    rows = [{col: values[i] for col, values in trans.items()} for i in range(len(trans["c1"]))]
+    return learn, trans, rows
+
+
+def _read_rows(native: IntoDataFrame) -> list[dict[str, int | None]]:
+    """Read a native encoded frame into rows, mapping nulls to ``None`` and codes to ``int``.
+
+    The null mask is read separately so this stays correct across backends (a pandas nullable
+    ``Int64`` null is ``pd.NA``, not ``None``), which matters when ``unknown_value=None`` makes
+    unknown categories encode to null.
+    """
+    frame = nw.from_native(native, eager_only=True)
+    columns = {col: (frame[col].is_null(), frame[col]) for col in frame.columns}
+    return [
+        {col: (None if mask[i] else int(values[i])) for col, (mask, values) in columns.items()}
+        for i in range(len(frame))
+    ]
+
+
+@pytest.mark.parametrize("params", list(ENCODER_PARAMS))
+def test_learn_many_codes_match_across_backends(
+    frame_backend: FrameBackend, params: dict[str, Any]
+) -> None:
+    """Category codes are assigned identically regardless of the input backend."""
+    data, _ = _categorical_batch()
+
+    reference = preprocessing.OrdinalEncoder(**params)
+    reference.learn_many(FRAME_BACKENDS["pandas"]().frame(data))
+
+    encoder = preprocessing.OrdinalEncoder(**params)
+    encoder.learn_many(frame_backend.frame(data))
+
+    assert encoder.values == reference.values
+
+
+@pytest.mark.parametrize("params", list(ENCODER_PARAMS))
+def test_learn_many_matches_learn_one(frame_backend: FrameBackend, params: dict[str, Any]) -> None:
+    """`learn_many` assigns the same codes as row-by-row `learn_one`."""
+    data, rows = _categorical_batch()
+
+    one = preprocessing.OrdinalEncoder(**params)
+    for row in rows:
+        one.learn_one(row)
+
+    many = preprocessing.OrdinalEncoder(**params)
+    many.learn_many(frame_backend.frame(data))
+
+    assert many.values == one.values
+
+
+@pytest.mark.parametrize(
+    ("params", "expected"),
+    [
+        ({}, {"a": 1, "b": 2, "c": 3, "d": 4}),
+        ({"unknown_value": None}, {"a": 0, "b": 1, "c": 2, "d": 3}),
+        ({"unknown_value": 1, "none_value": 2}, {"a": 0, "b": 3, "c": 4, "d": 5}),
+        ({"unknown_value": 5, "none_value": 10}, {"a": 0, "b": 1, "c": 2, "d": 3}),
+    ],
+)
+def test_learn_many_skips_reserved_codes(
+    frame_backend: FrameBackend, params: dict[str, Any], expected: dict[str, int]
+) -> None:
+    """Non-negative `unknown_value`/`none_value` are reserved and never assigned to a category."""
+    encoder = preprocessing.OrdinalEncoder(**params)
+    encoder.learn_many(frame_backend.frame({"c": ["a", "b", "c", "d"]}))
+
+    assert dict(encoder.values["c"]) == expected
+
+
+@pytest.mark.parametrize("params", list(ENCODER_PARAMS))
+def test_transform_many_is_backend_agnostic(
+    frame_backend: FrameBackend, params: dict[str, Any]
+) -> None:
+    """`transform_many` yields identical codes regardless of the input backend."""
+    learn, trans, _ = _unknowns_batch()
+
+    reference = preprocessing.OrdinalEncoder(**params)
+    reference.learn_many(FRAME_BACKENDS["pandas"]().frame(learn))
+    expected = _read_rows(reference.transform_many(FRAME_BACKENDS["pandas"]().frame(trans)))
+
+    encoder = preprocessing.OrdinalEncoder(**params)
+    encoder.learn_many(frame_backend.frame(learn))
+    got = _read_rows(encoder.transform_many(frame_backend.frame(trans)))
+
+    assert got == expected
+
+
+@pytest.mark.parametrize("params", list(ENCODER_PARAMS))
+def test_transform_many_matches_transform_one(
+    frame_backend: FrameBackend, params: dict[str, Any]
+) -> None:
+    """Each row of `transform_many` agrees with `transform_one`, including unknowns and nulls."""
+    learn, trans, rows = _unknowns_batch()
+
+    encoder = preprocessing.OrdinalEncoder(**params)
+    encoder.learn_many(frame_backend.frame(learn))
+
+    many = _read_rows(encoder.transform_many(frame_backend.frame(trans)))
+    for row, many_row in zip(rows, many):
+        assert encoder.transform_one(row) == many_row
+
+
+@pytest.mark.parametrize("sentinel_kind", ["none", "nan", "pd_na"])
+def test_transform_many_pandas_object_missing_maps_to_none_value(sentinel_kind: str) -> None:
+    """In a pandas object column, ``None`` / ``NaN`` / ``pd.NA`` all encode to ``none_value``.
+
+    The cross-backend tests already feed ``None`` through every backend (the nullable/pyarrow
+    constructors turn it into ``pd.NA``); this pins the remaining pandas-native sentinels.
+    """
+    pytest.importorskip("pandas")
+    import pandas as pd
+
+    sentinel: typing.Any = {"none": None, "nan": float("nan"), "pd_na": pd.NA}[sentinel_kind]
+    X = pd.DataFrame({"c": ["a", sentinel, "b"]})
+
+    encoder = preprocessing.OrdinalEncoder()
+    encoder.learn_many(X)
+
+    # The missing sentinel is never registered as a category, and encodes to none_value (-1).
+    assert dict(encoder.values["c"]) == {"a": 1, "b": 2}
+    assert _read_rows(encoder.transform_many(X)) == [{"c": 1}, {"c": -1}, {"c": 2}]
+
+
+def test_transform_many_numeric_nan_maps_to_none_value(frame_backend: FrameBackend) -> None:
+    """A numeric ``NaN`` is treated as missing on every backend.
+
+    polars/pyarrow keep ``NaN`` distinct from null, so the encoder folds it into the missing
+    mask explicitly; ``learn_many`` likewise skips it instead of learning it as a category.
+    """
+    data = {"c": [1.0, 2.0, float("nan"), 1.0]}
+
+    encoder = preprocessing.OrdinalEncoder()
+    encoder.learn_many(frame_backend.frame(data))
+
+    assert dict(encoder.values["c"]) == {1.0: 1, 2.0: 2}
+    expected = [{"c": 1}, {"c": 2}, {"c": -1}, {"c": 1}]
+    assert _read_rows(encoder.transform_many(frame_backend.frame(data))) == expected
+
+
+def test_transform_many_returns_native_backend(frame_backend: FrameBackend) -> None:
+    """`transform_many` returns the input backend's native frame type."""
+    data, _ = _categorical_batch()
+
+    encoder = preprocessing.OrdinalEncoder()
+    X = frame_backend.frame(data)
+    encoder.learn_many(X)
+    out = encoder.transform_many(X)
+
+    assert type(out) is type(X)
+
+
+def test_transform_many_preserves_pandas_index() -> None:
+    """The pandas path keeps the input index on the encoded frame."""
+    pytest.importorskip("pandas")
+    import pandas as pd
+
+    index = [7, 8, 9]
+    X = pd.DataFrame({"c1": ["a", "b", "a"], "c2": ["x", "y", "z"]}, index=index)
+
+    encoder = preprocessing.OrdinalEncoder()
+    encoder.learn_many(X)
+    out = encoder.transform_many(X)
+
+    assert list(out.index) == index

--- a/river/preprocessing/test_ordinal.py
+++ b/river/preprocessing/test_ordinal.py
@@ -11,8 +11,6 @@ from river import preprocessing
 from river.conftest import FRAME_BACKENDS
 
 if typing.TYPE_CHECKING:
-    from typing import Any
-
     from narwhals.stable.v2.typing import IntoDataFrame
 
     from river.conftest import FrameBackend
@@ -78,7 +76,7 @@ def _read_rows(native: IntoDataFrame) -> list[dict[str, int | None]]:
 
 @pytest.mark.parametrize("params", list(ENCODER_PARAMS))
 def test_learn_many_codes_match_across_backends(
-    frame_backend: FrameBackend, params: dict[str, Any]
+    frame_backend: FrameBackend, params: dict[str, typing.Any]
 ) -> None:
     """Category codes are assigned identically regardless of the input backend."""
     data, _ = _categorical_batch()
@@ -93,7 +91,9 @@ def test_learn_many_codes_match_across_backends(
 
 
 @pytest.mark.parametrize("params", list(ENCODER_PARAMS))
-def test_learn_many_matches_learn_one(frame_backend: FrameBackend, params: dict[str, Any]) -> None:
+def test_learn_many_matches_learn_one(
+    frame_backend: FrameBackend, params: dict[str, typing.Any]
+) -> None:
     """`learn_many` assigns the same codes as row-by-row `learn_one`."""
     data, rows = _categorical_batch()
 
@@ -117,7 +117,7 @@ def test_learn_many_matches_learn_one(frame_backend: FrameBackend, params: dict[
     ],
 )
 def test_learn_many_skips_reserved_codes(
-    frame_backend: FrameBackend, params: dict[str, Any], expected: dict[str, int]
+    frame_backend: FrameBackend, params: dict[str, typing.Any], expected: dict[str, int]
 ) -> None:
     """Non-negative `unknown_value`/`none_value` are reserved and never assigned to a category."""
     encoder = preprocessing.OrdinalEncoder(**params)
@@ -128,7 +128,7 @@ def test_learn_many_skips_reserved_codes(
 
 @pytest.mark.parametrize("params", list(ENCODER_PARAMS))
 def test_transform_many_is_backend_agnostic(
-    frame_backend: FrameBackend, params: dict[str, Any]
+    frame_backend: FrameBackend, params: dict[str, typing.Any]
 ) -> None:
     """`transform_many` yields identical codes regardless of the input backend."""
     learn, trans, _ = _unknowns_batch()
@@ -146,7 +146,7 @@ def test_transform_many_is_backend_agnostic(
 
 @pytest.mark.parametrize("params", list(ENCODER_PARAMS))
 def test_transform_many_matches_transform_one(
-    frame_backend: FrameBackend, params: dict[str, Any]
+    frame_backend: FrameBackend, params: dict[str, typing.Any]
 ) -> None:
     """Each row of `transform_many` agrees with `transform_one`, including unknowns and nulls."""
     learn, trans, rows = _unknowns_batch()


### PR DESCRIPTION
`OrdinalEncoder.learn_many` and `transform_many` were pandas-only. They now work with any narwhals-supported
eager backend (pandas, polars, pyarrow, ...) and no longer import pandas.

- `learn_many` registers categories via a single `unique(maintain_order=True)` pass per column, so codes are assigned in first-appearance order on every backend (polars' default `unique` does not preserve order), matching `learn_one`.
- `transform_many` encodes via vectorised `replace_strict` (known categories → codes, everything else → `unknown_value`) and folds missing cells into `none_value`. The input backend and shape are preserved on output.

## Behavior change

Missing cells (`None`, `NaN`, `pd.NA`) now encode to `none_value` consistently across backends. Previously the pandas `transform_many` mapped a numeric/object `NaN` to `unknown_value` (only `None` hit `none_value`). This aligns
`transform_many` with `transform_one` and across backends.

---

Related #1881, #1919 