### PR TITLE
Add worked example: encoding dirty categories with the GapEncoder

### DIFF
--- a/docs/examples/encoding-dirty-categories.ipynb
+++ b/docs/examples/encoding-dirty-categories.ipynb
@@ -1,0 +1,509 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9536b38c",
+   "metadata": {},
+   "source": [
+    "# Encoding dirty categories"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8311339f",
+   "metadata": {},
+   "source": [
+    "When a categorical feature is typed in by hand — a city, a company, a job title — the same\n",
+    "value shows up spelled a dozen different ways: `London`, `london`, `LONDON`, `Lomdon`, `London, UK`.\n",
+    "A one-hot encoder treats every spelling as a brand new, unrelated category. On a stream this is a\n",
+    "double problem: the number of categories keeps growing, and the model never gets to reuse what it\n",
+    "learned about `London` when it later sees `Lomdon`.\n",
+    "\n",
+    "The `preprocessing.GapEncoder` tackles this. It represents each string by its character n-gram\n",
+    "counts and factorizes them into a handful of latent topics, so that strings which share n-grams —\n",
+    "which is exactly what misspellings of the same word do — end up with similar encodings. It is the\n",
+    "online counterpart of [skrub's `GapEncoder`](https://skrub-data.org/stable/reference/generated/skrub.GapEncoder.html),\n",
+    "learning one record at a time.\n",
+    "\n",
+    "To see when it helps, we'll build a stream where the label depends on the *true* city, but the model\n",
+    "only ever sees a *misspelled* version of it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a4d1ab5",
+   "metadata": {},
+   "source": [
+    "## A stream of hand-typed cities"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af08a6eb",
+   "metadata": {},
+   "source": [
+    "Each customer belongs to a city, and each city has its own churn propensity (the signal we want to\n",
+    "recover). We then corrupt the city name the way a human would: random case, a dropped or swapped\n",
+    "character, sometimes a trailing country code. The label is drawn from the *true* city's propensity,\n",
+    "so a model that could read the clean city name would do well — but our models only see the corrupted\n",
+    "string."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c4205635",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T21:45:25.909414Z",
+     "iopub.status.busy": "2026-07-02T21:45:25.908688Z",
+     "iopub.status.idle": "2026-07-02T21:45:25.934205Z",
+     "shell.execute_reply": "2026-07-02T21:45:25.933292Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[({'city': 'MACNHESTER'}, True),\n",
+       " ({'city': 'mancehster, FR'}, False),\n",
+       " ({'city': 'Hmaburg city'}, True),\n",
+       " ({'city': 'lyon city'}, True),\n",
+       " ({'city': 'MNACHESTER'}, False)]"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import random\n",
+    "\n",
+    "CITIES = {\n",
+    "    \"London\": 0.15, \"Manchester\": 0.25, \"Birmingham\": 0.30,\n",
+    "    \"Paris\": 0.55, \"Marseille\": 0.65, \"Lyon\": 0.60,\n",
+    "    \"Berlin\": 0.80, \"Munich\": 0.75, \"Hamburg\": 0.85,\n",
+    "}\n",
+    "\n",
+    "\n",
+    "def corrupt(s, rng):\n",
+    "    \"\"\"Turn a clean city name into something a human might have typed.\"\"\"\n",
+    "    out = s\n",
+    "    r = rng.random()\n",
+    "    if r < 0.25:\n",
+    "        out = out.lower()\n",
+    "    elif r < 0.4:\n",
+    "        out = out.upper()\n",
+    "    if rng.random() < 0.4 and len(out) > 3:  # drop or swap a character\n",
+    "        i = rng.randrange(1, len(out) - 1)\n",
+    "        if rng.random() < 0.5:\n",
+    "            out = out[:i] + out[i + 1:]\n",
+    "        else:\n",
+    "            out = out[:i] + out[i + 1] + out[i] + out[i + 2:]\n",
+    "    if rng.random() < 0.3:  # trailing region/country, or nothing\n",
+    "        out = out + rng.choice([\", UK\", \", FR\", \", DE\", \" city\", \"\"])\n",
+    "    return out\n",
+    "\n",
+    "\n",
+    "def generate(n, seed=42):\n",
+    "    rng = random.Random(seed)\n",
+    "    for _ in range(n):\n",
+    "        city = rng.choice(list(CITIES))\n",
+    "        y = rng.random() < CITIES[city]\n",
+    "        yield city, corrupt(city, rng), y\n",
+    "\n",
+    "\n",
+    "records = list(generate(4000))\n",
+    "dataset = [({\"city\": dirty}, y) for _, dirty, y in records]\n",
+    "dataset[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6fad9ff",
+   "metadata": {},
+   "source": [
+    "Nine real cities, but a lot more spellings once humans get involved:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d037a3d5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T21:45:25.936444Z",
+     "iopub.status.busy": "2026-07-02T21:45:25.936060Z",
+     "iopub.status.idle": "2026-07-02T21:45:25.941988Z",
+     "shell.execute_reply": "2026-07-02T21:45:25.940883Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "689 distinct spellings for 9 real cities\n",
+      "['LODNON', 'LODNON city', 'LODNON, DE', 'LODNON, FR', 'LODON', 'LODON, DE', 'LON', 'LON, UK', 'LONDNO', 'LONDNO city']\n"
+     ]
+    }
+   ],
+   "source": [
+    "spellings = {x[\"city\"] for x, _ in dataset}\n",
+    "print(f\"{len(spellings)} distinct spellings for {len(CITIES)} real cities\")\n",
+    "print(sorted(s for s in spellings if s.lower().startswith(\"lo\") or \"ond\" in s.lower())[:10])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81919b03",
+   "metadata": {},
+   "source": [
+    "## Baseline: one-hot encoding"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7303265f",
+   "metadata": {},
+   "source": [
+    "We evaluate with progressive validation: for each record the model predicts first, then learns.\n",
+    "The metric is ROC AUC, which is well suited to this unbalanced target. The one-hot pipeline learns a\n",
+    "separate weight per spelling, so a spelling it has never seen carries no information."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d106d84d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T21:45:25.945144Z",
+     "iopub.status.busy": "2026-07-02T21:45:25.944950Z",
+     "iopub.status.idle": "2026-07-02T21:45:28.790504Z",
+     "shell.execute_reply": "2026-07-02T21:45:28.789700Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ROCAUC: 57.08%"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from river import compose, linear_model, metrics, preprocessing\n",
+    "\n",
+    "\n",
+    "def evaluate(model, dataset):\n",
+    "    auc = metrics.ROCAUC()\n",
+    "    for x, y in dataset:\n",
+    "        y_pred = model.predict_proba_one(x)\n",
+    "        auc.update(y, y_pred.get(True, 0.0))\n",
+    "        model.learn_one(x, y)\n",
+    "    return auc\n",
+    "\n",
+    "\n",
+    "one_hot = compose.Pipeline(\n",
+    "    preprocessing.OneHotEncoder(),\n",
+    "    linear_model.LogisticRegression(),\n",
+    ")\n",
+    "evaluate(one_hot, dataset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "48e4ab17",
+   "metadata": {},
+   "source": [
+    "Barely better than a coin flip. With hundreds of one-off spellings, most predictions are made on a\n",
+    "category the model is seeing for the first time."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2a9a64f",
+   "metadata": {},
+   "source": [
+    "## GapEncoder"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d027b8c",
+   "metadata": {},
+   "source": [
+    "Now we swap the one-hot step for a `GapEncoder` with 10 topics. It reads the text from the `city`\n",
+    "field, turns it into character n-grams, and emits 10 continuous features. Because misspellings of the\n",
+    "same city share n-grams, they map to nearby encodings, and the logistic regression can reuse what it\n",
+    "learned across spellings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "802cc522",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T21:45:28.792632Z",
+     "iopub.status.busy": "2026-07-02T21:45:28.792338Z",
+     "iopub.status.idle": "2026-07-02T21:45:30.379739Z",
+     "shell.execute_reply": "2026-07-02T21:45:30.378608Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ROCAUC: 70.48%"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gap = compose.Pipeline(\n",
+    "    preprocessing.GapEncoder(on=\"city\", n_components=10, seed=42),\n",
+    "    linear_model.LogisticRegression(),\n",
+    ")\n",
+    "evaluate(gap, dataset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0be50d15",
+   "metadata": {},
+   "source": [
+    "A large jump. To see how much of the signal that recovers, here is an *oracle* that cheats by\n",
+    "one-hot encoding the **clean** city name — the best any model could do given this data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "853e041b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T21:45:30.382368Z",
+     "iopub.status.busy": "2026-07-02T21:45:30.382128Z",
+     "iopub.status.idle": "2026-07-02T21:45:30.492674Z",
+     "shell.execute_reply": "2026-07-02T21:45:30.491088Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ROCAUC: 71.62%"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "clean = [({\"city\": city}, y) for city, _, y in records]\n",
+    "\n",
+    "oracle = compose.Pipeline(\n",
+    "    preprocessing.OneHotEncoder(),\n",
+    "    linear_model.LogisticRegression(),\n",
+    ")\n",
+    "evaluate(oracle, clean)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79b33de6",
+   "metadata": {},
+   "source": [
+    "The `GapEncoder` lands right next to the oracle, even though it only ever saw the misspelled\n",
+    "strings. It recovered almost all of the signal that one-hot encoding threw away."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc817cb5",
+   "metadata": {},
+   "source": [
+    "## Why it works: fuzzy strings share n-grams"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "935dd696",
+   "metadata": {},
+   "source": [
+    "Let's train a `GapEncoder` on its own and look at the encodings directly. We compare strings with\n",
+    "cosine similarity: variants of the same city should be close to 1, different cities close to 0."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "6735bba5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T21:45:30.495502Z",
+     "iopub.status.busy": "2026-07-02T21:45:30.495228Z",
+     "iopub.status.idle": "2026-07-02T21:45:31.228930Z",
+     "shell.execute_reply": "2026-07-02T21:45:31.228078Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    London / Lomdon     -> 1.00\n",
+      "    London / LONDON     -> 1.00\n",
+      "    London / Paris      -> 0.02\n",
+      "     Paris / Marseille  -> 0.02\n",
+      "    Berlin / Munich     -> 0.02\n"
+     ]
+    }
+   ],
+   "source": [
+    "import math\n",
+    "\n",
+    "encoder = preprocessing.GapEncoder(on=\"city\", n_components=10, seed=42)\n",
+    "for x, _ in dataset:\n",
+    "    encoder.learn_one({\"city\": x[\"city\"]})\n",
+    "\n",
+    "\n",
+    "def similarity(a, b):\n",
+    "    va = encoder.transform_one({\"city\": a})\n",
+    "    vb = encoder.transform_one({\"city\": b})\n",
+    "    dot = sum(va[k] * vb[k] for k in va)\n",
+    "    na = math.sqrt(sum(v * v for v in va.values()))\n",
+    "    nb = math.sqrt(sum(v * v for v in vb.values()))\n",
+    "    return dot / (na * nb + 1e-12)\n",
+    "\n",
+    "\n",
+    "pairs = [\n",
+    "    (\"London\", \"Lomdon\"),\n",
+    "    (\"London\", \"LONDON\"),\n",
+    "    (\"London\", \"Paris\"),\n",
+    "    (\"Paris\", \"Marseille\"),\n",
+    "    (\"Berlin\", \"Munich\"),\n",
+    "]\n",
+    "for a, b in pairs:\n",
+    "    print(f\"{a:>10} / {b:<10} -> {similarity(a, b):.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2647a9dd",
+   "metadata": {},
+   "source": [
+    "Misspellings and case changes of the same city sit right on top of each other, while different\n",
+    "cities are essentially orthogonal — including the typo `Lomdon`, which the encoder handles even\n",
+    "though it is just one more never-before-seen spelling."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f2757b8",
+   "metadata": {},
+   "source": [
+    "## Inspecting the topics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d27b608d",
+   "metadata": {},
+   "source": [
+    "Each of the 10 topics tends to specialise in one city. For every topic we can find the training\n",
+    "string that activates it the most, which gives the topics human-readable labels:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "37ee2504",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T21:45:31.231219Z",
+     "iopub.status.busy": "2026-07-02T21:45:31.231013Z",
+     "iopub.status.idle": "2026-07-02T21:45:31.295201Z",
+     "shell.execute_reply": "2026-07-02T21:45:31.294352Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "topic 0: 'MANCHESTER, UK'\n",
+      "topic 1: 'MUNICH, UK'\n",
+      "topic 2: 'BIRMINGHAM city'\n",
+      "topic 3: 'BERLIN city'\n",
+      "topic 4: 'Paris, UK'\n",
+      "topic 5: 'LYON, DE'\n",
+      "topic 6: 'LONDON city'\n",
+      "topic 7: 'MARSIELLE'\n",
+      "topic 8: 'HAMBURG, FR'\n",
+      "topic 9: 'MARSEILLE, FR'\n"
+     ]
+    }
+   ],
+   "source": [
+    "unique = sorted({x[\"city\"] for x, _ in dataset})\n",
+    "best = {}\n",
+    "for s in unique:\n",
+    "    h = encoder.transform_one({\"city\": s})\n",
+    "    topic = max(h, key=h.get)\n",
+    "    if topic not in best or h[topic] > best[topic][1]:\n",
+    "        best[topic] = (s, h[topic])\n",
+    "\n",
+    "for topic in sorted(best):\n",
+    "    print(f\"topic {topic}: {best[topic][0]!r}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f64a8eab",
+   "metadata": {},
+   "source": [
+    "## When to reach for it\n",
+    "\n",
+    "The `GapEncoder` earns its place when a categorical feature is **high-cardinality and messy** —\n",
+    "free-typed cities, company names, product labels, job titles, chat handles — where the interesting\n",
+    "structure lives in shared substrings rather than exact matches. It gives you a small, fixed-width,\n",
+    "continuous encoding that generalises across spellings, all learned online. For clean, low-cardinality\n",
+    "categories a plain `OneHotEncoder` is simpler and just as good; for full free text, reach for\n",
+    "`feature_extraction.BagOfWords`/`TFIDF` instead."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -89,6 +89,7 @@
 
 ## preprocessing
 
+- Added `preprocessing.GapEncoder`, an online Gamma-Poisson factorization of character n-gram counts for embedding fuzzy/dirty string categories (the streaming counterpart of skrub's `GapEncoder`). The vocabulary and topics grow as new strings arrive, and `transform_one` is read-only. Closes [#1439](https://github.com/online-ml/river/issues/1439).
 - Added a `window_size` parameter to `preprocessing.StandardScaler`, `preprocessing.MinMaxScaler`, and `preprocessing.MaxAbsScaler`. When set, the scaler tracks its statistics over the last `window_size` observations instead of the whole stream.
 - Added a `_from_state` classmethod to `preprocessing.MinMaxScaler`, `preprocessing.MaxAbsScaler`, and `preprocessing.StandardScaler` so a scaler can be warm-started from precomputed statistics without replaying past observations.
 - `preprocessing.FeatureHasher` now hashes with MurmurHash3 in Rust, making it much faster. It gains an `alternate_sign` parameter (default `True`, matching scikit-learn) and returns a plain `dict`. Hashed feature indices differ from previous versions.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8275,6 +8275,7 @@ nav:
     - examples/building-a-simple-nowcasting-model.md
     - examples/content-personalization.md
     - examples/debugging-a-pipeline.md
+    - examples/encoding-dirty-categories.md
     - examples/imbalanced-learning.md
     - Matrix factorization for recommender systems:
       - examples/matrix-factorization-for-recommender-systems/part-1.md

--- a/river/preprocessing/__init__.py
+++ b/river/preprocessing/__init__.py
@@ -10,6 +10,7 @@ the latter extracts new information from the data
 from __future__ import annotations
 
 from .feature_hasher import FeatureHasher
+from .gap_encoder import GapEncoder
 from .impute import PreviousImputer, StatImputer
 from .lda import LDA
 from .one_hot import OneHotEncoder
@@ -31,6 +32,7 @@ __all__ = [
     "AdaptiveStandardScaler",
     "Binarizer",
     "FeatureHasher",
+    "GapEncoder",
     "GaussianRandomProjector",
     "LDA",
     "MaxAbsScaler",

--- a/river/preprocessing/gap_encoder.py
+++ b/river/preprocessing/gap_encoder.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import collections
+
+import numpy as np
+
+from river import base
+from river.feature_extraction.vectorize import strip_accents_unicode
+
+__all__ = ["GapEncoder"]
+
+
+def _char_ngrams(text: str, ngram_range: tuple[int, int]) -> collections.Counter:
+    """Counts of contiguous character n-grams (spaces included).
+
+    Like sklearn's `CountVectorizer(analyzer='char')`, except whitespace runs are not collapsed.
+
+    """
+    counts: collections.Counter = collections.Counter()
+    for n in range(ngram_range[0], ngram_range[1] + 1):
+        for i in range(len(text) - n + 1):
+            counts[text[i : i + n]] += 1
+    return counts
+
+
+class GapEncoder(base.Transformer):
+    """Online Gamma-Poisson encoder for fuzzy string categories.
+
+    This is an online version of [skrub's `GapEncoder`](https://skrub-data.org/stable/reference/generated/skrub.GapEncoder.html),
+    learning one string at a time instead of in batches. Each string is turned into its character
+    n-gram counts `v`, and we look for a small set of latent topics that explain those counts:
+    `v ≈ h @ W`, where `W` holds the topic/n-gram weights and `h` says how strongly each topic is
+    activated by the string. The counts are treated as Poisson with a Gamma prior on `h`, and both
+    `h` and `W` are refined with multiplicative updates as data comes in.
+
+    The point is fuzzy matching. Strings that mean the same thing usually share most of their
+    n-grams ("london", "London, UK", "Lomdon"), so they light up the same topics even when they
+    have no exact token in common. That makes the encoder handy for messy categorical text:
+    hand-typed city names, job titles, chat messages full of typos, and so on.
+
+    The n-gram vocabulary is not fixed ahead of time; it grows as new strings show up, the same
+    way `preprocessing.LDA` grows its word vocabulary. Topics are kept up to date through two
+    accumulators `A` and `B`, with a forgetting factor `rho` that lets old observations decay.
+    `transform_one` is read-only: it only looks at n-grams it has already seen and never changes
+    the model.
+
+    Parameters
+    ----------
+    n_components
+        Number of latent topics.
+    on
+        The name of the feature that contains the text to encode. If `None`, then each
+        `learn_one` and `transform_one` should treat `x` as a `str` and not as a `dict`.
+    strip_accents
+        Whether or not to strip accent characters.
+    lowercase
+        Whether or not to convert all characters to lowercase.
+    ngram_range
+        The lower and upper boundary of the range of character n-grams to be extracted. All
+        values of n such that `min_n <= n <= max_n` will be used.
+    gamma_shape_prior
+        Shape parameter of the Gamma prior on the activations.
+    gamma_scale_prior
+        Scale parameter of the Gamma prior on the activations.
+    rho
+        Forgetting factor for the topic accumulators. Lower values forget the past faster.
+    max_iter_e_step
+        Number of multiplicative iterations used to fit the activations of a sample during
+        `learn_one`. `transform_one` always iterates until convergence (up to 100 iterations).
+    seed
+        Random number seed used for reproducibility. New vocabulary columns of `W` are
+        initialized with Gamma-distributed random draws.
+
+    Attributes
+    ----------
+    vocab : dict
+        Maps each seen n-gram to its column index.
+    W : np.ndarray
+        Topic/n-gram weights, shape `(n_components, len(vocab))`. Rows sum to 1.
+    A : np.ndarray
+        Numerator accumulator of the topic updates, same shape as `W`.
+    B : np.ndarray
+        Denominator accumulator of the topic updates, shape `(n_components, 1)`.
+
+    Examples
+    --------
+
+    Say people type in city names by hand. The same city shows up spelled several different ways,
+    with typos and extra bits, and no two spellings need to share a whole word. The encoder still
+    groups the variants under the same topic:
+
+    >>> from river import preprocessing
+
+    >>> enc = preprocessing.GapEncoder(n_components=2, seed=42)
+
+    >>> X = ["london", "London", "London, UK", "Lomdon", "paris", "Paris", "Paris, France", "pqris"]
+    >>> for _ in range(10):
+    ...     for x in X:
+    ...         enc.learn_one(x)
+
+    Each variant of a city activates the topic of that city, even with typos never seen during
+    training:
+
+    >>> for x in ["London, UK", "Lndon", "Paris, France", "Pariss"]:
+    ...     topics = enc.transform_one(x)
+    ...     print(x, max(topics, key=topics.get), {k: round(v, 3) for k, v in topics.items()})
+    London, UK 1 {0: 0.052, 1: 12.048}
+    Lndon 1 {0: 0.05, 1: 3.05}
+    Paris, France 0 {0: 16.548, 1: 0.052}
+    Pariss 0 {0: 4.55, 1: 0.05}
+
+    References
+    ----------
+    [^1]: [Cerda, P. and Varoquaux, G., 2020. Encoding high-cardinality string categorical variables. IEEE Transactions on Knowledge and Data Engineering.](https://inria.hal.science/hal-02171256v4)
+    [^2]: [skrub's GapEncoder](https://skrub-data.org/stable/reference/generated/skrub.GapEncoder.html)
+
+    """
+
+    def __init__(
+        self,
+        n_components: int = 10,
+        on: str | None = None,
+        strip_accents: bool = True,
+        lowercase: bool = True,
+        ngram_range: tuple[int, int] = (2, 4),
+        gamma_shape_prior: float = 1.1,
+        gamma_scale_prior: float = 1.0,
+        rho: float = 0.95,
+        max_iter_e_step: int = 10,
+        seed: int | None = None,
+    ):
+        self.n_components = n_components
+        self.on = on
+        self.strip_accents = strip_accents
+        self.lowercase = lowercase
+        self.ngram_range = ngram_range
+        self.gamma_shape_prior = gamma_shape_prior
+        self.gamma_scale_prior = gamma_scale_prior
+        self.rho = rho
+        self.max_iter_e_step = max_iter_e_step
+        self.seed = seed
+        self.rng = np.random.RandomState(seed)
+
+        self.vocab: dict[str, int] = {}
+        self.W = np.zeros((n_components, 0))
+        self.A = np.zeros((n_components, 0))
+        self.B = np.full((n_components, 1), 1e-10)
+
+    def _more_tags(self):
+        if self.on is None:
+            return {base.tags.TEXT_INPUT}
+        return {}
+
+    def _preprocess(self, x) -> str:
+        text = x[self.on] if self.on is not None else x
+        if self.strip_accents:
+            text = strip_accents_unicode(text)
+        if self.lowercase:
+            text = text.lower()
+        return text
+
+    def _rescale_w(self) -> None:
+        """Rescale the rows of `W` to sum to 1, keeping `A` consistent."""
+        s = self.W.sum(axis=1, keepdims=True)
+        self.W /= s
+        self.A /= s
+
+    def _fit_h(self, v: np.ndarray, idx: np.ndarray, max_iter: int) -> np.ndarray:
+        """Fit the activations of one sample by multiplicative updates.
+
+        Only the columns `idx` of `W`, i.e. the n-grams present in the sample, take part in the
+        computation.
+
+        """
+        h = np.full(self.n_components, max(1e-10, v.sum()) / self.n_components)
+        WT1 = 1 + 1 / self.gamma_scale_prior
+        W_ = self.W[:, idx]
+        W_WT1_ = W_ / WT1
+        const = (self.gamma_shape_prior - 1) / WT1
+        squared_epsilon = 1e-3**2
+        for _ in range(max_iter):
+            aux = W_WT1_ @ (v / (h @ W_ + 1e-10))
+            h_out = h * aux + const
+            squared_norm = np.dot(h_out - h, h_out - h) / np.dot(h, h)
+            h = h_out
+            if squared_norm <= squared_epsilon:
+                break
+        return h
+
+    def learn_one(self, x):
+        counts = _char_ngrams(self._preprocess(x), self.ngram_range)
+        if not counts:
+            return
+
+        # Grow the vocabulary, and thus W and A, with the sample's unseen n-grams.
+        new = [g for g in counts if g not in self.vocab]
+        if new:
+            for g in new:
+                self.vocab[g] = len(self.vocab)
+            self.W = np.concatenate(
+                [
+                    self.W,
+                    self.rng.gamma(
+                        shape=self.gamma_shape_prior,
+                        scale=self.gamma_scale_prior,
+                        size=(self.n_components, len(new)),
+                    ),
+                ],
+                axis=1,
+            )
+            self.A = np.concatenate([self.A, np.full((self.n_components, len(new)), 1e-10)], axis=1)
+            self._rescale_w()
+
+        idx = np.fromiter((self.vocab[g] for g in counts), dtype=np.intp)
+        v = np.fromiter(counts.values(), dtype=float)
+
+        h = self._fit_h(v, idx, max_iter=self.max_iter_e_step)
+
+        # Topic update through the decayed accumulators.
+        self.A *= self.rho
+        self.B *= self.rho
+        ratio = v / (h @ self.W[:, idx] + 1e-10)
+        self.A[:, idx] += self.W[:, idx] * np.outer(h, ratio)
+        self.B += h[:, None]
+        np.divide(self.A, self.B, out=self.W)
+        self._rescale_w()
+
+    def transform_one(self, x):
+        counts = _char_ngrams(self._preprocess(x), self.ngram_range)
+        known = {g: c for g, c in counts.items() if g in self.vocab}
+        if not known:
+            return {i: 0.0 for i in range(self.n_components)}
+
+        idx = np.fromiter((self.vocab[g] for g in known), dtype=np.intp)
+        v = np.fromiter(known.values(), dtype=float)
+        h = self._fit_h(v, idx, max_iter=100)
+        return dict(enumerate(h.tolist()))

--- a/river/preprocessing/test_gap_encoder.py
+++ b/river/preprocessing/test_gap_encoder.py
@@ -1,0 +1,173 @@
+"""
+The tests performed here confirm the behavioral contracts of preprocessing.GapEncoder: fuzzy
+variants of the same string cluster onto the same topic, the vocabulary grows online,
+transform_one is read-only, and results are reproducible under a fixed seed.
+
+References
+----------
+[^1]: Cerda, P. and Varoquaux, G., 2020. Encoding high-cardinality string categorical variables.
+    IEEE Transactions on Knowledge and Data Engineering.
+    https://inria.hal.science/hal-02171256v4
+
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from river import preprocessing
+
+CITY_SET = [
+    "london",
+    "London",
+    "London, UK",
+    "Lomdon",
+    "paris",
+    "Paris",
+    "Paris, France",
+    "pqris",
+]
+
+
+def _train_city_encoder(n_components=2, **params):
+    enc = preprocessing.GapEncoder(n_components=n_components, seed=42, **params)
+    for _ in range(10):
+        for x in CITY_SET:
+            enc.learn_one(x)
+    return enc
+
+
+def test_fuzzy_variants_cluster():
+    """Morphological variants of the same city, including unseen typos, activate the same
+    topic, and the two cities activate different topics."""
+    enc = _train_city_encoder()
+
+    def argmax(x):
+        topics = enc.transform_one(x)
+        return max(topics, key=topics.get)
+
+    london_topics = {argmax(x) for x in ["london", "London, UK", "Lomdon", "Lndon"]}
+    paris_topics = {argmax(x) for x in ["paris", "Paris, France", "pqris", "Pariss"]}
+
+    assert len(london_topics) == 1
+    assert len(paris_topics) == 1
+    assert london_topics != paris_topics
+
+
+def test_transform_one_is_pure():
+    """transform_one never mutates the model, even on strings with unseen n-grams, and is
+    idempotent."""
+    enc = _train_city_encoder()
+
+    vocab_size = len(enc.vocab)
+    W, A, B = enc.W.copy(), enc.A.copy(), enc.B.copy()
+
+    # Mix of known ("london") and unseen ("zzz") n-grams.
+    first = enc.transform_one("londonzzz")
+    second = enc.transform_one("londonzzz")
+
+    assert first == second
+    assert len(enc.vocab) == vocab_size
+    assert np.array_equal(enc.W, W)
+    assert np.array_equal(enc.A, A)
+    assert np.array_equal(enc.B, B)
+
+
+def test_seed_reproducibility():
+    """Two encoders with the same seed and stream are interchangeable; a different seed leads
+    to different topics."""
+    stream = CITY_SET * 5
+
+    enc_a = preprocessing.GapEncoder(n_components=2, seed=1)
+    enc_b = preprocessing.GapEncoder(n_components=2, seed=1)
+    enc_c = preprocessing.GapEncoder(n_components=2, seed=2)
+    for x in stream:
+        enc_a.learn_one(x)
+        enc_b.learn_one(x)
+        enc_c.learn_one(x)
+
+    for x in ["london", "paris", "Lndon"]:
+        assert enc_a.transform_one(x) == enc_b.transform_one(x)
+
+    # Same stream, hence same vocabulary and shapes, but the topics themselves differ.
+    assert enc_a.W.shape == enc_c.W.shape
+    assert not np.allclose(enc_a.W, enc_c.W)
+
+
+def test_unseen_input_transforms_to_zeros():
+    """Inputs without any known n-gram, including before any learning, map to all-zero
+    activations."""
+    enc = preprocessing.GapEncoder(n_components=2, seed=42)
+    assert enc.transform_one("anything") == {0: 0.0, 1: 0.0}
+
+    for _ in range(3):
+        enc.learn_one("london")
+
+    # No n-gram in common with "london".
+    assert enc.transform_one("zzz") == {0: 0.0, 1: 0.0}
+    assert enc.transform_one("") == {0: 0.0, 1: 0.0}
+
+
+def test_vocabulary_growth():
+    """The vocabulary and W grow with unseen n-grams, and inputs too short to produce any
+    n-gram are no-ops."""
+    enc = preprocessing.GapEncoder(n_components=2, ngram_range=(2, 2), seed=42)
+
+    enc.learn_one("ab")
+    assert len(enc.vocab) == 1
+    assert enc.W.shape == (2, 1)
+
+    enc.learn_one("abc")  # "ab" is known, "bc" is new
+    assert len(enc.vocab) == 2
+    assert enc.W.shape == (2, 2)
+
+    W, A, B = enc.W.copy(), enc.A.copy(), enc.B.copy()
+    enc.learn_one("")
+    enc.learn_one("a")
+    assert len(enc.vocab) == 2
+    assert np.array_equal(enc.W, W)
+    assert np.array_equal(enc.A, A)
+    assert np.array_equal(enc.B, B)
+
+
+def test_on_param_matches_plain_strings():
+    """With `on` set, the encoder reads the text from a dict field and behaves exactly like
+    the plain string encoder."""
+    enc_str = preprocessing.GapEncoder(n_components=2, seed=7)
+    enc_dict = preprocessing.GapEncoder(on="city", n_components=2, seed=7)
+
+    for _ in range(3):
+        for x in CITY_SET:
+            enc_str.learn_one(x)
+            enc_dict.learn_one({"city": x})
+
+    for x in ["london", "Paris, France", "Lndon"]:
+        assert enc_str.transform_one(x) == enc_dict.transform_one({"city": x})
+
+
+def test_output_keys_and_positivity():
+    """Transforming a seen string yields one strictly positive activation per component."""
+    enc = _train_city_encoder(n_components=3)
+    topics = enc.transform_one("london")
+
+    assert set(topics.keys()) == {0, 1, 2}
+    assert all(value > 0 for value in topics.values())
+
+
+def test_strip_accents_and_lowercase():
+    """Default preprocessing folds case and accents before n-gram extraction, so casing and
+    accent variants encode identically; with `lowercase=False` case is preserved, leaving an
+    all-caps query with no n-gram in common with a lowercase-trained vocabulary."""
+    enc = _train_city_encoder()
+    london = enc.transform_one("london")
+
+    assert enc.transform_one("LONDON") == london  # case folds onto the trained "london"
+    assert enc.transform_one("Lôndon") == london  # accents strip to the same n-grams
+
+    cased = preprocessing.GapEncoder(n_components=2, lowercase=False, seed=42)
+    for _ in range(5):
+        cased.learn_one("london")
+
+    # Case is kept, so uppercase shares no n-gram with the lowercase vocabulary.
+    assert cased.transform_one("LONDON") == {0: 0.0, 1: 0.0}
+    assert cased.transform_one("london") != {0: 0.0, 1: 0.0}


### PR DESCRIPTION
A worked example notebook for the `GapEncoder` (see #1439), living under `docs/examples`.

It builds a stream of hand-typed city names — 689 spellings for only 9 real cities — where the label depends on the true city but the model only sees the misspelled version. One-hot encoding barely beats chance (57% ROC AUC) because every typo is a new, unrelated category, while the `GapEncoder` recovers almost all the signal (70%, right next to a 72% oracle that gets to see the clean names). The notebook also shows fuzzy variants clustering by cosine similarity and the labels the topics learn.

Stacked on #1938 (which adds the `GapEncoder` itself) — this PR should be merged after it. Until then the diff shows both changes; it'll narrow to just the notebook + nav once #1938 lands.