### PR TITLE
feat(anomaly): make OneClassSVM.learn_many dataframe-agnostic via narwhals

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -14,6 +14,8 @@
 
 - Added `anomaly.LODA`, an online implementation of Pevný's *Lightweight on-line detector of anomalies*. It maintains an ensemble of one-dimensional `sketch.Histogram`s over sparse random projections and scores samples by their average negative log-likelihood.
 
+- Made `anomaly.OneClassSVM.learn_many` dataframe-agnostic via narwhals: it now accepts any narwhals-supported eager backend (pandas, polars, pyarrow, ...) instead of only pandas. Outputs are unchanged.
+
 ## compose
 
 - `compose.Pipeline` now forwards extra keyword arguments (such as the timestamp `t` used by `utils.TimeRolling`, or a sample weight `w`) to each step whose method declares them, and drops them for steps that don't. This makes `feature_extraction.Agg`/`TargetAgg` backed by `utils.TimeRolling` work inside a pipeline via `model.learn_one(x, y, t=t)`. Routing applies to `learn_one` and to the predict-time methods (`predict_one`, `predict_proba_one`, `score_one`, `transform_one`), so it also works under `compose.learn_during_predict` where unsupervised steps learn during `predict_one(x, t=t)`. Fixes [#1600](https://github.com/online-ml/river/issues/1600). The accepted arguments are determined once when the pipeline plan is built, so pipelines with no extra arguments keep their previous speed.
@@ -70,6 +72,7 @@
 - Fixed `optim.AdaBound` raising `TypeError` after being cloned (its base learning rate was captured as a scheduler instead of a number), which broke it inside `evaluate`, ensembles, model selection, and anywhere else estimators are cloned.
 - Fixed `optim.NesterovMomentum` and `optim.FTRLProximal` raising when used to optimise estimators whose weights are stored as NumPy arrays, such as the factorization machines (`facto`).
 - Added a test covering every optimizer against every estimator that accepts one, so optimizer/estimator incompatibilities are caught going forward.
+- Fixed `optim.losses.Hinge.gradient` returning different values for single samples and numpy batches at the exact margin (`y * p == threshold`): the batch path used a strict `<` while the single-sample path used `<=`. Both now use `<=` (matching scikit-learn), so a point on the margin is treated as a violation and `learn_one`/`learn_many` agree. This only affects samples lying exactly on the margin.
 
 ## preprocessing
 

--- a/river/anomaly/svm.py
+++ b/river/anomaly/svm.py
@@ -103,8 +103,12 @@ class OneClassSVM(linear_model.base.GLM, anomaly.base.AnomalyDetector):
         super().learn_one(x, y=1)
 
     def learn_many(self, X):
-        pd = utils.pandas.import_pandas()
-        super().learn_many(X, y=pd.Series(True, index=X.index))
+        # The one-class SVM trains against a constant positive label, so the target series is just
+        # `1` repeated for every row. Build it with the same backend (and pandas index) as `X` so
+        # any narwhals-supported eager frame flows through, mirroring the GLM mini-batch boundary.
+        Xnw = utils.dataframe.into_frame(X)
+        y = utils.dataframe.to_native_series([1.0] * len(Xnw), name=None, like=Xnw)
+        super().learn_many(X, y=y)
 
     def score_one(self, x):
         return self._raw_dot_one(x) - self.intercept

--- a/river/anomaly/test_svm.py
+++ b/river/anomaly/test_svm.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
 import math
+import typing
 
 import pytest
 from sklearn import linear_model as sklm
 
 from river import anomaly, datasets, optim
