### PR TITLE
perf(utils, preprocessing): Build native frames directly from 2D numpy, simplify `StandardScaler`

### DIFF
--- a/river/preprocessing/scale.py
+++ b/river/preprocessing/scale.py
@@ -12,7 +12,8 @@ import numpy as np
 from river import base, stats, utils
 
 if typing.TYPE_CHECKING:
-    import pandas as pd
+    from collections.abc import Mapping
+
     from narwhals.stable.v2.typing import IntoDataFrame, IntoDataFrameT
 
 __all__ = [
@@ -24,6 +25,17 @@ __all__ = [
     "RobustScaler",
     "StandardScaler",
 ]
+
+NW_TO_NP_DTYPES: Mapping[nw.dtypes.DType, np.number] = {
+    nw.Int8(): np.float16(),
+    nw.Int16(): np.float32(),
+    nw.Int32(): np.float64(),
+    nw.UInt8(): np.float16(),
+    nw.UInt16(): np.float32(),
+    nw.UInt32(): np.float64(),
+    nw.Float32(): np.float32(),
+    nw.Float64(): np.float64(),
+}
 
 
 def safe_div(a, b):
@@ -359,10 +371,11 @@ class StandardScaler(base.MiniBatchTransformer):
     def transform_many(self, X: IntoDataFrameT) -> IntoDataFrameT:
         """Scale a mini-batch of features.
 
-        Classic numpy-backed pandas keeps the historical fast path, which preserves the input's
-        float dtype (e.g. ``float32`` stays ``float32``). Every other narwhals-supported backend
-        (polars, pyarrow, nullable/arrow-backed pandas, ...) is scaled through a backend-agnostic
-        path whose compute runs in ``float64``.
+        Every narwhals-supported backend (pandas, polars, pyarrow, nullable/arrow-backed
+        pandas, ...) takes the same backend-agnostic path. The compute dtype is inferred from
+        the input schema, so a feature's float dtype is preserved (e.g. ``float32`` stays
+        ``float32``); integer columns are widened to the matching float and anything else falls
+        back to ``float64``.
 
         Parameters
         ----------
@@ -372,62 +385,26 @@ class StandardScaler(base.MiniBatchTransformer):
 
         """
         Xnw = utils.dataframe.into_frame(X)
-        # The fast path relies on `.values` yielding a numeric numpy view, which only holds for
-        # classic numpy-backed pandas; nullable/arrow-backed pandas return object arrays and so
-        # take the agnostic path alongside polars/pyarrow.
-        if Xnw.implementation.is_pandas() and all(
-            isinstance(dtype, np.dtype) for dtype in typing.cast("pd.DataFrame", X).dtypes
-        ):
-            native = self._transform_many_pandas(typing.cast("pd.DataFrame", X))
-        else:
-            native = self._transform_many_narwhals(Xnw)
-        return typing.cast("IntoDataFrameT", native)
-
-    def _transform_many_pandas(self, X: pd.DataFrame) -> pd.DataFrame:
-        pd = utils.pandas.import_pandas()
-        # Determine dtype of input
-        dtypes = X.dtypes.unique()
-        dtype = dtypes[0] if len(dtypes) == 1 else np.float64
-
-        # Check if the dtype is integer type and convert to corresponding float type
-        if np.issubdtype(dtype, np.integer):
-            bytes_size = dtype.itemsize
-            dtype = np.dtype(f"float{bytes_size * 8}")  # type: ignore[operator]
+        schema = Xnw.schema
+        columns = schema.names()
+        dtypes = {NW_TO_NP_DTYPES.get(dtype, np.float64()) for dtype in schema.dtypes()}
+        dtype = np.result_type(*dtypes)
 
         if self.window_size is None:
-            means = np.array([self.means[c] for c in X.columns], dtype=dtype)
+            means = np.array([self.means[c] for c in columns], dtype=dtype)
         else:
-            means = np.array([self.means[c].get() for c in X.columns], dtype=dtype)
-        Xt = X.values - means
+            means = np.array([self.means[c].get() for c in columns], dtype=dtype)
+
+        Xt = utils.dataframe.to_numpy(Xnw, dtype=dtype) - means
 
         if self.with_std:
             if self.window_size is None:
-                stds = np.array([self.vars[c] ** 0.5 for c in X.columns], dtype=dtype)
+                stds = np.array([self.vars[c] ** 0.5 for c in columns], dtype=dtype)
             else:
-                stds = np.array([self.vars[c].get() ** 0.5 for c in X.columns], dtype=dtype)
+                stds = np.array([self.vars[c].get() ** 0.5 for c in columns], dtype=dtype)
             np.divide(Xt, stds, where=stds > 0, out=Xt)
 
-        return pd.DataFrame(Xt, index=X.index, columns=X.columns, copy=False)
-
-    def _transform_many_narwhals(self, Xnw: nw.DataFrame[IntoDataFrameT]) -> IntoDataFrameT:
-        columns = Xnw.columns
-
-        if self.window_size is None:
-            means = np.array([self.means[c] for c in columns], dtype=np.float64)
-        else:
-            means = np.array([self.means[c].get() for c in columns], dtype=np.float64)
-        Xt = utils.dataframe.to_numpy(Xnw) - means
-
-        if self.with_std:
-            if self.window_size is None:
-                stds = np.array([self.vars[c] ** 0.5 for c in columns], dtype=np.float64)
-            else:
-                stds = np.array([self.vars[c].get() ** 0.5 for c in columns], dtype=np.float64)
-            np.divide(Xt, stds, where=stds > 0, out=Xt)
-
-        native = utils.dataframe.to_native_frame(
-            {col: Xt[:, j] for j, col in enumerate(columns)}, like=Xnw
-        )
+        native = utils.dataframe.to_native_frame(Xt, columns=columns, like=Xnw)
         return typing.cast("IntoDataFrameT", native)
 
 

--- a/river/preprocessing/test_scale.py
+++ b/river/preprocessing/test_scale.py
@@ -538,10 +538,10 @@ def test_issue_1313():
     """
 
 
-# `StandardScaler`'s mini-batch path is routed through narwhals: classic numpy-backed pandas keeps
-# the historical fast path (preserving its float dtype), while every other backend is scaled
-# through a backend-agnostic float64 path. These tests pin the cross-backend behaviour, using the
-# pandas path as the oracle.
+# `StandardScaler`'s mini-batch path is routed through narwhals: every backend takes the same
+# backend-agnostic path, which infers the compute dtype from the input schema and so preserves the
+# input's float dtype. These tests pin the cross-backend behaviour, using the pandas path as the
+# oracle.
 
 
 def _numeric_batch(n: int = 40) -> dict[str, list[float]]:

--- a/river/utils/dataframe.py
+++ b/river/utils/dataframe.py
@@ -40,7 +40,7 @@ __all__ = [
 ]
 
 
-def to_numpy(frame: nw.DataFrame[Any]) -> NDArray[np.float64]:
+def to_numpy(frame: nw.DataFrame[Any], dtype: np.number = np.float64) -> NDArray[np.number]:
     """Extract a `float64` numpy matrix from a narwhals dataframe for the numpy compute core.
 
     A pandas frame backed by pyarrow (`ArrowDtype`) columns returns an ``object`` array from
@@ -48,7 +48,7 @@ def to_numpy(frame: nw.DataFrame[Any]) -> NDArray[np.float64]:
     not support argument 0 of type float"*). Coercing to ``float64`` at the boundary keeps the
     core backend-agnostic; ``np.asarray`` is a no-op when the frame already yields ``float64``.
     """
-    return np.asarray(frame.to_numpy(), dtype=np.float64)
+    return np.asarray(frame.to_numpy(), dtype=dtype)
 
 
 def into_frame(X: IntoDataFrameT) -> nw.DataFrame[IntoDataFrameT]:
@@ -89,8 +89,26 @@ def to_native_series(
     return typing.cast("IntoSeries", native)
 
 
+@typing.overload
 def to_native_frame(
-    data: Mapping[Any, NDArray[Any] | Sequence[Any]], *, like: nw.DataFrame[Any]
+    data: Mapping[Any, NDArray[Any] | Sequence[Any]],
+    *,
+    like: nw.DataFrame[Any],
+    columns: None = None,
+) -> IntoDataFrame: ...
+
+
+@typing.overload
+def to_native_frame(
+    data: NDArray[Any], *, like: nw.DataFrame[Any], columns: Sequence[Any]
+) -> IntoDataFrame: ...
+
+
+def to_native_frame(
+    data: Mapping[Any, NDArray[Any] | Sequence[Any]] | NDArray[Any],
+    *,
+    like: nw.DataFrame[Any],
+    columns: Sequence[Any] | None = None,
 ) -> IntoDataFrame:
     """Build a native dataframe matching the backend (and pandas index) of `like`.
 
@@ -101,16 +119,28 @@ def to_native_frame(
     Parameters
     ----------
     data
-        A mapping from column label to column values (numpy arrays from the numpy core).
+        Either a mapping from column label to column values, or a single 2D numpy array. The
+        array form takes the fast `narwhals.from_numpy` path (no per-column slicing) and
+        requires `columns` to name its columns.
     like
         The narwhals dataframe the call received as input. Its backend determines the
         return type, and its index (pandas only) is carried over to the result.
+    columns
+        Column labels for the array form of `data`. Ignored when `data` is a mapping.
 
     """
     impl = like.implementation
-    if not impl.is_pandas_like():
-        data = {str(key): value for key, value in data.items()}
-    frame = nw.from_dict(data, backend=impl).to_native()
+    if isinstance(data, np.ndarray):
+        if columns is None:
+            raise ValueError("`columns` must be provided when `data` is a numpy array.")
+        # narwhals requires string column names for non-pandas backends; pandas keeps the
+        # original labels (mirroring the mapping path above).
+        names = list(columns) if impl.is_pandas_like() else [str(col) for col in columns]
+        frame = nw.from_numpy(data, schema=names, backend=impl).to_native()
+    else:
+        if not impl.is_pandas_like():
+            data = {str(key): value for key, value in data.items()}
+        frame = nw.from_dict(data, backend=impl).to_native()
     # Carry over the pandas index; no-op for non-pandas backends (maybe_get_index -> None).
     if (index := nw.maybe_get_index(like)) is not None:
         frame.index = index
@@ -146,9 +176,9 @@ def sparse_to_native_frame(
         ns = nw.get_native_namespace(like)
         frame = ns.DataFrame.sparse.from_spmatrix(matrix, columns=list(columns))
     else:
-        dense = matrix.toarray()
-        data = {str(col): dense[:, j] for j, col in enumerate(columns)}
-        frame = nw.from_dict(data, backend=impl).to_native()
+        dense = typing.cast("NDArray[Any]", matrix.toarray())
+        schema = [str(col) for col in columns]
+        frame = nw.from_numpy(dense, schema=schema, backend=impl).to_native()
     # Carry over the pandas index; no-op for non-pandas backends (maybe_get_index -> None).
     if (index := nw.maybe_get_index(like)) is not None:
         frame.index = index

--- a/river/utils/dataframe.py
+++ b/river/utils/dataframe.py
@@ -27,7 +27,7 @@ if typing.TYPE_CHECKING:
         IntoSeries,
         IntoSeriesT,
     )
-    from numpy.typing import NDArray
+    from numpy.typing import DTypeLike, NDArray
     from scipy import sparse
 
 __all__ = [
@@ -40,13 +40,14 @@ __all__ = [
 ]
 
 
-def to_numpy(frame: nw.DataFrame[Any], dtype: np.number = np.float64) -> NDArray[np.number]:
-    """Extract a `float64` numpy matrix from a narwhals dataframe for the numpy compute core.
+def to_numpy(frame: nw.DataFrame[Any], dtype: DTypeLike = np.float64) -> NDArray[Any]:
+    """Extract a numpy matrix from a narwhals dataframe for the numpy compute core.
 
     A pandas frame backed by pyarrow (`ArrowDtype`) columns returns an ``object`` array from
     ``.to_numpy()``, which breaks downstream ufuncs (e.g. ``np.exp`` raises *"loop of ufunc does
-    not support argument 0 of type float"*). Coercing to ``float64`` at the boundary keeps the
-    core backend-agnostic; ``np.asarray`` is a no-op when the frame already yields ``float64``.
+    not support argument 0 of type float"*). Coercing to a floating ``dtype`` (``float64`` by
+    default) at the boundary keeps the core backend-agnostic; ``np.asarray`` is a no-op when the
+    frame already yields that dtype.
     """
     return np.asarray(frame.to_numpy(), dtype=dtype)
 
@@ -136,7 +137,16 @@ def to_native_frame(
         # narwhals requires string column names for non-pandas backends; pandas keeps the
         # original labels (mirroring the mapping path above).
         names = list(columns) if impl.is_pandas_like() else [str(col) for col in columns]
-        frame = nw.from_numpy(data, schema=names, backend=impl).to_native()
+        # `nw.from_numpy` does not expose `orient`, so polars infers row/column orientation.
+        # For a square array with column names pinned (as here), it breaks the tie from the
+        # memory layout and reads a Fortran-contiguous array column-major: a silent transpose.
+        # `to_numpy` returns exactly such an F-contiguous array for a polars frame, and
+        # arithmetic on it (e.g. the centering/scaling in `StandardScaler`) keeps that layout.
+        # Forcing C-contiguity pins the read to row-major. Cost: a no-op (returns `data`
+        # unchanged) when `data` is already C-contiguous; otherwise a single O(rows * cols)
+        # memcpy, on the same order as building the frame, so negligible relative to the
+        # conversion itself.
+        frame = nw.from_numpy(np.ascontiguousarray(data), schema=names, backend=impl).to_native()
     else:
         if not impl.is_pandas_like():
             data = {str(key): value for key, value in data.items()}

--- a/river/utils/test_pandas.py
+++ b/river/utils/test_pandas.py
@@ -10,19 +10,22 @@ def _raise_missing_pandas() -> None:
     raise ImportError("`pandas` is required for this operation.")
 
 
-def test_transform_many_requires_pandas_only_for_pandas_input(
+def test_transform_many_does_not_require_pandas_helper_for_pandas_input(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # `StandardScaler.transform_many` keeps a pandas fast path, so a pandas input still needs
-    # pandas. `learn_many` is routed through narwhals and never imports pandas.
+    # `StandardScaler` mini-batching is fully routed through narwhals: there is no longer a
+    # pandas-specific fast path, so neither `learn_many` nor `transform_many` go through the
+    # `import_pandas` helper, even for pandas input.
     import pandas as pd
 
     monkeypatch.setattr(pandas_utils, "import_pandas", _raise_missing_pandas)
 
     scaler = preprocessing.StandardScaler()
     scaler.learn_many(pd.DataFrame({"x": [1.0, 2.0, 3.0]}))
-    with pytest.raises(ImportError, match="pandas"):
-        scaler.transform_many(pd.DataFrame({"x": [1.0, 2.0, 3.0]}))
+    out = scaler.transform_many(pd.DataFrame({"x": [1.0, 2.0, 3.0]}))
+
+    assert isinstance(out, pd.DataFrame)
+    assert len(out) == 3
 
 
 def test_transform_many_does_not_require_pandas_for_polars(


### PR DESCRIPTION
* `utils.dataframe.to_native_frame` can now build a native frame directly from a 2D numpy array via `narwhals.from_numpy` (no per-column slicing), and `to_numpy` takes a dtype.
* `StandardScaler.transform_many` drops its pandas-specific fast path for a single backend-agnostic path that infers the compute dtype from the input, so the input float dtype is preserved on every backend (not just pandas). Also fixes a silent transpose when from_numpy builds a polars frame from a square, Fortran-contiguous array.
