### PR TITLE
Fix BalancedAccuracy deflating its score for predicted-only classes

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -66,6 +66,7 @@
 ## metrics
 
 - Fixed `metrics.base.Metrics` (a metrics collection, built via `metric_a + metric_b`) dropping the sample weight `w`: `update` now forwards `w` to each child metric, so weighted metrics report correct values inside a collection and `update`/`revert` cancel exactly. Previously `revert` applied the weight but `update` ignored it.
+- Fixed `metrics.BalancedAccuracy` deflating its score when a label appears in the predictions but never as a ground-truth label. Such a class has no support, so its recall is undefined and must be excluded from the per-class average; previously it was counted as `0` and inflated the denominator, disagreeing with `sklearn.metrics.balanced_accuracy_score`. `BalancedAccuracy` is now covered by the scikit-learn equivalence test.
 
 ## multiclass
 

--- a/river/metrics/balanced_accuracy.py
+++ b/river/metrics/balanced_accuracy.py
@@ -45,13 +45,18 @@ class BalancedAccuracy(metrics.base.MultiClassMetric):
 
     def get(self):
         total = 0
+        n_classes = 0
         for c in self.cm.classes:
             try:
                 total += self.cm[c][c] / self.cm.sum_row[c]
             except ZeroDivisionError:
+                # A class that only appears in the predictions has no support, so its
+                # recall is undefined and it must not be counted in the average (this
+                # matches sklearn.metrics.balanced_accuracy_score).
                 continue
+            n_classes += 1
         try:
-            score = total / len(self.cm.classes)
+            score = total / n_classes
 
             return score
 

--- a/river/metrics/test_metrics.py
+++ b/river/metrics/test_metrics.py
@@ -136,6 +136,7 @@ def pr_auc_score(y_true, y_score):
 
 TEST_CASES = [
     (metrics.Accuracy(), sk_metrics.accuracy_score),
+    (metrics.BalancedAccuracy(), sk_metrics.balanced_accuracy_score),
     (metrics.Precision(), partial(sk_metrics.precision_score, zero_division=0)),
     (
         metrics.MacroPrecision(),
@@ -329,3 +330,20 @@ def test_metrics_collection_forwards_sample_weight():
     coll.revert(0, 0, 1.0)
     coll.revert(0, 10, 99.0)
     assert coll[0].get() == pytest.approx(0.0)
+
+
+def test_balanced_accuracy_ignores_unseen_predicted_classes():
+    # A class that only shows up in the predictions has no support, so its recall is
+    # undefined and must be excluded from the average, exactly like
+    # sklearn.metrics.balanced_accuracy_score. Otherwise the score is deflated by
+    # dividing over too many classes.
+    y_true = [0, 0, 1, 1]
+    y_pred = [0, 2, 1, 1]  # class 2 never appears as a true label
+
+    metric = metrics.BalancedAccuracy()
+    for yt, yp in zip(y_true, y_pred):
+        metric.update(yt, yp)
+
+    # recall(0) = 1/2, recall(1) = 2/2, class 2 dropped -> (0.5 + 1.0) / 2
+    assert metric.get() == pytest.approx(sk_metrics.balanced_accuracy_score(y_true, y_pred))
+    assert metric.get() == pytest.approx(0.75)


### PR DESCRIPTION
### The bug

`BalancedAccuracy.get` averages per-class recall, but it divided the recall sum by `len(self.cm.classes)`, where `cm.classes` is the **union** of true and predicted labels:

```python
for c in self.cm.classes:
    try:
        total += self.cm[c][c] / self.cm.sum_row[c]
    except ZeroDivisionError:
        continue
return total / len(self.cm.classes)
```

A class that only appears in the **predictions** (never as a ground-truth label) has no support: its recall is undefined (`0/0` → `ZeroDivisionError`, correctly skipped in the numerator) — but it was still counted in the denominator. The score is therefore deflated by dividing over too many classes.

In online learning this is the normal regime: a model calls `predict_one` then `metric.update(y_true, y_pred)`, so it can emit a label before that label has ever occurred as ground truth (stream start, rare classes, drift).

```python
y_true = [0, 0, 1, 1]
y_pred = [0, 2, 1, 1]   # class 2 never appears as a true label

# recall(0) = 1/2, recall(1) = 2/2
BalancedAccuracy -> 0.5     # (0.5 + 1.0) / 3   (union size 3)
sklearn          -> 0.75    # (0.5 + 1.0) / 2   (class 2 dropped)
```

`sklearn.metrics.balanced_accuracy_score` excludes such classes (it even warns `y_pred contains classes not in y_true`).

### The fix

Count only the classes whose recall is defined:

```python
n_classes = 0
for c in self.cm.classes:
    try:
        total += self.cm[c][c] / self.cm.sum_row[c]
    except ZeroDivisionError:
        continue
    n_classes += 1
score = total / n_classes
```

### Why it went unnoticed

`BalancedAccuracy` was never registered in the scikit-learn equivalence test suite (`TEST_CASES` in `test_metrics.py`), which streams random multi-class data and asserts river-vs-sklearn agreement. This PR adds it there (so the streaming/rolling harness now covers it) plus a targeted regression test. The existing docstring examples have no predicted-only class, so their `62.50%` output is unchanged.

### Verification

- Regression test + the `TEST_CASES` registration fail before the fix, pass after.
- `pytest river/metrics/ --doctest-modules` → 277 passed. `ruff check`/`ruff format --check` clean. Changelog entry added under `## metrics`.

---

This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro against scikit-learn, wrote the test, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
