### PR TITLE
Ship abi3 fallback wheels alongside native ones

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -78,6 +78,82 @@ jobs:
           name: cibw-wheels-${{ matrix.os }}-${{ matrix.python-version }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
+  # In addition to the per-version native wheels above, build a single abi3
+  # ("limited API") wheel per platform, tagged cp311-abi3 so it runs on any
+  # CPython >= 3.11. pip/uv always prefer the more specific native wheel when one
+  # matches the running interpreter, so these are only used as a fallback — e.g.
+  # on a new CPython release before its native wheels are published. The toggle
+  # is the `abi3` Cargo feature, forwarded to maturin via MATURIN_PEP517_ARGS.
+  build_linux_abi3_wheels:
+    name: Build abi3 (3.11+) ~ ${{ matrix.linux_tag }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        linux_tag: ["manylinux", "musllinux"]
+    env:
+      MATURIN_PEP517_ARGS: "--features abi3"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v3.4.1
+        timeout-minutes: 720
+        env:
+          CIBW_BUILD: "cp311-${{ matrix.linux_tag }}_*"
+          CIBW_ARCHS_LINUX: "x86_64 aarch64 ppc64le"
+          # The build runs inside a container, so forward the host env var in.
+          CIBW_ENVIRONMENT_PASS_LINUX: MATURIN_PEP517_ARGS
+      - uses: actions/upload-artifact@v5
+        with:
+          name: cibw-wheels-abi3-${{ matrix.linux_tag }}
+          path: ./wheelhouse/*.whl
+
+  build_macos_abi3_wheels:
+    name: Build abi3 (3.11+) ~ macos-15
+    runs-on: macos-15
+    env:
+      MATURIN_PEP517_ARGS: "--features abi3"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v3.4.1
+        timeout-minutes: 720
+        env:
+          CIBW_BUILD: "cp311-*"
+          CIBW_ARCHS_MACOS: "universal2"
+      - uses: actions/upload-artifact@v5
+        with:
+          name: cibw-wheels-abi3-macos
+          path: ./wheelhouse/*.whl
+
+  build_windows_abi3_wheels:
+    name: Build abi3 (3.11+) ~ windows-2025
+    runs-on: windows-2025
+    env:
+      MATURIN_PEP517_ARGS: "--features abi3"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v3.4.1
+        timeout-minutes: 720
+        env:
+          CIBW_BUILD: "cp311-*"
+          CIBW_ARCHS_WINDOWS: "AMD64"
+          CIBW_ENVIRONMENT_WINDOWS: 'PATH="$UserProfile\.cargo\bin;$PATH"'
+      - uses: actions/upload-artifact@v5
+        with:
+          name: cibw-wheels-abi3-windows
+          path: ./wheelhouse/*.whl
+
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
@@ -149,7 +225,7 @@ jobs:
   upload_to_pypi:
     name: Upload all wheels to PyPI
     runs-on: ubuntu-latest
-    needs: [build_linux_wheels, build_macos_wheels, build_windows_wheels, build_sdist, build_pyodide_wheels]
+    needs: [build_linux_wheels, build_macos_wheels, build_windows_wheels, build_linux_abi3_wheels, build_macos_abi3_wheels, build_windows_abi3_wheels, build_sdist, build_pyodide_wheels]
     permissions:
       id-token: write
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,12 @@ name = "river"
 path = "rust_src/lib.rs"
 crate-type = ["cdylib", "rlib"]
 
+[features]
+# Build against CPython's stable ABI (limited API) for 3.11+. Enabled only for
+# the abi3 fallback wheel in CI (see .github/workflows/pypi.yml); the default
+# per-version wheels are built without it for full-speed native code.
+abi3 = ["pyo3/abi3-py311"]
+
 [dependencies]
 pyo3 = "0.29.0"
 bincode = "1.3.3"

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Add `ppc64le` architecture to Linux wheel builds.
+- Publish `abi3` (stable-ABI, `cp311-abi3`) wheels alongside the per-version native wheels. pip/uv keep using the faster native wheel whenever one matches your interpreter; the `abi3` wheel is a fallback so River still installs as a wheel on CPython versions that don't yet have native builds (e.g. a brand-new release).
 - Moved `altair` from the runtime dependencies to the `docs`/`dev` groups; it was only used to draw plots in the docs, so installing River no longer pulls it in.
 - Publish Pyodide/WebAssembly wheels (CPython 3.13 and 3.14) so River can run in the browser, e.g. via [JupyterLite](https://jupyterlite.readthedocs.io/) or `micropip`. The minimum `numpy` and `scipy` versions were lowered to `2.2.5` and `1.14.1` to match Pyodide.
 - Display `compose.TransformerUnion` elements vertically in HTML representations.


### PR DESCRIPTION
Closes #1435.

## What

Build a single `cp311-abi3` (stable-ABI / "limited API") wheel per platform **in addition to** the existing per-version native wheels. This is the "best of both worlds" approach from the issue discussion:

- **Native wheels** (`cp311-cp311`, `cp312-cp312`, ...) — full-speed code, used whenever one matches your interpreter.
- **abi3 wheel** (`cp311-abi3`) — runs on any CPython ≥ 3.11. pip/uv only fall back to it when no native wheel matches, e.g. on a brand-new CPython release before its native wheels are published.

## How

- **`Cargo.toml`** — opt-in `abi3 = ["pyo3/abi3-py311"]` feature. The default build is untouched and still emits version-specific native wheels; abi3 is strictly opt-in.
- **`.github/workflows/pypi.yml`** — three new jobs (`build_linux_abi3_wheels` for manylinux + musllinux, `build_macos_abi3_wheels`, `build_windows_abi3_wheels`), each building one `cp311-abi3` wheel per platform/arch. The feature is forwarded to maturin via `MATURIN_PEP517_ARGS="--features abi3"` (passed into the Linux container with `CIBW_ENVIRONMENT_PASS_LINUX`; inherited from host env on macOS/Windows so the existing PATH / deployment-target config is left intact). All three feed `upload_to_pypi`.
- **`docs/releases/unreleased.md`** — changelog entry.

The abi3 wheel is built with the oldest supported interpreter (3.11), per the cibuildwheel/PyO3 convention — the `abi3-py311` floor fixes the wheel's compatibility regardless of build interpreter, and building against the oldest headers avoids accidentally pulling in a newer-only limited-API symbol.

## Verification (locally)

- **Compiles under abi3** — every raw `ffi::*` call in `vectordict.rs` (`PyDict_Next`, `PyNumber_*`, `PyFloat_AsDouble`, ...) is in the stable ABI, so `--features abi3` builds cleanly and maturin emits `river-0.25.0-cp311-abi3-*.whl`.
- **Runs on a newer interpreter** — installed the `cp311-abi3` wheel into a Python 3.13 venv; `import river`, the Rust submodules, a `RsQuantile` computation, and a pickle round-trip all work.
- **Default build unchanged** — a plain `maturin build` still produces `cp311-cp311` native wheels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)