### PR TITLE
Stop PreviousImputer.transform_one from mutating the input dict

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -104,6 +104,7 @@
 - `preprocessing.FeatureHasher` now hashes with MurmurHash3 in Rust, making it much faster. It gains an `alternate_sign` parameter (default `True`, matching scikit-learn) and returns a plain `dict`. Hashed feature indices differ from previous versions.
 - `preprocessing.OneHotEncoder` mini-batch methods (`learn_many`, `transform_many`) now accept and return any [narwhals](https://github.com/narwhals-dev/narwhals)-supported eager backend (pandas, polars, pyarrow, ...) instead of being pandas-only, preserving the input backend (including the pandas index) on output. The pandas path keeps returning `Sparse[uint8]` columns; other backends return dense integer columns, as they have no sparse-array equivalent. `transform_many` only requires `pandas` when the input is a pandas frame.
 - `preprocessing.OrdinalEncoder` mini-batch methods (`learn_many`, `predict_many`, `predict_proba_many`) now accept and return any [narwhals](https://github.com/narwhals-dev/narwhals)-supported eager backend (pandas, polars, pyarrow, ...) instead of being pandas-only. The input backend is preserved on output, including the pandas index. These methods no longer require `pandas` to be installed.
+- Fixed `preprocessing.PreviousImputer.transform_one` mutating the caller's dictionary in place: it now copies the features before filling missing values, like `StatImputer` does. Transformers are supposed to be pure, and the mutation was visible to other branches of a `compose.TransformerUnion` fed the same dict.
 
 ## proba
 

--- a/river/preprocessing/impute.py
+++ b/river/preprocessing/impute.py
@@ -35,6 +35,8 @@ class PreviousImputer(base.Transformer):
                 self._latest[i] = v
 
     def transform_one(self, x):
+        # Transformers are supposed to be pure, therefore we make a copy of the features
+        x = x.copy()
         for i, v in x.items():
             if v is None:
                 x[i] = self._latest.get(i)

--- a/river/preprocessing/test_impute.py
+++ b/river/preprocessing/test_impute.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from river import preprocessing
+
+
+def test_previous_imputer_does_not_mutate_input():
+    """transform_one must be pure: it should not modify the caller's dict.
+
+    The purity check in river.checks uses a dataset without missing values, so
+    it never exercises the branch that fills a None, which is exactly where the
+    mutation happened.
+    """
+    imputer = preprocessing.PreviousImputer()
+    imputer.learn_one({"x": 5})
+
+    x = {"x": None, "y": 1}
+    original = dict(x)
+    transformed = imputer.transform_one(x)
+
+    assert x == original, "transform_one mutated its input"
+    assert transformed is not x
+    assert transformed == {"x": 5, "y": 1}

--- a/river/preprocessing/test_impute.py
+++ b/river/preprocessing/test_impute.py
@@ -4,12 +4,6 @@ from river import preprocessing
 
 
 def test_previous_imputer_does_not_mutate_input():
-    """transform_one must be pure: it should not modify the caller's dict.
-
-    The purity check in river.checks uses a dataset without missing values, so
-    it never exercises the branch that fills a None, which is exactly where the
-    mutation happened.
-    """
     imputer = preprocessing.PreviousImputer()
     imputer.learn_one({"x": 5})
 

--- a/river/test_estimators.py
+++ b/river/test_estimators.py
@@ -60,7 +60,6 @@ def iter_estimators_which_can_be_tested():
         imblearn.RandomSampler,
         model_selection.SuccessiveHalvingClassifier,
         neighbors.LazySearch,
-        preprocessing.PreviousImputer,
         preprocessing.OneHotEncoder,
         preprocessing.StatImputer,
     )


### PR DESCRIPTION
### Problem

`PreviousImputer.transform_one` mutates the caller's dict:

```python
imp = preprocessing.PreviousImputer()
imp.learn_one({"x": 5})
x = {"x": None, "y": 1}
imp.transform_one(x)
# x is now {"x": 5, "y": 1} -- the input was changed in place, and the
# return value is the same object.
```

Transformers are supposed to be pure. The sibling `StatImputer` already copies the features (`x = x.copy()`) with exactly that rationale in a comment; `PreviousImputer` was missing it and wrote straight into `x`.

### Why the estimator check didn't catch it

`check_predict_one_pure` asserts the input isn't mutated, but it runs on a dataset with no missing values, so the `None` branch — the only place the mutation happens — is never exercised.

### Impact

`compose.TransformerUnion` feeds the same `x` to every branch. If a `PreviousImputer` runs first, it rewrites the values the other branches then see (e.g. a missing-flag branch would no longer see the `None`).

### Fix

Copy the features at the top of `transform_one`, mirroring `StatImputer`. One line, plus a regression test asserting purity, plus a changelog entry.

Verification: the new test fails on `main` (`transform_one mutated its input`) and passes here; `check_estimator(PreviousImputer())` passes; the `impute` doctests pass; `ruff` clean.

---

*Disclosure: authored by an AI coding agent (Claude Code) running on this account — it found the bug, ran the repro, wrote the test and this description. I review every change and am accountable for it; the verification above is real and re-runnable from the diff.*
