### PR TITLE
Fix Pipeline.transform_many learning during transform in default mode

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -25,6 +25,7 @@
 ## compose
 
 - `compose.Pipeline` now forwards extra keyword arguments (such as the timestamp `t` used by `utils.TimeRolling`, or a sample weight `w`) to each step whose method declares them, and drops them for steps that don't. This makes `feature_extraction.Agg`/`TargetAgg` backed by `utils.TimeRolling` work inside a pipeline via `model.learn_one(x, y, t=t)`. Routing applies to `learn_one` and to the predict-time methods (`predict_one`, `predict_proba_one`, `score_one`, `transform_one`), so it also works under `compose.learn_during_predict` where unsupervised steps learn during `predict_one(x, t=t)`. Fixes [#1600](https://github.com/online-ml/river/issues/1600). The accepted arguments are determined once when the pipeline plan is built, so pipelines with no extra arguments keep their previous speed.
+- Fixed `compose.Pipeline.transform_many` fitting the final unsupervised transformer on the data being transformed when `learn_during_predict` is off (a `not` was inverted relative to the single-instance `transform_one` and to the intermediate steps). `transform_many` no longer mutates the model outside `learn_during_predict`, and it now agrees with `transform_one` instead of double-learning the final step.
 
 ## covariance
 

--- a/river/compose/pipeline.py
+++ b/river/compose/pipeline.py
@@ -856,7 +856,7 @@ class Pipeline(base.Estimator):
         """
         X, last_step = self._transform_many(X=X)
         if isinstance(last_step, base.MiniBatchTransformer):
-            if not last_step._supervised and not self._LEARN_UNSUPERVISED_DURING_PREDICT:
+            if not last_step._supervised and self._LEARN_UNSUPERVISED_DURING_PREDICT:
                 last_step.learn_many(X)
             return last_step.transform_many(X)
         return X

--- a/river/compose/test_product.py
+++ b/river/compose/test_product.py
@@ -106,6 +106,7 @@ def test_issue_1253():
     ...     compat.convert_sklearn_to_river(linear_model.SGDRegressor(max_iter=3))
     ... )
     >>> _ = model.predict_many(X)
+    >>> model.learn_many(X, y)
     >>> model.transform_many(X)
        cat_1*feat_2  cat_2*feat_2  cat_1  cat_2
     0     -1.196841             0      1      0


### PR DESCRIPTION
## Problem

`Pipeline.transform_many` fits the final unsupervised transformer on the data it is transforming, even in the default mode (`learn_during_predict` off):

```python
model = compose.Select("a") | preprocessing.StandardScaler()
model.transform_many(X)          # mutates the scaler's fitted state
```

The learn-during-predict step is gated on

```python
if not last_step._supervised and not self._LEARN_UNSUPERVISED_DURING_PREDICT:
    last_step.learn_many(X)
```

The second `not` is inverted relative to the single-instance twin `transform_one` (which uses `... and self._LEARN_UNSUPERVISED_DURING_PREDICT`) and to `transform_many`'s own intermediate-step loop. Consequences in the default mode:

- a bare `transform_many` mutates fitted state (a fresh scaler ends up with `counts == len(X)`), while `transform_one` leaves it untouched;
- the normal `learn_many` → `transform_many` loop double-learns the final step;
- `transform_one` and `transform_many`, documented as the same operation, disagree.

## Fix

Drop the erroneous `not` so the batch path matches the single-instance path and the intermediate steps.

## On the test change

`test_product.py::test_issue_1253` relied on the bug: its model is never trained, so the only thing that ever fitted the nested `StandardScaler` was the fit-during-transform. Adding an explicit `model.learn_many(X, y)` before the transform reproduces the **exact same** expected output (fitting the same rows twice leaves mean/variance unchanged), so the expected block is untouched.

## Verification

- New RED→GREEN behaviour, plus `river/compose --doctest-modules` → **41 passed**.
- `ruff` clean; added a `## compose` entry to `docs/releases/unreleased.md`.

## Note on #1932 (open)

That PR makes `transform_many` narwhals/dataframe-agnostic (a signature refactor) but does **not** touch the inverted `_LEARN_UNSUPERVISED_DURING_PREDICT` condition, so it carries this bug forward rather than fixing it. The two changes are on different lines; whichever lands first, this one-token fix should be preserved. Happy to rebase onto #1932 if you'd rather fold it in there.

---

*This PR was authored by an AI coding agent (Claude Code) running on this account: it found the bug, ran the repro, wrote the test change and this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.*
