### PR TITLE
Fix Beta.n_samples returning the negation of the sample count

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -108,6 +108,7 @@
 ## proba
 
 - Added weighted sample support to `MultivariateGaussian.update` and `MultivariateGaussian.revert` by accepting an optional `w` parameter and propagating it to the underlying `EmpiricalCovariance` instance.
+- Fixed `Beta.n_samples` returning the negative of the observed-sample count (the two operands of the difference were transposed), so it now returns a non-negative count consistent with the other `proba` distributions.
 
 ## reco
 

--- a/river/proba/beta.py
+++ b/river/proba/beta.py
@@ -60,6 +60,11 @@ class Beta(base.ContinuousDistribution):
     >>> beta(.21), beta(.35)
     (2.525...e-05, 0.841...)
 
+    ``n_samples`` counts the observed updates, not the prior pseudo-counts:
+
+    >>> beta.n_samples
+    300
+
     >>> beta.cdf(.35)
     0.994168...
 
@@ -78,7 +83,7 @@ class Beta(base.ContinuousDistribution):
 
     @property
     def n_samples(self):
-        return self._alpha - self.alpha + self._beta - self.beta
+        return self.alpha - self._alpha + self.beta - self._beta
 
     def update(self, x):
         if x:


### PR DESCRIPTION
## Problem

`proba.Beta.n_samples` returns the **negative** of the observed-sample count:

```python
>>> from river import proba
>>> b = proba.Beta()
>>> for _ in range(5): b.update(True)
>>> b.n_samples
-5          # expected 5
```

The property computes `self._alpha - self.alpha + self._beta - self.beta`. `_alpha`/`_beta` are the frozen initial parameters, while `alpha`/`beta` are incremented by `update()`, so the expression evaluates to `-(#successes + #failures)`.

`n_samples` is the `proba.base.Distribution` abstract contract ("The number of observed samples"), and every sibling returns it as a non-negative count — `Gaussian.n_samples` → `.mean.n`, `Multinomial.n_samples` → `sum(counts)`. `Beta` is the only one with the sign flipped.

## Fix

Swap the two operands so the difference is `grown - initial`:

```python
return self.alpha - self._alpha + self.beta - self._beta
```

Priors stay excluded (a fresh `Beta(81, 219)` still reports `0` until it sees data), matching the initial value and the other distributions.

## Verification

- Added an `n_samples` line to the existing `Beta` doctest — it fails with `-300` before the change and passes with `300` after (300 = 100 + 200 updates in that example, priors excluded).
- `pytest --doctest-modules river/proba/` → 7 passed; `river/bandit/test_policies.py` (the main `Beta` consumer, via `sample()`) → 8 passed / 22 skipped; `ruff check` clean.
- Grepped the whole tree: no in-tree code reads `Beta.n_samples`, so this only corrects the public property's returned sign — no caller relied on the negative value.
- Added an entry under `## proba` in `docs/releases/unreleased.md`.

---

*This PR was authored by an AI coding agent (Claude Code) running on this account: it found the bug, ran the repro, wrote the test and this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.*
