### PR TITLE
ci: deny Rust warnings, run pyodide build only on demand

### DIFF
--- a/.github/workflows/test-for-pyodide.yml
+++ b/.github/workflows/test-for-pyodide.yml
@@ -1,10 +1,11 @@
 name: test-for-pyodide
 
+# Building the Pyodide (Emscripten) wheels is slow and rarely breaks, so we
+# don't run it on every PR/push. Trigger it manually before cutting a release
+# to confirm the wasm build still works. The release pipeline (pypi.yml) also
+# builds these wheels on tag push.
 on:
-  pull_request:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,12 @@ crate-type = ["cdylib", "rlib"]
 # per-version wheels are built without it for full-speed native code.
 abi3 = ["pyo3/abi3-py311"]
 
+# Treat warnings as hard errors so dead code, unused imports, etc. block the
+# build instead of scrolling past in CI logs. Applies to local `uv sync` /
+# `maturin develop` too, so issues surface before they reach CI.
+[lints.rust]
+warnings = "deny"
+
 [dependencies]
 pyo3 = "0.29.0"
 bincode = "1.3.3"

--- a/rust_src/vectordict.rs
+++ b/rust_src/vectordict.rs
@@ -82,10 +82,6 @@ impl VectorDict {
         !self.use_mask && !self.use_factory
     }
 
-    fn data_bound<'py>(&self, py: Python<'py>) -> Bound<'py, PyDict> {
-        self.data.bind(py).clone()
-    }
-
     /// `_get`: 0 (or default_factory()) for missing or masked keys.
     fn get_value<'py>(
         &self,


### PR DESCRIPTION
## What

Three CI/build-hygiene changes:

1. **Rust warnings are now hard errors.** Added `[lints.rust] warnings = "deny"` to `Cargo.toml`, so dead code, unused imports, etc. block the build instead of scrolling past in CI logs. Because it lives in `Cargo.toml` (not a CI-only `RUSTFLAGS`), it also fires during local `uv sync` / `maturin develop`, surfacing issues before they reach CI. The toolchain is pinned via `rust-toolchain.toml`, so `deny(warnings)` only changes behavior on a deliberate toolchain bump.

2. **Removed the unused `VectorDict::data_bound` method** in `rust_src/vectordict.rs`, which was emitting the `dead_code` warning that motivated point 1.

3. **Pyodide build runs on demand only.** `test-for-pyodide.yml` switches from `pull_request`/`push` triggers to `workflow_dispatch`. The Emscripten/wasm build is slow and rarely breaks, so it's now run manually before cutting a release. The release pipeline (`pypi.yml`) already builds the same pyodide wheels on tag push, so releases remain covered.

## Notes

- `cargo build --release` is clean with `deny(warnings)` in place.
- No changelog entry: these are CI/build-only changes with no end-user-facing effect.
- The `build-sdist` job in `code-quality.yml` was left untouched — it verifies the sdist is complete and buildable (compiles a wheel *from the sdist*), which the working-tree-based test jobs don't cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)