### PR TITLE
feat(multiclass): dataframe-agnostic OneVsRestClassifier mini-batching via narwhals

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -51,6 +51,10 @@
 - `linear_model.LinearRegression` and `linear_model.LogisticRegression` mini-batch methods (`learn_many`, `predict_many`, `predict_proba_many`) now accept and return any [narwhals](https://github.com/narwhals-dev/narwhals)-supported eager backend (pandas, polars, pyarrow, ...) instead of being pandas-only. The input backend is preserved on output, including the pandas index. These methods no longer require `pandas` to be installed.
 - `linear_model.BayesianLinearRegression` is now a `MiniBatchRegressor`: it gained a `learn_many` method, equivalent to looping `learn_one` over the rows (exact without smoothing, and the matching closed-form geometric weighting with smoothing). Its `learn_many`/`predict_many` accept and return any [narwhals](https://github.com/narwhals-dev/narwhals)-supported eager backend (pandas, polars, pyarrow, ...), preserving the input backend and pandas index, and no longer require `pandas`.
 
+## multiclass
+
+- `multiclass.OneVsRestClassifier` mini-batch methods (`learn_many`, `predict_many`, `predict_proba_many`) now accept and return any [narwhals](https://github.com/narwhals-dev/narwhals)-supported eager backend (pandas, polars, pyarrow, ...) instead of being pandas-only. The input backend is preserved on output, including the pandas index, and these methods no longer require `pandas` to be installed. Outputs are unchanged on the pandas path.
+
 ## multioutput
 
 - Added `multioutput.PerOutputClassifier`, the streaming equivalent of scikit-learn's `MultiOutputClassifier`. Trains one independent classifier per target output.

--- a/river/multiclass/ovr.py
+++ b/river/multiclass/ovr.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import typing
 
+import narwhals.stable.v2 as nw
+import numpy as np
+
 from river import base, linear_model, utils
 
 if typing.TYPE_CHECKING:
-    pass
+    from narwhals.stable.v2.typing import IntoDataFrame, IntoSeries
 
 __all__ = ["OneVsRestClassifier"]
 
@@ -56,19 +59,36 @@ class OneVsRestClassifier(base.Wrapper, base.Classifier):
     >>> evaluate.progressive_val_score(dataset, model, metric)
     MacroF1: 77.46%
 
-    This estimator also also supports mini-batching.
+    This estimator also supports mini-batching. The whole pipeline — the `StandardScaler` and the
+    one-vs-rest `LogisticRegression`s — is trained and queried on mini-batches of a dataframe:
+
+    >>> model = preprocessing.StandardScaler() | multiclass.OneVsRestClassifier(
+    ...     linear_model.LogisticRegression()
+    ... )
+
+    >>> metric = metrics.MacroF1()
 
     >>> for X in pd.read_csv(dataset.path, chunksize=64):
     ...     y = X.pop('category')
     ...     y_pred = model.predict_many(X)
     ...     model.learn_many(X, y)
+    ...     for y_true, y_p in zip(y, y_pred):
+    ...         if y_p is not None:
+    ...             metric.update(y_true, y_p)
+
+    >>> metric
+    MacroF1: 59.77%
+
+    The mini-batch methods are dataframe-agnostic: any narwhals-supported eager backend
+    (pandas, polars, pyarrow, ...) can be passed to `learn_many`/`predict_many`, and the
+    predictions are returned in that same backend.
 
     """
 
     def __init__(self, classifier: base.Classifier):
         self.classifier = classifier
         self.classifiers: dict[base.typing.ClfTarget, base.Classifier] = {}
-        self._y_name = None
+        self._y_name: str | None = None
 
     @property
     def _wrapped_model(self):
@@ -104,29 +124,64 @@ class OneVsRestClassifier(base.Wrapper, base.Classifier):
             return {label: votes / total for label, votes in y_pred.items()}
         return {label: 1 / len(y_pred) for label in y_pred}
 
-    def learn_many(self, X, y, **kwargs):
-        self._y_name = y.name
+    def learn_many(self, X: IntoDataFrame, y: IntoSeries, **kwargs) -> None:
+        # narwhals at the boundary: the per-label target is a boolean series built with the input
+        # series' own backend, so each binary sub-classifier sees a native series it understands.
+        ynw = utils.dataframe.into_series(y)
+        self._y_name = ynw.name
 
-        # Instantiate a new binary classifier for the classes that have not yet been seen
-        for label in y.unique():
+        # Instantiate a new binary classifier for the classes that have not yet been seen. The
+        # appearance order is preserved so the class set matches the single-instance path.
+        for label in ynw.unique(maintain_order=True).to_list():
             if label not in self.classifiers:
                 self.classifiers[label] = self.classifier.clone()
 
-        # Train each label's associated classifier
+        # Train each label's associated classifier against the one-vs-rest boolean target.
         for label, model in self.classifiers.items():
-            model.learn_many(X, y == label, **kwargs)
+            typing.cast("base.MiniBatchClassifier", model).learn_many(
+                X, (ynw == label).to_native(), **kwargs
+            )
 
-    def predict_proba_many(self, X, **kwargs):
-        pd = utils.pandas.import_pandas()
-        y_pred = pd.DataFrame(columns=self.classifiers.keys(), index=X.index)
+    def _positive_probas(
+        self, X, **kwargs
+    ) -> tuple[nw.DataFrame[IntoDataFrame], list[base.typing.ClfTarget], np.ndarray]:
+        """Return ``(Xnw, labels, P)`` with the raw positive-class probabilities.
 
-        for label, clf in self.classifiers.items():
-            y_pred[label] = clf.predict_proba_many(X, **kwargs)[True]
+        Column ``j`` of ``P`` is the (un-normalised) probability that ``labels[j]`` is the
+        positive class. Each binary sub-classifier exposes that probability under the ``True``
+        column, which narwhals reports as the boolean ``True`` on pandas and the string
+        ``"True"`` elsewhere; either way ``str(column) == "True"`` locates it (selecting by a
+        boolean key is rejected by narwhals, so the column is taken positionally).
+        """
+        Xnw = utils.dataframe.into_frame(X)
+        labels = list(self.classifiers)
+        columns = []
+        for clf in self.classifiers.values():
+            proba = utils.dataframe.into_frame(
+                typing.cast("base.MiniBatchClassifier", clf).predict_proba_many(X, **kwargs)
+            )
+            positive = next(j for j, col in enumerate(proba.columns) if str(col) == "True")
+            columns.append(utils.dataframe.to_numpy(proba)[:, positive])
 
-        return y_pred.div(y_pred.sum(axis="columns"), axis="rows")
+        P = np.column_stack(columns) if columns else np.empty((len(Xnw), 0))
+        return Xnw, labels, P
 
-    def predict_many(self, X, **kwargs):
-        pd = utils.pandas.import_pandas()
-        if not self.classifiers:
-            return pd.Series([None] * len(X), index=X.index, dtype="object")
-        return self.predict_proba_many(X, **kwargs).idxmax(axis="columns").rename(self._y_name)
+    def predict_proba_many(self, X: IntoDataFrame, **kwargs) -> IntoDataFrame:
+        Xnw, labels, P = self._positive_probas(X, **kwargs)
+        totals = P.sum(axis=1, keepdims=True)
+        # Normalise each row to sum to 1. `where` leaves all-zero rows as NaN — matching the old
+        # pandas `df.div(df.sum(axis="columns"))` — without triggering a divide-by-zero warning.
+        P = np.divide(P, totals, out=np.full_like(P, np.nan), where=totals != 0)
+        return utils.dataframe.to_native_frame(
+            {label: P[:, j] for j, label in enumerate(labels)}, like=Xnw
+        )
+
+    def predict_many(self, X: IntoDataFrame, **kwargs) -> IntoSeries:
+        Xnw, labels, P = self._positive_probas(X, **kwargs)
+        if not labels:
+            return utils.dataframe.to_native_series([None] * len(Xnw), name=self._y_name, like=Xnw)
+        # Row-normalisation scales every class by the same per-row constant, so the winner is the
+        # same as over the raw probabilities. `argmax` breaks ties on the first column, matching
+        # the old pandas `idxmax(axis="columns")`.
+        winners = [labels[int(i)] for i in np.argmax(P, axis=1)]
+        return utils.dataframe.to_native_series(winners, name=self._y_name, like=Xnw)

--- a/river/multiclass/test_ovr.py
+++ b/river/multiclass/test_ovr.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
+import typing
+
+import narwhals.stable.v2 as nw
+import numpy as np
 import pandas as pd
 
 from river import datasets, linear_model, metrics, multiclass, preprocessing, stream
+
+if typing.TYPE_CHECKING:
+    from river.conftest import FrameBackend
 
 
 def test_online_batch_consistent():
@@ -50,3 +57,70 @@ def test_online_batch_consistent():
             break
 
     assert online_metric.get() == batch_metric.get()
+
+
+# `OneVsRestClassifier`'s mini-batch methods are routed through narwhals. These tests pin that
+# `learn_many`/`predict_many`/`predict_proba_many` behave identically on every dataframe backend,
+# using the pandas path as the oracle.
+
+
+def _multiclass_batch(n: int = 90) -> tuple[dict[str, list[float]], list[str]]:
+    """A reproducible, linearly-separable-ish 3-class batch as (feature columns, labels)."""
+    rng = np.random.RandomState(42)
+    classes = ["cat", "dog", "fish"]
+    y = [classes[i % 3] for i in range(n)]
+    offset = {"cat": 0.0, "dog": 4.0, "fish": -4.0}
+    data = {
+        "a": [rng.normal(offset[label], 1.0) for label in y],
+        "b": [rng.normal(-offset[label], 1.0) for label in y],
+    }
+    return data, y
+
+
+def test_ovr_predict_many_backend_agnostic(frame_backend: FrameBackend) -> None:
+    """`predict_many` returns the same labels (and series name) on every backend."""
+    data, y = _multiclass_batch()
+
+    reference = multiclass.OneVsRestClassifier(linear_model.LogisticRegression())
+    reference.learn_many(pd.DataFrame(data), pd.Series(y, name="category"))
+    expected = nw.from_native(
+        reference.predict_many(pd.DataFrame(data)), series_only=True
+    ).to_list()
+
+    model = multiclass.OneVsRestClassifier(linear_model.LogisticRegression())
+    model.learn_many(frame_backend.frame(data), frame_backend.series(y, name="category"))
+    got = nw.from_native(model.predict_many(frame_backend.frame(data)), series_only=True).to_list()
+
+    assert got == expected
+
+
+def test_ovr_predict_proba_many_backend_agnostic(frame_backend: FrameBackend) -> None:
+    """`predict_proba_many` yields the same per-class probabilities on every backend."""
+    data, y = _multiclass_batch()
+
+    reference = multiclass.OneVsRestClassifier(linear_model.LogisticRegression())
+    reference.learn_many(pd.DataFrame(data), pd.Series(y, name="category"))
+    expected = nw.from_native(reference.predict_proba_many(pd.DataFrame(data)), eager_only=True)
+
+    model = multiclass.OneVsRestClassifier(linear_model.LogisticRegression())
+    model.learn_many(frame_backend.frame(data), frame_backend.series(y, name="category"))
+    got = nw.from_native(model.predict_proba_many(frame_backend.frame(data)), eager_only=True)
+
+    # Columns are the class labels; non-pandas backends stringify them, so align by string name.
+    for label in expected.columns:
+        got_col = np.asarray(got[str(label)].to_numpy(), dtype=float)
+        np.testing.assert_allclose(
+            got_col, np.asarray(expected[label].to_numpy(), dtype=float), atol=1e-9
+        )
+
+
+def test_ovr_predict_many_returns_native_backend(frame_backend: FrameBackend) -> None:
+    """The prediction series is rebuilt in the caller's own backend."""
+    data, y = _multiclass_batch()
+    native = frame_backend.frame(data)
+
+    model = multiclass.OneVsRestClassifier(linear_model.LogisticRegression())
+    model.learn_many(native, frame_backend.series(y, name="category"))
+    out = model.predict_many(native)
+
+    assert type(out) is type(frame_backend.series(y, name="category"))


### PR DESCRIPTION
## Motivation

Part of #1919 (migrate all `_many` methods to narwhals). Makes `multiclass.OneVsRestClassifier`'s mini-batch methods dataframe-agnostic, so it can be trained/queried on any narwhals-supported eager backend (pandas, polars, pyarrow, ...). The input backend (and pandas index) is preserved on output, and `pandas` is no longer required.

## Changes

- **`learn_many`** builds the per-label one-vs-rest boolean target with the input series' own backend, so each binary sub-classifier receives a native series. Classes are registered in appearance order (`maintain_order=True`), matching `learn_one`.
- The positive-class column is located by `str(col) == "True"` — narwhals reports it as the boolean `True` on pandas and the string `"True"` elsewhere, and rejects selecting columns by a boolean key.
- **`predict_proba_many`** normalises rows with a NaN-preserving `np.divide(..., where=totals != 0)`, matching the old pandas `df.div(df.sum(axis="columns"))` exactly (zero-sum rows → NaN) without a divide-by-zero warning.
- **`predict_many`** takes `argmax` over the *raw* positive-class probabilities (row-normalisation can't change the winner), with first-column tie-breaking like pandas `idxmax(axis="columns")`.

Outputs are unchanged on the pandas path.

## Tests & docs

- Multi-backend tests via the `frame_backend` fixture (predicted labels, per-class probabilities, native-backend round-trip), with pandas as the oracle.
- Added a mini-batch pipeline example (`StandardScaler | OneVsRestClassifier(LogisticRegression)`) to the docstring.
- All multiclass tests + 166 OvR estimator-checks pass; mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)