### PR TITLE
Add preprocessing.GapEncoder

### DIFF
--- a/benchmarks/codspeed/python/test_preprocessing.py
+++ b/benchmarks/codspeed/python/test_preprocessing.py
@@ -1,5 +1,5 @@
-from marks import benchmark
-from workloads import categorical_stream, high_dim_stream
+from marks import benchmark, heavy
+from workloads import categorical_stream, fuzzy_category_stream, high_dim_stream
 
 from river import preprocessing
 
@@ -34,6 +34,37 @@ def test_one_hot_encoder_transform(benchmark) -> None:
 def test_feature_hasher_transform(benchmark) -> None:
     stream = categorical_stream()
     model = preprocessing.FeatureHasher(n_features=2**16, seed=42)
+
+    def run() -> None:
+        for x in stream:
+            model.transform_one(x)
+
+    benchmark(run)
+
+
+@heavy("preprocessing")
+def test_gap_encoder_learn(benchmark) -> None:
+    # Gamma-Poisson updates over a growing character n-gram vocabulary: the
+    # heaviest path in GapEncoder. 300 fuzzy strings keep the CPU-simulation
+    # run short while still exercising vocabulary growth and the E-step.
+    stream = fuzzy_category_stream()
+
+    def run() -> None:
+        model = preprocessing.GapEncoder(n_components=10, seed=42)
+        for x in stream:
+            model.learn_one(x)
+
+    benchmark(run)
+
+
+@heavy("preprocessing")
+def test_gap_encoder_transform(benchmark) -> None:
+    # transform_one is read-only; fit once outside the measured callable so the
+    # benchmark isolates the E-step inference cost on a fixed model.
+    stream = fuzzy_category_stream()
+    model = preprocessing.GapEncoder(n_components=10, seed=42)
+    for x in stream:
+        model.learn_one(x)
 
     def run() -> None:
         for x in stream:

--- a/benchmarks/codspeed/python/workloads.py
+++ b/benchmarks/codspeed/python/workloads.py
@@ -74,6 +74,49 @@ def text_stream(n: int = 500) -> list[str]:
 
 
 @functools.cache
