### PR TITLE
Fix Metrics collection dropping the sample weight

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -58,6 +58,10 @@
 - `linear_model.LinearRegression` and `linear_model.LogisticRegression` mini-batch methods (`learn_many`, `predict_many`, `predict_proba_many`) now accept and return any [narwhals](https://github.com/narwhals-dev/narwhals)-supported eager backend (pandas, polars, pyarrow, ...) instead of being pandas-only. The input backend is preserved on output, including the pandas index. These methods no longer require `pandas` to be installed.
 - `linear_model.BayesianLinearRegression` is now a `MiniBatchRegressor`: it gained a `learn_many` method, equivalent to looping `learn_one` over the rows (exact without smoothing, and the matching closed-form geometric weighting with smoothing). Its `learn_many`/`predict_many` accept and return any [narwhals](https://github.com/narwhals-dev/narwhals)-supported eager backend (pandas, polars, pyarrow, ...), preserving the input backend and pandas index, and no longer require `pandas`.
 
+## metrics
+
+- Fixed `metrics.base.Metrics` (a metrics collection, built via `metric_a + metric_b`) dropping the sample weight `w`: `update` now forwards `w` to each child metric, so weighted metrics report correct values inside a collection and `update`/`revert` cancel exactly. Previously `revert` applied the weight but `update` ignored it.
+
 ## multiclass
 
 - `multiclass.OneVsRestClassifier` mini-batch methods (`learn_many`, `predict_many`, `predict_proba_many`) now accept and return any [narwhals](https://github.com/narwhals-dev/narwhals)-supported eager backend (pandas, polars, pyarrow, ...) instead of being pandas-only. The input backend is preserved on output, including the pandas index, and these methods no longer require `pandas` to be installed. Outputs are unchanged on the pandas path.

--- a/river/metrics/base.py
+++ b/river/metrics/base.py
@@ -225,13 +225,13 @@ class Metrics(Metric, collections.UserList):
         if hasattr(self, "requires_labels") and not self.requires_labels:
             for m in self:
                 if m.requires_labels:
-                    m.update(y_true, max(y_pred, key=y_pred.get))
+                    m.update(y_true, max(y_pred, key=y_pred.get), w)
                 else:
-                    m.update(y_true, y_pred)
+                    m.update(y_true, y_pred, w)
             return
 
         for m in self:
-            m.update(y_true, y_pred)
+            m.update(y_true, y_pred, w)
 
     def revert(self, y_true, y_pred, w=1.0) -> None:
         # If the metrics are classification metrics, then we have to handle the case where some

--- a/river/metrics/test_metrics.py
+++ b/river/metrics/test_metrics.py
@@ -313,3 +313,19 @@ def test_compose():
 
     with pytest.raises(ValueError):
         _ = metrics.MSE() + metrics.MAE() + metrics.LogLoss()
+
+
+def test_metrics_collection_forwards_sample_weight():
+    # A Metrics collection must forward the sample weight to its children, just
+    # like a standalone metric does (and like Metrics.revert already does).
+    coll = metrics.MAE() + metrics.MSE()
+    standalone = metrics.MAE()
+    for y_true, y_pred, w in [(0, 0, 1.0), (0, 10, 99.0)]:
+        coll.update(y_true, y_pred, w)
+        standalone.update(y_true, y_pred, w)
+    assert coll[0].get() == standalone.get() == pytest.approx(9.9)
+
+    # update(w) and revert(w) must cancel exactly, leaving empty-state values.
+    coll.revert(0, 0, 1.0)
+    coll.revert(0, 10, 99.0)
+    assert coll[0].get() == pytest.approx(0.0)


### PR DESCRIPTION
## Problem

A `metrics.base.Metrics` collection — the object you get from `metric_a + metric_b` — accepts a sample weight `w` in `update`, but never forwards it to its child metrics. The weight is silently treated as `1`.

`Metrics.revert` *does* pass `w` to the children, so the two methods are asymmetric. Two consequences:

```python
from river import metrics

coll = metrics.MAE() + metrics.MSE()
coll.update(0, 0, w=1)
coll.update(0, 10, w=99)
coll[0].get()          # 5.0   ❌  (weight dropped)

standalone = metrics.MAE()
standalone.update(0, 0, w=1)
standalone.update(0, 10, w=99)
standalone.get()       # 9.9   ✅  (weight honored)
```

1. A weighted metric inside a collection reports the wrong value.
2. Because `update` adds weight `1` while `revert` removes the real weight, an `update(w)` / `revert(w)` pair no longer cancels — it can raise `ValueError("Cannot go below 0")` from the underlying running statistic.

Note `Metrics.works_with_weights` already advertises weight support (`all(child.works_with_weights ...)`), so the collection claims a capability its `update` didn't honor.

## Fix

Forward `w` in the three `update` call sites, exactly mirroring `revert`.

## Test plan

Added `test_metrics_collection_forwards_sample_weight` to `river/metrics/test_metrics.py`: a weighted collection now matches a standalone metric (`9.9`), and `update`/`revert` cancel back to empty state.

- On `main` the new test fails (`assert 5.0 == 9.9`); with this change it passes.
- `pytest river/metrics/` → 274 passed (including doctests).
- `ruff check` / `ruff format --check` clean on both files.
- Added a `## metrics` entry to `docs/releases/unreleased.md`.

---
Authored with assistance from Claude Code (Anthropic); the bug, fix, and test were reviewed and verified locally by the contributor.