### PR TITLE
fix remaining deprecated abstractproperty decorator

### DIFF
--- a/river/bandit/datasets/base.py
+++ b/river/bandit/datasets/base.py
@@ -40,7 +40,8 @@ class BanditDataset(datasets.base.Dataset):
             sparse=sparse,
         )
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def arms(self) -> list[bandit.base.ArmID]:
         """The list of arms that can be pulled."""
 


### PR DESCRIPTION
`abc.abstractproperty` is deprecated since Python 3.3, in favor of stacked decorators:
```
@property
@abstractmethod
def ...
```
This pattern is enforced everywhere in the codebase except one tiny omission, this PR fixes it.