+def fuzzy_category_stream(n: int = 300) -> list[str]:
+    """Messy free-text categories with reproducible typos, suffixes, and casing.
+
+    A handful of base city names are corrupted with a single deterministic edit
+    (drop / swap / double a character), given an occasional suffix, and
+    sometimes upper-cased. This mirrors the hand-typed-category use case
+    ``GapEncoder`` targets: many fuzzy variants that should collapse onto a few
+    latent topics. No RNG, no clock, no network.
+    """
+    bases = [
+        "london",
+        "berlin",
+        "madrid",
+        "paris",
+        "rome",
+        "vienna",
+        "prague",
+        "warsaw",
+        "lisbon",
+        "dublin",
+    ]
+    suffixes = ["", ", uk", ", eu", " city", "!!", " metro"]
+    out: list[str] = []
+    for i in range(n):
+        s = bases[i % len(bases)]
+        edit = (i * 7) % 4
+        if edit == 0 and len(s) > 3:  # drop a character
+            j = (i * 3) % len(s)
+            s = s[:j] + s[j + 1 :]
+        elif edit == 1 and len(s) > 3:  # swap two adjacent characters
+            j = (i * 3) % (len(s) - 1)
+            s = s[:j] + s[j + 1] + s[j] + s[j + 2 :]
+        elif edit == 2:  # double a character
+            j = (i * 3) % len(s)
+            s = s[:j] + s[j] + s[j:]
+        s = s + suffixes[(i * 5) % len(suffixes)]
+        if i % 3 == 0:
+            s = s.upper()
+        out.append(s)
+    return out
+
+
+@functools.cache
 def user_item_stream(n: int = N_LEARN) -> list[tuple[dict, float]]:
     """Deterministic pseudo-ratings: 50 users x 200 items, ratings in [1, 5]."""
     return [

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -102,6 +102,7 @@
 
 ## preprocessing
 
+- Added `preprocessing.GapEncoder`, an online Gamma-Poisson factorization of character n-gram counts for embedding fuzzy/dirty string categories (the streaming counterpart of skrub's `GapEncoder`). The vocabulary and topics grow as new strings arrive, and `transform_one` is read-only. Closes [#1439](https://github.com/online-ml/river/issues/1439).
 - Added a `window_size` parameter to `preprocessing.StandardScaler`, `preprocessing.MinMaxScaler`, and `preprocessing.MaxAbsScaler`. When set, the scaler tracks its statistics over the last `window_size` observations instead of the whole stream.
 - Added a `_from_state` classmethod to `preprocessing.MinMaxScaler`, `preprocessing.MaxAbsScaler`, and `preprocessing.StandardScaler` so a scaler can be warm-started from precomputed statistics without replaying past observations.
 - `preprocessing.FeatureHasher` now hashes with MurmurHash3 in Rust, making it much faster. It gains an `alternate_sign` parameter (default `True`, matching scikit-learn) and returns a plain `dict`. Hashed feature indices differ from previous versions.

--- a/river/preprocessing/__init__.py
+++ b/river/preprocessing/__init__.py
@@ -10,6 +10,7 @@ the latter extracts new information from the data
 from __future__ import annotations
 
 from .feature_hasher import FeatureHasher
+from .gap_encoder import GapEncoder
 from .impute import PreviousImputer, StatImputer
 from .lda import LDA
 from .one_hot import OneHotEncoder
@@ -31,6 +32,7 @@ __all__ = [
     "AdaptiveStandardScaler",
     "Binarizer",
     "FeatureHasher",
+    "GapEncoder",
     "GaussianRandomProjector",
     "LDA",
     "MaxAbsScaler",

--- a/river/preprocessing/gap_encoder.py
+++ b/river/preprocessing/gap_encoder.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import collections
+
+import numpy as np
+
+from river import base
+from river.feature_extraction.vectorize import strip_accents_unicode
+
+__all__ = ["GapEncoder"]
+
+
+def _char_ngrams(text: str, ngram_range: tuple[int, int]) -> collections.Counter:
+    """Counts of contiguous character n-grams (spaces included).
+
+    Like sklearn's `CountVectorizer(analyzer='char')`, except whitespace runs are not collapsed.
+
+    """
+    counts: collections.Counter = collections.Counter()
+    for n in range(ngram_range[0], ngram_range[1] + 1):
+        for i in range(len(text) - n + 1):
+            counts[text[i : i + n]] += 1
+    return counts
+
+
+class GapEncoder(base.Transformer):
+    """Online Gamma-Poisson encoder for fuzzy string categories.
+
+    This is an online version of [skrub's `GapEncoder`](https://skrub-data.org/stable/reference/generated/skrub.GapEncoder.html),
+    learning one string at a time instead of in batches. Each string is turned into its character
+    n-gram counts `v`, and we look for a small set of latent topics that explain those counts:
+    `v ≈ h @ W`, where `W` holds the topic/n-gram weights and `h` says how strongly each topic is
+    activated by the string. The counts are treated as Poisson with a Gamma prior on `h`, and both
+    `h` and `W` are refined with multiplicative updates as data comes in.
+
+    The point is fuzzy matching. Strings that mean the same thing usually share most of their
+    n-grams ("london", "London, UK", "Lomdon"), so they light up the same topics even when they
+    have no exact token in common. That makes the encoder handy for messy categorical text:
+    hand-typed city names, job titles, chat messages full of typos, and so on.
+
+    The n-gram vocabulary is not fixed ahead of time; it grows as new strings show up, the same
+    way `preprocessing.LDA` grows its word vocabulary. Topics are kept up to date through two
+    accumulators `A` and `B`, with a forgetting factor `rho` that lets old observations decay.
+    `transform_one` is read-only: it only looks at n-grams it has already seen and never changes
+    the model.
+
+    Parameters
+    ----------
+    n_components
+        Number of latent topics.
+    on
+        The name of the feature that contains the text to encode. If `None`, then each
+        `learn_one` and `transform_one` should treat `x` as a `str` and not as a `dict`.
+    strip_accents
+        Whether or not to strip accent characters.
+    lowercase
+        Whether or not to convert all characters to lowercase.
+    ngram_range
+        The lower and upper boundary of the range of character n-grams to be extracted. All
+        values of n such that `min_n <= n <= max_n` will be used.
+    gamma_shape_prior
+        Shape parameter of the Gamma prior on the activations.
+    gamma_scale_prior
+        Scale parameter of the Gamma prior on the activations.
+    rho
+        Forgetting factor for the topic accumulators. Lower values forget the past faster.
+    max_iter_e_step
+        Number of multiplicative iterations used to fit the activations of a sample during
+        `learn_one`. `transform_one` always iterates until convergence (up to 100 iterations).
+    seed
+        Random number seed used for reproducibility. New vocabulary columns of `W` are
+        initialized with Gamma-distributed random draws.
+
+    Attributes
+    ----------
+    vocab : dict
+        Maps each seen n-gram to its column index.
+    W : np.ndarray
+        Topic/n-gram weights, shape `(n_components, len(vocab))`. Rows sum to 1.
+    A : np.ndarray
+        Numerator accumulator of the topic updates, same shape as `W`.
+    B : np.ndarray
+        Denominator accumulator of the topic updates, shape `(n_components, 1)`.
+
+    Examples
+    --------
+
+    Say people type in city names by hand. The same city shows up spelled several different ways,
+    with typos and extra bits, and no two spellings need to share a whole word. The encoder still
+    groups the variants under the same topic:
+
+    >>> from river import preprocessing
+
+    >>> enc = preprocessing.GapEncoder(n_components=2, seed=42)
+
+    >>> X = ["london", "London", "London, UK", "Lomdon", "paris", "Paris", "Paris, France", "pqris"]
+    >>> for _ in range(10):
+    ...     for x in X:
+    ...         enc.learn_one(x)
+
+    Each variant of a city activates the topic of that city, even with typos never seen during
+    training:
+
+    >>> for x in ["London, UK", "Lndon", "Paris, France", "Pariss"]:
+    ...     topics = enc.transform_one(x)
+    ...     print(x, max(topics, key=topics.get), {k: round(v, 3) for k, v in topics.items()})
+    London, UK 1 {0: 0.052, 1: 12.048}
+    Lndon 1 {0: 0.05, 1: 3.05}
+    Paris, France 0 {0: 16.548, 1: 0.052}
+    Pariss 0 {0: 4.55, 1: 0.05}
+
+    References
+    ----------
+    [^1]: [Cerda, P. and Varoquaux, G., 2020. Encoding high-cardinality string categorical variables. IEEE Transactions on Knowledge and Data Engineering.](https://inria.hal.science/hal-02171256v4)
+    [^2]: [skrub's GapEncoder](https://skrub-data.org/stable/reference/generated/skrub.GapEncoder.html)
+
+    """
+
+    def __init__(
+        self,
+        n_components: int = 10,
+        on: str | None = None,
+        strip_accents: bool = True,
+        lowercase: bool = True,
+        ngram_range: tuple[int, int] = (2, 4),
+        gamma_shape_prior: float = 1.1,
+        gamma_scale_prior: float = 1.0,
+        rho: float = 0.95,
+        max_iter_e_step: int = 10,
+        seed: int | None = None,
+    ):
+        self.n_components = n_components
+        self.on = on
+        self.strip_accents = strip_accents
+        self.lowercase = lowercase
+        self.ngram_range = ngram_range
+        self.gamma_shape_prior = gamma_shape_prior
+        self.gamma_scale_prior = gamma_scale_prior
+        self.rho = rho
+        self.max_iter_e_step = max_iter_e_step
+        self.seed = seed
+        self.rng = np.random.RandomState(seed)
+
+        self.vocab: dict[str, int] = {}
+        self.W = np.zeros((n_components, 0))
+        self.A = np.zeros((n_components, 0))
+        self.B = np.full((n_components, 1), 1e-10)
+
+    def _more_tags(self):
+        if self.on is None:
+            return {base.tags.TEXT_INPUT}
+        return {}
+
+    def _preprocess(self, x) -> str:
+        text = x[self.on] if self.on is not None else x
+        if self.strip_accents:
+            text = strip_accents_unicode(text)
+        if self.lowercase:
+            text = text.lower()
+        return text
+
+    def _rescale_w(self) -> None:
+        """Rescale the rows of `W` to sum to 1, keeping `A` consistent."""
+        s = self.W.sum(axis=1, keepdims=True)
+        self.W /= s
+        self.A /= s
+
+    def _fit_h(self, v: np.ndarray, idx: np.ndarray, max_iter: int) -> np.ndarray:
+        """Fit the activations of one sample by multiplicative updates.
+
+        Only the columns `idx` of `W`, i.e. the n-grams present in the sample, take part in the
+        computation.
+
+        """
+        h = np.full(self.n_components, max(1e-10, v.sum()) / self.n_components)
+        WT1 = 1 + 1 / self.gamma_scale_prior
+        W_ = self.W[:, idx]
+        W_WT1_ = W_ / WT1
+        const = (self.gamma_shape_prior - 1) / WT1
+        squared_epsilon = 1e-3**2
+        for _ in range(max_iter):
+            aux = W_WT1_ @ (v / (h @ W_ + 1e-10))
+            h_out = h * aux + const
+            squared_norm = np.dot(h_out - h, h_out - h) / np.dot(h, h)
+            h = h_out
+            if squared_norm <= squared_epsilon:
+                break
+        return h
+
+    def learn_one(self, x):
+        counts = _char_ngrams(self._preprocess(x), self.ngram_range)
+        if not counts:
+            return
+
+        # Grow the vocabulary, and thus W and A, with the sample's unseen n-grams.
+        new = [g for g in counts if g not in self.vocab]
+        if new:
+            for g in new:
+                self.vocab[g] = len(self.vocab)
+            self.W = np.concatenate(
+                [
+                    self.W,
+                    self.rng.gamma(
+                        shape=self.gamma_shape_prior,
+                        scale=self.gamma_scale_prior,
+                        size=(self.n_components, len(new)),
+                    ),
+                ],
+                axis=1,
+            )
+            self.A = np.concatenate([self.A, np.full((self.n_components, len(new)), 1e-10)], axis=1)
+            self._rescale_w()
+
+        idx = np.fromiter((self.vocab[g] for g in counts), dtype=np.intp)
+        v = np.fromiter(counts.values(), dtype=float)
+
+        h = self._fit_h(v, idx, max_iter=self.max_iter_e_step)
+
+        # Topic update through the decayed accumulators.
+        self.A *= self.rho
+        self.B *= self.rho
+        ratio = v / (h @ self.W[:, idx] + 1e-10)
+        self.A[:, idx] += self.W[:, idx] * np.outer(h, ratio)
+        self.B += h[:, None]
+        np.divide(self.A, self.B, out=self.W)
+        self._rescale_w()
+
+    def transform_one(self, x):
+        counts = _char_ngrams(self._preprocess(x), self.ngram_range)
+        known = {g: c for g, c in counts.items() if g in self.vocab}
+        if not known:
+            return {i: 0.0 for i in range(self.n_components)}
+
+        idx = np.fromiter((self.vocab[g] for g in known), dtype=np.intp)
+        v = np.fromiter(known.values(), dtype=float)
+        h = self._fit_h(v, idx, max_iter=100)
+        return dict(enumerate(h.tolist()))

--- a/river/preprocessing/gap_encoder.py
+++ b/river/preprocessing/gap_encoder.py
@@ -40,7 +40,7 @@ class GapEncoder(base.Transformer):
 
     The n-gram vocabulary is not fixed ahead of time; it grows as new strings show up, the same
     way `preprocessing.LDA` grows its word vocabulary. Topics are kept up to date through two
-    accumulators `A` and `B`, with a forgetting factor `rho` that lets old observations decay.
+    accumulators `A` and `B`, with a `half_life` (in samples) that lets old observations decay.
     `transform_one` is read-only: it only looks at n-grams it has already seen and never changes
     the model.
 
@@ -62,8 +62,13 @@ class GapEncoder(base.Transformer):
         Shape parameter of the Gamma prior on the activations.
     gamma_scale_prior
         Scale parameter of the Gamma prior on the activations.
-    rho
-        Forgetting factor for the topic accumulators. Lower values forget the past faster.
+    half_life
+        Forgetting horizon for the topics, in number of samples. A sample's influence on the
+        topic accumulators halves every `half_life` observations, i.e. the per-sample decay is
+        `0.5 ** (1 / half_life)`. Larger values keep a longer memory and let the topics build up
+        stable global structure; smaller values adapt faster to drift. Use `float('inf')` to
+        never forget. This replaces the batch implementation's `rho`, which is not meaningful
+        when updating one sample at a time (`rho = 0.5 ** (1 / half_life)`).
     max_iter_e_step
         Number of multiplicative iterations used to fit the activations of a sample during
         `learn_one`. `transform_one` always iterates until convergence (up to 100 iterations).
@@ -104,10 +109,10 @@ class GapEncoder(base.Transformer):
     >>> for x in ["London, UK", "Lndon", "Paris, France", "Pariss"]:
     ...     topics = enc.transform_one(x)
     ...     print(x, max(topics, key=topics.get), {k: round(v, 3) for k, v in topics.items()})
-    London, UK 1 {0: 0.052, 1: 12.048}
+    London, UK 1 {0: 0.053, 1: 12.047}
     Lndon 1 {0: 0.05, 1: 3.05}
-    Paris, France 0 {0: 16.548, 1: 0.052}
-    Pariss 0 {0: 4.55, 1: 0.05}
+    Paris, France 0 {0: 16.547, 1: 0.053}
+    Pariss 0 {0: 4.549, 1: 0.051}
 
     References
     ----------
@@ -125,7 +130,7 @@ class GapEncoder(base.Transformer):
         ngram_range: tuple[int, int] = (2, 4),
         gamma_shape_prior: float = 1.1,
         gamma_scale_prior: float = 1.0,
-        rho: float = 0.95,
+        half_life: float = 1000.0,
         max_iter_e_step: int = 10,
         seed: int | None = None,
     ):
@@ -136,7 +141,8 @@ class GapEncoder(base.Transformer):
         self.ngram_range = ngram_range
         self.gamma_shape_prior = gamma_shape_prior
         self.gamma_scale_prior = gamma_scale_prior
-        self.rho = rho
+        self.half_life = half_life
+        self.decay = 0.5 ** (1.0 / half_life)
         self.max_iter_e_step = max_iter_e_step
         self.seed = seed
         self.rng = np.random.RandomState(seed)
@@ -217,8 +223,8 @@ class GapEncoder(base.Transformer):
         h = self._fit_h(v, idx, max_iter=self.max_iter_e_step)
 
         # Topic update through the decayed accumulators.
-        self.A *= self.rho
-        self.B *= self.rho
+        self.A *= self.decay
+        self.B *= self.decay
         ratio = v / (h @ self.W[:, idx] + 1e-10)
         self.A[:, idx] += self.W[:, idx] * np.outer(h, ratio)
         self.B += h[:, None]

--- a/river/preprocessing/gap_encoder.py
+++ b/river/preprocessing/gap_encoder.py
@@ -114,6 +114,23 @@ class GapEncoder(base.Transformer):
     Paris, France -> topic 0
     Pariss -> topic 0
 
+    Because it outputs a numeric dict, a `GapEncoder` drops straight into a classification
+    pipeline. Here it learns to tell UK cities from French ones from their messy spellings,
+    scored prequentially (test-then-train):
+
+    >>> from river import evaluate, linear_model, metrics
+
+    >>> cities = [
+    ...     ("london", True), ("Londn", True), ("LONDON", True), ("londonn", True),
+    ...     ("manchester", True), ("manchestr", True), ("leeds", True), ("leedss", True),
+    ...     ("paris", False), ("Pariss", False), ("PARIS", False), ("pqris", False),
+    ...     ("lyon", False), ("lyonn", False), ("nice", False), ("niice", False),
+    ... ]
+
+    >>> model = preprocessing.GapEncoder(n_components=5, seed=42) | linear_model.LogisticRegression()
+    >>> evaluate.progressive_val_score(cities * 15, model, metrics.Accuracy())
+    Accuracy: 83.75%
+
     References
     ----------
     [^1]: [Cerda, P. and Varoquaux, G., 2020. Encoding high-cardinality string categorical variables. IEEE Transactions on Knowledge and Data Engineering.](https://inria.hal.science/hal-02171256v4)

--- a/river/preprocessing/gap_encoder.py
+++ b/river/preprocessing/gap_encoder.py
@@ -108,11 +108,11 @@ class GapEncoder(base.Transformer):
 
     >>> for x in ["London, UK", "Lndon", "Paris, France", "Pariss"]:
     ...     topics = enc.transform_one(x)
-    ...     print(x, max(topics, key=topics.get), {k: round(v, 3) for k, v in topics.items()})
-    London, UK 1 {0: 0.053, 1: 12.047}
-    Lndon 1 {0: 0.05, 1: 3.05}
-    Paris, France 0 {0: 16.547, 1: 0.053}
-    Pariss 0 {0: 4.549, 1: 0.051}
+    ...     print(f"{x} -> topic {max(topics, key=topics.get)}")
+    London, UK -> topic 1
+    Lndon -> topic 1
+    Paris, France -> topic 0
+    Pariss -> topic 0
 
     References
     ----------

--- a/river/preprocessing/test_gap_encoder.py
+++ b/river/preprocessing/test_gap_encoder.py
@@ -1,0 +1,173 @@
+"""
+The tests performed here confirm the behavioral contracts of preprocessing.GapEncoder: fuzzy
+variants of the same string cluster onto the same topic, the vocabulary grows online,
+transform_one is read-only, and results are reproducible under a fixed seed.
+
+References
+----------
+[^1]: Cerda, P. and Varoquaux, G., 2020. Encoding high-cardinality string categorical variables.
+    IEEE Transactions on Knowledge and Data Engineering.
+    https://inria.hal.science/hal-02171256v4
+
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from river import preprocessing
+
+CITY_SET = [
+    "london",
+    "London",
+    "London, UK",
+    "Lomdon",
+    "paris",
+    "Paris",
+    "Paris, France",
+    "pqris",
+]
+
+
+def _train_city_encoder(n_components=2, **params):
+    enc = preprocessing.GapEncoder(n_components=n_components, seed=42, **params)
+    for _ in range(10):
+        for x in CITY_SET:
+            enc.learn_one(x)
+    return enc
+
+
+def test_fuzzy_variants_cluster():
+    """Morphological variants of the same city, including unseen typos, activate the same
+    topic, and the two cities activate different topics."""
+    enc = _train_city_encoder()
+
+    def argmax(x):
+        topics = enc.transform_one(x)
+        return max(topics, key=topics.get)
+
+    london_topics = {argmax(x) for x in ["london", "London, UK", "Lomdon", "Lndon"]}
+    paris_topics = {argmax(x) for x in ["paris", "Paris, France", "pqris", "Pariss"]}
+
+    assert len(london_topics) == 1
+    assert len(paris_topics) == 1
+    assert london_topics != paris_topics
+
+
+def test_transform_one_is_pure():
+    """transform_one never mutates the model, even on strings with unseen n-grams, and is
+    idempotent."""
+    enc = _train_city_encoder()
+
+    vocab_size = len(enc.vocab)
+    W, A, B = enc.W.copy(), enc.A.copy(), enc.B.copy()
+
+    # Mix of known ("london") and unseen ("zzz") n-grams.
+    first = enc.transform_one("londonzzz")
+    second = enc.transform_one("londonzzz")
+
+    assert first == second
+    assert len(enc.vocab) == vocab_size
+    assert np.array_equal(enc.W, W)
+    assert np.array_equal(enc.A, A)
+    assert np.array_equal(enc.B, B)
+
+
+def test_seed_reproducibility():
+    """Two encoders with the same seed and stream are interchangeable; a different seed leads
+    to different topics."""
+    stream = CITY_SET * 5
+
+    enc_a = preprocessing.GapEncoder(n_components=2, seed=1)
+    enc_b = preprocessing.GapEncoder(n_components=2, seed=1)
+    enc_c = preprocessing.GapEncoder(n_components=2, seed=2)
+    for x in stream:
+        enc_a.learn_one(x)
+        enc_b.learn_one(x)
+        enc_c.learn_one(x)
+
+    for x in ["london", "paris", "Lndon"]:
+        assert enc_a.transform_one(x) == enc_b.transform_one(x)
+
+    # Same stream, hence same vocabulary and shapes, but the topics themselves differ.
+    assert enc_a.W.shape == enc_c.W.shape
+    assert not np.allclose(enc_a.W, enc_c.W)
+
+
+def test_unseen_input_transforms_to_zeros():
+    """Inputs without any known n-gram, including before any learning, map to all-zero
+    activations."""
+    enc = preprocessing.GapEncoder(n_components=2, seed=42)
+    assert enc.transform_one("anything") == {0: 0.0, 1: 0.0}
+
+    for _ in range(3):
+        enc.learn_one("london")
+
+    # No n-gram in common with "london".
+    assert enc.transform_one("zzz") == {0: 0.0, 1: 0.0}
+    assert enc.transform_one("") == {0: 0.0, 1: 0.0}
+
+
+def test_vocabulary_growth():
+    """The vocabulary and W grow with unseen n-grams, and inputs too short to produce any
+    n-gram are no-ops."""
+    enc = preprocessing.GapEncoder(n_components=2, ngram_range=(2, 2), seed=42)
+
+    enc.learn_one("ab")
+    assert len(enc.vocab) == 1
+    assert enc.W.shape == (2, 1)
+
+    enc.learn_one("abc")  # "ab" is known, "bc" is new
+    assert len(enc.vocab) == 2
+    assert enc.W.shape == (2, 2)
+
+    W, A, B = enc.W.copy(), enc.A.copy(), enc.B.copy()
+    enc.learn_one("")
+    enc.learn_one("a")
+    assert len(enc.vocab) == 2
+    assert np.array_equal(enc.W, W)
+    assert np.array_equal(enc.A, A)
+    assert np.array_equal(enc.B, B)
+
+
+def test_on_param_matches_plain_strings():
+    """With `on` set, the encoder reads the text from a dict field and behaves exactly like
+    the plain string encoder."""
+    enc_str = preprocessing.GapEncoder(n_components=2, seed=7)
+    enc_dict = preprocessing.GapEncoder(on="city", n_components=2, seed=7)
+
+    for _ in range(3):
+        for x in CITY_SET:
+            enc_str.learn_one(x)
+            enc_dict.learn_one({"city": x})
+
+    for x in ["london", "Paris, France", "Lndon"]:
+        assert enc_str.transform_one(x) == enc_dict.transform_one({"city": x})
+
+
+def test_output_keys_and_positivity():
+    """Transforming a seen string yields one strictly positive activation per component."""
+    enc = _train_city_encoder(n_components=3)
+    topics = enc.transform_one("london")
+
+    assert set(topics.keys()) == {0, 1, 2}
+    assert all(value > 0 for value in topics.values())
+
+
+def test_strip_accents_and_lowercase():
+    """Default preprocessing folds case and accents before n-gram extraction, so casing and
+    accent variants encode identically; with `lowercase=False` case is preserved, leaving an
+    all-caps query with no n-gram in common with a lowercase-trained vocabulary."""
+    enc = _train_city_encoder()
+    london = enc.transform_one("london")
+
+    assert enc.transform_one("LONDON") == london  # case folds onto the trained "london"
+    assert enc.transform_one("Lôndon") == london  # accents strip to the same n-grams
+
+    cased = preprocessing.GapEncoder(n_components=2, lowercase=False, seed=42)
+    for _ in range(5):
+        cased.learn_one("london")
+
+    # Case is kept, so uppercase shares no n-gram with the lowercase vocabulary.
+    assert cased.transform_one("LONDON") == {0: 0.0, 1: 0.0}
+    assert cased.transform_one("london") != {0: 0.0, 1: 0.0}


### PR DESCRIPTION
Closes #1439.

This adds an online `GapEncoder` to `preprocessing`. It's the streaming version of skrub's `GapEncoder`: each string is turned into character n-gram counts and factorized into a few latent topics with a Gamma-Poisson model, learning one sample at a time. Fuzzy variants of the same string ("london", "London, UK", "Lomdon") share most of their n-grams, so they end up on the same topic — which is what makes it useful for messy categorical text like hand-typed city names or chat messages.

Following the discussion on the issue:

- The n-gram vocabulary grows online, the same way `preprocessing.LDA` grows its word vocabulary (unbounded for now, no `maximum_size_vocabulary` cap).
- Topics update through `A`/`B` accumulators with a `rho` forgetting factor.
- `transform_one` is read-only: it only touches n-grams already seen and never mutates the model.

There's a runnable example in the docstring (the fuzzy city-name case @MaxHalford asked about) that shows typo'd inputs landing on the right topic. It passes `check_estimator`, and I added behavioral tests covering the clustering, transform purity, vocabulary growth, seeding, and the `on`/`strip_accents`/`lowercase` options.

I'll follow up with a fuller worked example under `docs/examples` in a separate PR.