### PR TITLE
feat(compat): dataframe-agnostic scikit-learn wrappers via narwhals

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -22,6 +22,12 @@
 - Gave the `CluStream`, `DenStream`, and `DBSTREAM` micro-cluster objects `__slots__`. These are created in large numbers on long streams, so dropping their per-instance `__dict__` trims memory (~40 bytes per micro-cluster). Behavior is unchanged.
 - `CluStreamMicroCluster` no longer inherits from `base.Base`; it is an internal data structure, not an estimator, so the estimator machinery (cloning, parameter introspection, `repr`) never applied to it. This matches the `DenStream`/`DBSTREAM` micro-clusters and is what lets it use `__slots__`.
 
+## compat
+
+- The mini-batch methods of the scikit-learn wrappers (`compat.SKL2RiverRegressor`, `compat.SKL2RiverClassifier`) now accept and return any [narwhals](https://github.com/narwhals-dev/narwhals)-supported eager backend (pandas, polars, pyarrow, ...) instead of being pandas-only, preserving the input backend and pandas index on output. A mini-batch missing a learnt feature now raises a `ValueError` naming it.
+- `compat.convert_sklearn_to_river` is now overloaded on `classes`, so a type checker infers `SKL2RiverRegressor` when it is omitted and `SKL2RiverClassifier` when it is given. Behavior change: passing `classes` along with a regressor now raises a `ValueError` instead of being silently ignored.
+- `compat.SKL2RiverClassifier.predict_proba_one` now returns plain `float` probabilities instead of numpy scalars.
+
 ## compose
 
 - The mini-batch methods of `compose.Pipeline`, `compose.TransformerUnion`, `compose.Select`, and `compose.TransformerProduct` now accept and return any [narwhals](https://github.com/narwhals-dev/narwhals)-supported eager backend (pandas, polars, pyarrow, ...) instead of being pandas-only, so a whole pipeline can be mini-batched on a non-pandas backend. The input backend is preserved on output, including the pandas index, and `pandas` is no longer required unless the input is a pandas frame. `TransformerProduct` keeps the pandas `Sparse[uint8]` fast path when crossing one-hot encoded features.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -272,7 +272,7 @@ module = [
     "river.sketch.*",
     "river.facto.*",
     "river.covariance.*",
-    "river.compat.*",
+    "river.compat.river_to_sklearn",
     "river.multiclass.*",
     "river.reco.*",
     "river.imblearn.*",

--- a/river/compat/sklearn_to_river.py
+++ b/river/compat/sklearn_to_river.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import copy
-import functools
 import typing
 
+import narwhals.stable.v2 as nw
+import numpy as np
 from sklearn import base as sklearn_base
 from sklearn import exceptions as sklearn_exceptions
 from sklearn import linear_model as sklearn_linear_model
@@ -11,59 +12,104 @@ from sklearn import linear_model as sklearn_linear_model
 from river import base, utils
 
 if typing.TYPE_CHECKING:
-    import pandas as pd
+    from collections.abc import Iterator
+
+    from narwhals.stable.v2.typing import IntoDataFrame, IntoDataFrameT, IntoSeries
+    from numpy.typing import NDArray
+
+    T = typing.TypeVar("T")
+
+    class _IncrementalEstimator(typing.Protocol):
+        """The duck-typed slice of a scikit-learn estimator these wrappers rely on.
+
+        `sklearn.base.BaseEstimator` declares none of these: `partial_fit`/`predict` come from the
+        mixins and are only present on the concrete estimators. Naming the contract here keeps the
+        call sites typed, and mirrors the `hasattr(estimator, "partial_fit")` guard in
+        `convert_sklearn_to_river`.
+        """
+
+        def partial_fit(self, X: typing.Any, y: typing.Any, **kwargs: typing.Any) -> typing.Any: ...
+
+        def predict(self, X: typing.Any) -> NDArray[typing.Any]: ...
+
+    class _ProbabilisticEstimator(_IncrementalEstimator, typing.Protocol):
+        def predict_proba(self, X: typing.Any) -> NDArray[np.float64]: ...
+
 
 __all__ = ["convert_sklearn_to_river", "SKL2RiverClassifier", "SKL2RiverRegressor"]
 
 
-def convert_sklearn_to_river(estimator: sklearn_base.BaseEstimator, classes: list | None = None):
+@typing.overload
+def convert_sklearn_to_river(
+    estimator: sklearn_base.BaseEstimator, classes: None = None
+) -> SKL2RiverRegressor: ...
+
+
+@typing.overload
+def convert_sklearn_to_river(
+    estimator: sklearn_base.BaseEstimator, classes: list[base.typing.ClfTarget]
+) -> SKL2RiverClassifier: ...
+
+
+def convert_sklearn_to_river(
+    estimator: sklearn_base.BaseEstimator, classes: list[base.typing.ClfTarget] | None = None
+) -> SKL2RiverRegressor | SKL2RiverClassifier:
     """Wraps a scikit-learn estimator to make it compatible with river.
 
     Parameters
     ----------
     estimator
     classes
-        Class names necessary for classifiers.
+        Class names. Required for classifiers, and not accepted for regressors.
 
     """
 
     if not hasattr(estimator, "partial_fit"):
         raise ValueError(f"{estimator} does not have a partial_fit method")
 
-    if isinstance(estimator, sklearn_base.ClassifierMixin) and classes is None:
-        raise ValueError("classes must be provided to convert a classifier")
+    if isinstance(estimator, sklearn_base.RegressorMixin):
+        if classes is not None:
+            raise ValueError("classes is only used for classifiers, a regressor cannot take it")
+        return SKL2RiverRegressor(copy.deepcopy(estimator))
 
-    wrappers = [
-        (sklearn_base.RegressorMixin, SKL2RiverRegressor),
-        (
-            sklearn_base.ClassifierMixin,
-            functools.partial(SKL2RiverClassifier, classes=classes),  # type:ignore[arg-type]
-        ),
-    ]
-
-    for base_type, wrapper in wrappers:
-        if isinstance(estimator, base_type):
-            return wrapper(copy.deepcopy(estimator))  # type: ignore
+    if isinstance(estimator, sklearn_base.ClassifierMixin):
+        if classes is None:
+            raise ValueError("classes must be provided to convert a classifier")
+        return SKL2RiverClassifier(copy.deepcopy(estimator), classes=classes)
 
     raise ValueError("Couldn't find an appropriate wrapper")
 
 
 class SKL2RiverBase:
-    def __init__(self, estimator: sklearn_base.BaseEstimator):
-        self.estimator = estimator
-        self._feature_names: list | None = None
+    def __init__(self, estimator: sklearn_base.BaseEstimator) -> None:
+        # The public contract is "any scikit-learn estimator", but only the incremental slice of
+        # its interface is ever used; see `_IncrementalEstimator`.
+        self.estimator = typing.cast("_IncrementalEstimator", estimator)
+        self._feature_names: list[base.typing.FeatureName] | None = None
 
-    def _align_dict(self, x: dict) -> list:
+    def _align_dict(self, x: dict[base.typing.FeatureName, T]) -> list[T]:
         if self._feature_names is None:
             self._feature_names = list(x.keys())
         return [x[k] for k in self._feature_names]
 
-    def _align_df(self, X: pd.DataFrame) -> pd.DataFrame:
+    def _align_frame(self, X: IntoDataFrameT) -> nw.DataFrame[IntoDataFrameT]:
+        X_nw = utils.dataframe.into_frame(X)
+        columns = X_nw.columns
         if self._feature_names is None:
-            self._feature_names = list(X.columns)
-        return X[self._feature_names]
+            self._feature_names = list(columns)
+        if columns == self._feature_names:
+            return X_nw
+        if missing := [name for name in self._feature_names if name not in columns]:
+            raise ValueError(
+                f"The following features are missing from the mini-batch: {missing}. "
+                "Every batch has to carry the features seen in the first one."
+            )
+        # `nw.col` rather than bare names: pandas allows non-string column labels
+        # (a frame built from an array is keyed on integers), which `select` rejects
+        # unless wrapped with nw.col(...)
+        return X_nw.select(nw.col(self._feature_names))  # type: ignore[arg-type]
 
-    def _unit_test_skips(self):  # noqa
+    def _unit_test_skips(self) -> set[str]:
         return {
             "check_emerging_features",
             "check_disappearing_features",
@@ -107,27 +153,34 @@ class SKL2RiverRegressor(SKL2RiverBase, base.Regressor):
 
     """
 
-    def learn_one(self, x, y):
+    def learn_one(
+        self, x: dict[base.typing.FeatureName, typing.Any], y: base.typing.RegTarget
+    ) -> None:
         self.estimator.partial_fit(X=[self._align_dict(x)], y=[y])
 
-    def learn_many(self, X, y):
-        self.estimator.partial_fit(X=self._align_df(X), y=y)
+    def learn_many(self, X: IntoDataFrame, y: IntoSeries) -> None:
+        self.estimator.partial_fit(X=self._align_frame(X).to_native(), y=y)
 
-    def predict_one(self, x):
+    def predict_one(self, x: dict[base.typing.FeatureName, typing.Any]) -> base.typing.RegTarget:
         try:
-            return self.estimator.predict(X=[self._align_dict(x)])[0]
+            prediction = self.estimator.predict(X=[self._align_dict(x)])[0]
         except sklearn_exceptions.NotFittedError:
             return 0
+        # Indexing a numpy array yields `typing.Any`; a regressor predicts a real number.
+        return typing.cast("base.typing.RegTarget", prediction)
 
-    def predict_many(self, X):
-        pd = utils.pandas.import_pandas()
+    def predict_many(self, X: IntoDataFrame) -> IntoSeries:
+        X_nw = self._align_frame(X)
+        values: NDArray[typing.Any]
         try:
-            return pd.Series(self.estimator.predict(self._align_df(X)))
+            values = self.estimator.predict(X_nw.to_native())
         except sklearn_exceptions.NotFittedError:
-            return pd.Series([0] * len(X), index=X.index)
+            # Mirror the `0` that `predict_one` falls back on, dtype included.
+            values = np.zeros(len(X_nw), dtype=np.int64)
+        return utils.dataframe.to_native_series(values, name=None, like=X_nw)
 
     @classmethod
-    def _unit_test_params(cls):
+    def _unit_test_params(cls) -> Iterator[dict[str, typing.Any]]:
         yield {"estimator": sklearn_linear_model.SGDRegressor()}
 
 
@@ -174,58 +227,68 @@ class SKL2RiverClassifier(SKL2RiverBase, base.Classifier):
 
     """
 
-    def __init__(self, estimator: sklearn_base.ClassifierMixin, classes: list):
+    #: A classifier additionally has to expose `predict_proba`; this narrows the declaration
+    #: inherited from `SKL2RiverBase`.
+    estimator: _ProbabilisticEstimator
+
+    def __init__(
+        self, estimator: sklearn_base.BaseEstimator, classes: list[base.typing.ClfTarget]
+    ) -> None:
         super().__init__(estimator)
         self.classes = classes
 
     @property
-    def _multiclass(self):
+    def _multiclass(self) -> bool:
         return len(self.classes) > 2
 
-    def learn_one(self, x, y):
+    def learn_one(
+        self, x: dict[base.typing.FeatureName, typing.Any], y: base.typing.ClfTarget
+    ) -> None:
         self.estimator.partial_fit(X=[self._align_dict(x)], y=[y], classes=self.classes)
 
-    def learn_many(self, X, y):
-        self.estimator.partial_fit(X=self._align_df(X), y=y, classes=self.classes)
+    def learn_many(self, X: IntoDataFrame, y: IntoSeries) -> None:
+        self.estimator.partial_fit(X=self._align_frame(X).to_native(), y=y, classes=self.classes)
 
-    def predict_proba_one(self, x):
+    def predict_proba_one(
+        self, x: dict[base.typing.FeatureName, typing.Any], **kwargs: typing.Any
+    ) -> dict[base.typing.ClfTarget, float]:
         try:
             y_pred = self.estimator.predict_proba([self._align_dict(x)])[0]
-            return {self.classes[i]: p for i, p in enumerate(y_pred)}
+            return {self.classes[i]: float(p) for i, p in enumerate(y_pred)}
         except sklearn_exceptions.NotFittedError:
             return {c: 1 / len(self.classes) for c in self.classes}
 
-    def predict_proba_many(self, X):
-        pd = utils.pandas.import_pandas()
+    def predict_proba_many(self, X: IntoDataFrame) -> IntoDataFrame:
+        X_nw = self._align_frame(X)
+        probas: NDArray[np.float64]
         try:
-            return pd.DataFrame(
-                self.estimator.predict_proba(self._align_df(X)),
-                columns=self.classes,
-                index=X.index,
-            )
+            probas = self.estimator.predict_proba(X_nw.to_native())
         except sklearn_exceptions.NotFittedError:
-            return pd.DataFrame(
-                [[1 / len(self.classes)] * len(self.classes)] * len(X),
-                columns=self.classes,
-                index=X.index,
-            )
+            probas = np.full((len(X_nw), len(self.classes)), 1 / len(self.classes))
+        return utils.dataframe.to_native_frame(probas, like=X_nw, columns=self.classes)
 
-    def predict_one(self, x):
+    def predict_one(
+        self, x: dict[base.typing.FeatureName, typing.Any], **kwargs: typing.Any
+    ) -> base.typing.ClfTarget:
         try:
-            y_pred = self.estimator.predict(X=[self._align_dict(x)])[0]
-            return y_pred
+            prediction = self.estimator.predict(X=[self._align_dict(x)])[0]
         except sklearn_exceptions.NotFittedError:
             return self.classes[0]
+        # Indexing a numpy array yields `typing.Any`; the values are the labels the model was given.
+        return typing.cast("base.typing.ClfTarget", prediction)
 
-    def predict_many(self, X):
-        pd = utils.pandas.import_pandas()
+    def predict_many(self, X: IntoDataFrame) -> IntoSeries:
+        X_nw = self._align_frame(X)
+        values: NDArray[typing.Any] | list[base.typing.ClfTarget]
         try:
-            return pd.Series(self.estimator.predict(self._align_df(X)))
+            values = self.estimator.predict(X_nw.to_native())
         except sklearn_exceptions.NotFittedError:
-            return pd.Series([self.classes[0]] * len(X), index=X.index)
+            # Mirror the first class that `predict_one` falls back on.
+            values = [self.classes[0]] * len(X_nw)
+        return utils.dataframe.to_native_series(values, name=None, like=X_nw)
 
     @classmethod
-    def _unit_test_params(cls):
+    def _unit_test_params(cls) -> Iterator[dict[str, typing.Any]]:
         yield {
             "estimator": sklearn_linear_model.SGDClassifier(loss="log_loss"),
             "classes": [False, True],

--- a/river/compat/test_sklearn.py
+++ b/river/compat/test_sklearn.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import typing
+
+import narwhals.stable.v2 as nw
+import numpy as np
 import pandas as pd
 import pytest
 from sklearn import datasets as sk_datasets
@@ -7,28 +11,66 @@ from sklearn import linear_model as sk_linear_model
 from sklearn.utils import estimator_checks
 
 from river import base, cluster, compat, linear_model, preprocessing
+from river.conftest import FRAME_BACKENDS
+
+if typing.TYPE_CHECKING:
+    from narwhals.stable.v2.typing import IntoDataFrame, IntoSeries
+    from numpy.typing import NDArray
+
+    from river import compose
+    from river.conftest import FrameBackend
+
+    WrappedRegressor = compat.SKL2RiverRegressor | compose.Pipeline
+    WrappedClassifier = compat.SKL2RiverClassifier | compose.Pipeline
+
+    ClassifierReference = tuple[list[typing.Any], NDArray[np.float64]]
+    """The pandas oracle a classifier's mini-batch output is compared against;
+    consisting of (labels, probability matrix). """
+
+
+def _regressor() -> compat.SKL2RiverRegressor:
+    return compat.convert_sklearn_to_river(sk_linear_model.SGDRegressor(random_state=42))
+
+
+def _classifier(n_classes: int = 2) -> compat.SKL2RiverClassifier:
+    return compat.convert_sklearn_to_river(
+        sk_linear_model.SGDClassifier(loss="log_loss", random_state=42),
+        classes=list(range(n_classes)),
+    )
+
+
+def _labels(series: IntoSeries) -> list[typing.Any]:
+    return nw.from_native(series, series_only=True).to_list()
+
+
+def _values(frame: IntoDataFrame) -> NDArray[np.float64]:
+    """Read a native frame into a float matrix, positionally."""
+    return np.asarray(nw.from_native(frame, eager_only=True).to_numpy(), dtype=np.float64)
+
+
+def _implementation(native: IntoDataFrame | IntoSeries) -> nw.Implementation:
+    """The dataframe library a native frame or series belongs to."""
+    return nw.from_native(native, allow_series=True).implementation
 
 
 @pytest.mark.parametrize(
-    "estimator",  # type: ignore[misc]
+    "estimator",
     [
-        pytest.param(estimator, id=str(estimator))
-        for estimator in [
-            linear_model.LinearRegression(),
-            linear_model.LogisticRegression(),
-            preprocessing.StandardScaler(),
-            cluster.KMeans(n_clusters=3, seed=42),
-        ]
+        linear_model.LinearRegression(),
+        linear_model.LogisticRegression(),
+        preprocessing.StandardScaler(),
+        cluster.KMeans(n_clusters=3, seed=42),
     ],
+    ids=str,
 )
-@pytest.mark.filterwarnings("ignore::sklearn.utils.estimator_checks.SkipTestWarning")  # type: ignore[misc]
-def test_river_to_sklearn_check_estimator(estimator: base.Estimator):
+@pytest.mark.filterwarnings("ignore::sklearn.utils.estimator_checks.SkipTestWarning")
+def test_river_to_sklearn_check_estimator(estimator: base.Estimator) -> None:
     skl_estimator = compat.convert_river_to_sklearn(estimator)
     estimator_checks.check_estimator(skl_estimator)
 
 
 @pytest.mark.filterwarnings("ignore::sklearn.utils.estimator_checks.SkipTestWarning")
-def test_sklearn_check_twoway():
+def test_sklearn_check_twoway() -> None:
     estimator = sk_linear_model.SGDRegressor()
     river_estimator = compat.convert_sklearn_to_river(estimator)
     skl_estimator = compat.convert_river_to_sklearn(river_estimator)
@@ -37,23 +79,18 @@ def test_sklearn_check_twoway():
 
 @pytest.mark.parametrize(
     "estimator",
-    [
-        pytest.param(estimator, id=str(estimator))
-        for estimator in [
-            compat.convert_sklearn_to_river(sk_linear_model.SGDRegressor()),
-            (
-                preprocessing.StandardScaler()
-                | compat.convert_sklearn_to_river(sk_linear_model.SGDRegressor())
-            ),
-        ]
-    ],
+    [_regressor(), preprocessing.StandardScaler() | _regressor()],
+    ids=str,
 )
-def test_not_fitted_still_works_regression(estimator):
-    X, _ = sk_datasets.make_regression(n_samples=500, n_features=4)
-    X = pd.DataFrame(X)
+def test_not_fitted_still_works_regression(estimator: WrappedRegressor) -> None:
+    _Xs, _ = sk_datasets.make_regression(n_samples=500, n_features=4)
+    X = pd.DataFrame(_Xs)
+
     y_pred = estimator.predict_many(X)
+
+    assert isinstance(y_pred, pd.Series)
     assert len(y_pred) == len(X)
-    assert y_pred.eq(0).all()
+    assert (y_pred == 0).all()
 
 
 @pytest.mark.parametrize(
@@ -62,27 +99,24 @@ def test_not_fitted_still_works_regression(estimator):
         pytest.param(estimator, n_classes, id=f"{estimator}-{n_classes} classes")
         for n_classes in [2, 3]
         for estimator in [
-            compat.convert_sklearn_to_river(
-                sk_linear_model.SGDClassifier(loss="log_loss"), classes=list(range(n_classes))
-            ),
-            (
-                preprocessing.StandardScaler()
-                | compat.convert_sklearn_to_river(
-                    sk_linear_model.SGDClassifier(loss="log_loss"), classes=list(range(n_classes))
-                )
-            ),
+            _classifier(n_classes),
+            preprocessing.StandardScaler() | _classifier(n_classes),
         ]
     ],
 )
-def test_not_fitted_still_works_classification(estimator, n_classes):
-    X, y = sk_datasets.make_classification(
+def test_not_fitted_still_works_classification(
+    estimator: WrappedClassifier, n_classes: int
+) -> None:
+    _Xs, _ys = sk_datasets.make_classification(
         n_samples=500, n_features=10, n_informative=6, n_classes=n_classes
     )
-    X = pd.DataFrame(X)
-    y = pd.Series(y)
+    X = pd.DataFrame(_Xs)
+    y = pd.Series(_ys)
+
     y_pred = estimator.predict_many(X)
+    assert isinstance(y_pred, pd.Series)
     assert len(y_pred) == len(X)
-    assert y_pred.eq(0).all()
+    assert (y_pred == 0).all()
 
     y_pred_proba = estimator.predict_proba_many(X)
     assert isinstance(y_pred_proba, pd.DataFrame)
@@ -94,3 +128,99 @@ def test_not_fitted_still_works_classification(estimator, n_classes):
     assert isinstance(y_pred_proba, pd.DataFrame)
     assert y_pred_proba.shape == (len(X), n_classes)
     assert list(y_pred_proba.index) == list(X.index)
+
+
+# The `*_many` methods of the scikit-learn wrappers go through narwhals, so any eager backend
+# (pandas, polars, pyarrow, ...) can be fed in and comes back out.
+
+Xs: dict[str, list[float]] = {
+    "f0": [0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+    "f1": [1.0, 0.5, 0.0, -0.5, -1.0, -1.5],
+}
+Ys = [0, 0, 0, 1, 1, 1]
+
+
+@pytest.fixture(scope="module")
+def regressor_reference() -> list[typing.Any]:
+    """Predictions of a pandas-fed regressor: the oracle every other backend has to match."""
+    pandas = FRAME_BACKENDS["pandas"]()
+    model = _regressor()
+    model.learn_many(pandas.frame(Xs), pandas.series(Ys))
+    return _labels(model.predict_many(pandas.frame(Xs)))
+
+
+@pytest.fixture(scope="module")
+def classifier_reference() -> ClassifierReference:
+    """Labels and probabilities of a pandas-fed classifier: the oracle for the other backends."""
+    pandas = FRAME_BACKENDS["pandas"]()
+    model = _classifier()
+    model.learn_many(pandas.frame(Xs), pandas.series(Ys))
+    X = pandas.frame(Xs)
+    return _labels(model.predict_many(X)), _values(model.predict_proba_many(X))
+
+
+def test_sklearn_regressor_mini_batch_is_backend_agnostic(
+    frame_backend: FrameBackend, regressor_reference: list[typing.Any]
+) -> None:
+    X = frame_backend.frame(Xs)
+    model = _regressor()
+    model.learn_many(X, frame_backend.series(Ys))
+
+    preds = model.predict_many(X)
+
+    assert _implementation(preds) == _implementation(X)
+    np.testing.assert_allclose(_labels(preds), regressor_reference, rtol=1e-12)
+
+
+def test_sklearn_classifier_mini_batch_is_backend_agnostic(
+    frame_backend: FrameBackend, classifier_reference: ClassifierReference
+) -> None:
+    expected_labels, expected_proba = classifier_reference
+
+    X = frame_backend.frame(Xs)
+    model = _classifier()
+    model.learn_many(X, frame_backend.series(Ys))
+
+    preds = model.predict_many(X)
+    proba = model.predict_proba_many(X)
+
+    assert _implementation(preds) == _implementation(X)
+    assert _implementation(proba) == _implementation(X)
+    assert _labels(preds) == expected_labels
+    np.testing.assert_allclose(_values(proba), expected_proba, rtol=1e-12)
+
+
+def test_sklearn_wrapper_realigns_reordered_columns(frame_backend: FrameBackend) -> None:
+    """scikit-learn identifies features by position, so later batches are reordered to match."""
+    X = frame_backend.frame(Xs)
+    model = _regressor()
+    model.learn_many(X, frame_backend.series(Ys))
+
+    in_order = model.predict_many(X)
+    reordered = model.predict_many(
+        frame_backend.frame({key: Xs[key] for key in reversed(list(Xs))})
+    )
+
+    np.testing.assert_allclose(_labels(reordered), _labels(in_order))
+
+
+def test_sklearn_wrapper_realigns_reordered_integer_columns() -> None:
+    """Pandas is the only backend accepting non-string labels, as a frame built from an array has."""
+    X = pd.DataFrame(np.column_stack(list(Xs.values())))
+    assert list(X.columns) == [0, 1]
+
+    model = _regressor()
+    model.learn_many(X, pd.Series(Ys))
+
+    in_order = model.predict_many(X)
+    reordered = model.predict_many(X[list(reversed(X.columns))])
+
+    np.testing.assert_allclose(_labels(reordered), _labels(in_order))
+
+
+def test_sklearn_wrapper_rejects_a_missing_feature(frame_backend: FrameBackend) -> None:
+    model = _regressor()
+    model.learn_many(frame_backend.frame(Xs), frame_backend.series(Ys))
+
+    with pytest.raises(ValueError, match="missing from the mini-batch"):
+        model.predict_many(frame_backend.frame({"f0": Xs["f0"]}))


### PR DESCRIPTION
# Description

This PR is following two streams of work: adoption of narwhals (#1919 ) and strict typing (#1944) .

## Narwhals adoptiong

Routes the mini-batch methods of `SKL2RiverRegressor` and `SKL2RiverClassifier` through narwhals, so `learn_many` / `predict_many` / `predict_proba_many` accept any eager dataframe (pandas, polars, pyarrow, ...) and return output in the same backend. Previously they hard-required pandas via a runtime `import_pandas()`.

`_align_df` becomes `_align_frame`: it reorders a batch's columns to the order seen in the first batch (scikit-learn identifies features by position), and now raises a `ValueError` naming the missing features instead of surfacing a pandas `KeyError`. 

## Strict typing

I allowed myself some creative freedom. Both classifier and regressor wrappers and the conversion helper are now fully typed: `convert_sklearn_to_river` gains overloads, so `classes=None` narrows to `SKL2RiverRegressor` and `classes=[...]` to `SKL2RiverClassifier`; two `Protocol`s name the duck-typed slice of the scikit-learn interface the wrappers actually rely on.

Some big effort was done also to strict type the test suite

## Breaking changes

* Passing `classes=` when converting a regressor now raises `ValueError`; it was silently ignored before.
* `predict_proba_one` returns plain `float` probabilities rather than numpy scalars.