+from river.conftest import FRAME_BACKENDS
+
+if typing.TYPE_CHECKING:
+    from typing import Any
+
+    from river.conftest import FrameBackend
 
 tests = {
     "Vanilla": (
@@ -36,3 +43,73 @@ def test_sklearn_coherence(river_params, sklearn_params):
 
     for i, w in enumerate(rv.weights.values()):
         assert math.isclose(w, sk.coef_[i])
+
+
+# Dataframe-agnostic mini-batching (narwhals): pandas, polars and pyarrow
+
+
+def _columnar(n: int = 80) -> tuple[dict[str, list[Any]], list[dict[str, Any]]]:
+    """Materialise a dataset into ({column: values}, [feature dicts])."""
+    feats = [x for x, _ in datasets.Phishing().take(n)]
+    cols = list(feats[0])
+    data = {c: [f[c] for f in feats] for c in cols}
+    return data, feats
+
+
+def test_learn_many_is_backend_agnostic(frame_backend: FrameBackend) -> None:
+    """`learn_many` must produce identical weights regardless of the input backend."""
+
+    data, _ = _columnar()
+
+    pandas = FRAME_BACKENDS["pandas"]()
+    reference = anomaly.OneClassSVM()
+    reference.learn_many(pandas.frame(data))
+
+    model = anomaly.OneClassSVM()
+    model.learn_many(frame_backend.frame(data))
+
+    assert model.weights.keys() == reference.weights.keys()
+    for key, weight in reference.weights.items():
+        assert math.isclose(model.weights[key], weight, rel_tol=1e-12, abs_tol=1e-12)
+    assert math.isclose(model.intercept, reference.intercept, rel_tol=1e-12, abs_tol=1e-12)
+
+
+def test_learn_many_matches_learn_one(frame_backend: FrameBackend) -> None:
+    """Row-by-row `learn_many` must match `learn_one` on every backend.
+
+    With a single-row batch the mean gradient reduces to the one-sample gradient, so the two
+    APIs are numerically identical -- but only because the `Hinge` gradient now resolves the
+    margin boundary the same way in its scalar and vectorised branches (the very first sample
+    sits exactly on the margin, since `intercept_init=1.0` and the weights start at zero).
+    """
+
+    data, feats = _columnar()
+
+    one = anomaly.OneClassSVM()
+    for x in feats:
+        one.learn_one(x)
+
+    many = anomaly.OneClassSVM()
+    for i in range(len(feats)):
+        many.learn_many(frame_backend.frame({c: [data[c][i]] for c in data}))
+
+    for key in one.weights:
+        assert math.isclose(many.weights[key], one.weights[key], rel_tol=1e-9)
+    assert math.isclose(many.intercept, one.intercept, rel_tol=1e-9)
+
+
+def test_learn_many_preserves_pandas_index() -> None:
+    """A pandas input still learns correctly when it carries a non-default index."""
+    import pandas as pd
+
+    data, _ = _columnar(20)
+    index = list(range(100, 100 + len(next(iter(data.values())))))
+
+    default = anomaly.OneClassSVM()
+    default.learn_many(pd.DataFrame(data))
+
+    reindexed = anomaly.OneClassSVM()
+    reindexed.learn_many(pd.DataFrame(data, index=index))
+
+    for key, weight in default.weights.items():
+        assert math.isclose(reindexed.weights[key], weight, rel_tol=1e-12, abs_tol=1e-12)

--- a/river/optim/losses.py
+++ b/river/optim/losses.py
@@ -8,10 +8,6 @@ Several losses are piecewise (`Hinge`, `Absolute`, `EpsilonInsensitiveHinge`, `H
 their gradient is discontinuous at a kink. The invariant we hold everywhere is that the scalar and
 vectorised branches of a loss **must** resolve such a boundary point identically; otherwise looping
 `learn_one` and a single `learn_many` call would disagree on inputs that land exactly on the kink.
-The tie itself is broken following each loss's standard (scikit-learn) definition: in particular
-`Hinge` treats a point sitting exactly on the margin as a violation (active piece, gradient `-y`),
-matching scikit-learn's `dloss`, so both branches use ``<=``. `test_loss_boundary_scalar_array_agree`
-guards this agreement at the exact kinks.
 
 """
 

--- a/river/optim/losses.py
+++ b/river/optim/losses.py
@@ -2,6 +2,17 @@
 
 Each loss function is intended to work with both single values as well as numpy vectors.
 
+Boundary convention
+-------------------
+Several losses are piecewise (`Hinge`, `Absolute`, `EpsilonInsensitiveHinge`, `Huber`, ...), so
+their gradient is discontinuous at a kink. The invariant we hold everywhere is that the scalar and
+vectorised branches of a loss **must** resolve such a boundary point identically; otherwise looping
+`learn_one` and a single `learn_many` call would disagree on inputs that land exactly on the kink.
+The tie itself is broken following each loss's standard (scikit-learn) definition: in particular
+`Hinge` treats a point sitting exactly on the margin as a violation (active piece, gradient `-y`),
+matching scikit-learn's `dloss`, so both branches use ``<=``. `test_loss_boundary_scalar_array_agree`
+guards this agreement at the exact kinks.
+
 """
 
 from __future__ import annotations
@@ -249,8 +260,12 @@ class Hinge(BinaryLoss):
     def gradient(self, y_true, y_pred):
         y_true = y_true * 2 - 1  # [0, 1] -> [-1, 1]
 
+        # Boundary convention (see module docstring): a point sitting exactly on the margin
+        # (`y_true * y_pred == threshold`) is treated as a violation, so both branches use `<=`.
+        # This matches scikit-learn's hinge `dloss` and keeps the scalar and vectorised paths
+        # identical, so `learn_one` and `learn_many` agree.
         if isinstance(y_true, np.ndarray):
-            return np.where(y_true * y_pred < self.threshold, -y_true, 0)
+            return np.where(y_true * y_pred <= self.threshold, -y_true, 0)
 
         if y_true * y_pred <= self.threshold:
             return -y_true

--- a/river/optim/test_.py
+++ b/river/optim/test_.py
@@ -36,6 +36,47 @@ def test_loss_batch_online_equivalence(loss):
         assert math.isclose(loss.gradient(yt, yp), g, abs_tol=1e-9)
 
 
+# Each tuple is (loss, y_true, y_pred) with y_pred sitting *exactly* on one of the loss's kinks.
+# The scalar and vectorised gradient branches must agree there (see the boundary convention in
+# `river/optim/losses.py`). These values are all exactly representable in float64, so the `==`
+# comparisons inside the losses really do fire on the boundary.
+LOSS_BOUNDARY_CASES = [
+    # Hinge margin: y_true is remapped to {-1, 1}; the kink is at y_true' * y_pred == threshold.
+    (optim.losses.Hinge(), 1, 1.0),  # y_true' = +1, kink at p = 1
+    (optim.losses.Hinge(), 0, -1.0),  # y_true' = -1, kink at p = -1
+    (optim.losses.Hinge(threshold=0.0), 1, 0.0),  # Perceptron-style margin at 0
+    # Absolute value: kink at y_pred == y_true.
+    (optim.losses.Absolute(), 1, 1.0),
+    (optim.losses.Absolute(), 0, 0.0),
+    # Epsilon-insensitive tube edges (y_true remapped to {-1, 1}): p == y_true' ± eps.
+    (optim.losses.EpsilonInsensitiveHinge(eps=0.5), 1, 1.5),
+    (optim.losses.EpsilonInsensitiveHinge(eps=0.5), 1, 0.5),
+    # Huber transition: |y_pred - y_true| == epsilon.
+    (optim.losses.Huber(epsilon=0.5), 1, 1.5),
+    (optim.losses.Huber(epsilon=0.5), 1, 0.5),
+    # Quantile pinball kink at y_pred == y_true.
+    (optim.losses.Quantile(0.5), 1, 1.0),
+]
+
+
+@pytest.mark.parametrize(
+    "loss, y_true, y_pred",
+    [
+        pytest.param(loss, yt, yp, id=f"{loss.__class__.__name__}-{yt}-{yp}")
+        for loss, yt, yp in LOSS_BOUNDARY_CASES
+    ],
+)
+def test_loss_boundary_scalar_array_agree(loss, y_true, y_pred):
+    """A point exactly on a kink must get the same gradient from both code paths.
+
+    Random sweeps (see `test_loss_batch_online_equivalence`) practically never land on a
+    boundary, so this pins the convention that makes `learn_one` and `learn_many` identical.
+    """
+    scalar = loss.gradient(y_true, y_pred)
+    array = loss.gradient(np.array([y_true], dtype=float), np.array([y_pred], dtype=float))[0]
+    assert math.isclose(scalar, array, abs_tol=1e-12)
+
+
 def optimizers() -> typing.Iterable[optim.base.Optimizer]:
     for _, optimizer in inspect.getmembers(
         importlib.import_module("river.optim"),


### PR DESCRIPTION
## What

Brings `anomaly.OneClassSVM` in line with the GLM-based linear models, which already do dataframe-agnostic mini-batching via [narwhals](https://github.com/narwhals-dev/narwhals).

### `OneClassSVM.learn_many` is now backend-agnostic

`learn_many` previously hard-coded a `pandas.Series` for its constant positive target (`pd.Series(True, index=X.index)`), which broke on any non-pandas frame. It now builds that target with the *input frame's own backend* (and pandas index), so pandas, polars, pyarrow, and pandas[nullable]/[pyarrow] all flow through. Outputs are unchanged.

### Fixed a scalar/batch mismatch in `Hinge.gradient`

While reviewing the implementation I found that `optim.losses.Hinge.gradient` disagreed between its scalar and numpy-batch branches **at the exact margin** (`y * p == threshold`): the batch path used a strict `<`, the single-sample path used `<=`. Because `OneClassSVM` sets `intercept_init=1.0` with zero-initialised weights, the very first sample sits exactly on the margin — so looping `learn_one` and a single-row `learn_many` diverged from row one and never reconverged.

Both branches now use `<=`, matching scikit-learn's hinge `dloss` (a point on the margin is a violation). This is also the convention River's already-validated scalar path and the OCSVM/GLM sklearn-coherence tests are pinned to, so aligning the batch path is the safe direction.

The agreed convention (documented in `losses.py`): **a loss's scalar and vectorised branches must resolve a kink identically**, so `learn_one`/`learn_many` never disagree on a point lying exactly on it. I audited every piecewise loss — `Absolute`, `EpsilonInsensitiveHinge`, `Huber`, `Quantile` were already consistent; `Hinge` was the only violation.

## Tests

- `anomaly/test_svm.py`: `learn_many` is backend-agnostic (all 5 backends → identical weights/intercept), preserves a non-default pandas index, and matches a `learn_one` loop row-by-row.
- `optim/test_.py`: `test_loss_boundary_scalar_array_agree` probes each piecewise loss at its *exact* kink — the existing random sweep never lands there, which is how the `Hinge` mismatch hid.

384 tests pass across `optim`, `linear_model`, `anomaly`, and the optimizer/estimator-compat suite; mypy and ruff clean.

## Note

The multi-row-batch averaging difference between `learn_one` and `learn_many` remains (a single mean-gradient step ≠ N sequential steps) — that's the target of the per-sample-SGD refactor in #1912, which I've commented on with these findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)