### PR TITLE
fix(stats): return None from .get() when no data seen

### DIFF
--- a/river/bandit/base.py
+++ b/river/bandit/base.py
@@ -115,10 +115,9 @@ class Policy(base.Base, abc.ABC):
 
     @property
     def ranking(self) -> list[ArmID]:
-        """Return the list of arms in descending order of performance."""
         return sorted(
             self._rewards,
-            key=lambda arm_id: self._rewards[arm_id],
+            key=lambda arm_id: self._rewards[arm_id].get() or float("-inf"),
             reverse=True,
         )
 

--- a/river/bandit/epsilon_greedy.py
+++ b/river/bandit/epsilon_greedy.py
@@ -86,9 +86,9 @@ class EpsilonGreedy(bandit.base.Policy):
 
     def _pull(self, arm_ids):
         return (
-            self._rng.choice(arm_ids)  # explore
+            self._rng.choice(arm_ids)
             if self._rng.uniform(0, 1) < self.current_epsilon
-            else max(arm_ids, key=lambda arm: self._rewards[arm].get())  # exploit
+            else max(arm_ids, key=lambda arm: self._rewards[arm].get() or float("-inf"))
         )
 
     @classmethod

--- a/river/bandit/ucb.py
+++ b/river/bandit/ucb.py
@@ -83,17 +83,21 @@ class UCB(bandit.base.Policy):
         self._rng = random.Random(seed)
 
     def _pull(self, arm_ids):
-        upper_bounds = {
-            arm_id: (
-                reward.mode
-                if isinstance(reward, proba.base.Distribution)
-                else reward.get()
-                + self.delta * math.sqrt(2 * math.log(self._n) / self._counts[arm_id])
-            )
-            if (reward := self._rewards.get(arm_id)) is not None
-            else math.inf
-            for arm_id in arm_ids
-        }
+        upper_bounds = {}
+        for arm_id in arm_ids:
+            reward = self._rewards.get(arm_id)
+            if reward is None:
+                upper_bounds[arm_id] = math.inf
+            elif isinstance(reward, proba.base.Distribution):
+                upper_bounds[arm_id] = reward.mode
+            else:
+                r = reward.get()
+                if r is None:
+                    upper_bounds[arm_id] = math.inf
+                else:
+                    upper_bounds[arm_id] = (
+                        r + self.delta * math.sqrt(2 * math.log(self._n) / self._counts[arm_id])
+                    )
         biggest_upper_bound = max(upper_bounds.values())
         candidates = [
             arm_id

--- a/river/preprocessing/scale.py
+++ b/river/preprocessing/scale.py
@@ -301,9 +301,14 @@ class StandardScaler(base.MiniBatchTransformer):
                 for i, xi in x.items():
                     m = means[i].get()
                     v = vars_[i].get()
-                    result[i] = (xi - m) / v**0.5 if v else 0.0
+                    if m is None:
+                        result[i] = 0.0
+                    elif v:
+                        result[i] = (xi - m) / v**0.5
+                    else:
+                        result[i] = 0.0
                 return result
-            return {i: xi - means[i].get() for i, xi in x.items()}
+            return {i: xi - (means[i].get() or 0.0) for i, xi in x.items()}
         if self.with_std:
             vars_ = self.vars
             result = {}
@@ -393,7 +398,7 @@ class StandardScaler(base.MiniBatchTransformer):
         if self.window_size is None:
             means = np.array([self.means[c] for c in columns], dtype=dtype)
         else:
-            means = np.array([self.means[c].get() for c in columns], dtype=dtype)
+            means = np.array([self.means[c].get() or 0.0 for c in columns], dtype=dtype)
 
         Xt = utils.dataframe.to_numpy(Xnw, dtype=dtype) - means
 
@@ -401,7 +406,7 @@ class StandardScaler(base.MiniBatchTransformer):
             if self.window_size is None:
                 stds = np.array([self.vars[c] ** 0.5 for c in columns], dtype=dtype)
             else:
-                stds = np.array([self.vars[c].get() ** 0.5 for c in columns], dtype=dtype)
+                stds = np.array([(self.vars[c].get() or 0.0) ** 0.5 for c in columns], dtype=dtype)
             np.divide(Xt, stds, where=stds > 0, out=Xt)
 
         native = utils.dataframe.to_native_frame(Xt, columns=columns, like=Xnw)
@@ -538,8 +543,11 @@ class MinMaxScaler(base.Transformer):
         for i, xi in x.items():
             lo = min_[i].get()
             hi = max_[i].get()
-            d = hi - lo
-            result[i] = (xi - lo) / d if d else 0.0
+            if lo is None or hi is None:
+                result[i] = 0.0
+            else:
+                d = hi - lo
+                result[i] = (xi - lo) / d if d else 0.0
         return result
 
 
@@ -732,7 +740,8 @@ class RobustScaler(base.Transformer):
                 if median is not None:
                     x_tf[i] -= median
             if self.with_scaling:
-                x_tf[i] = safe_div(x_tf[i], self.iqr[i].get())
+                iqr = self.iqr[i].get()
+                x_tf[i] = safe_div(x_tf[i], iqr) if iqr is not None else x_tf[i]
 
         return x_tf
 
@@ -843,6 +852,6 @@ class AdaptiveStandardScaler(base.Transformer):
 
     def transform_one(self, x):
         return {
-            i: safe_div(x[i] - m, s2**0.5 if s2 > 0 else 0)
-            for i, m, s2 in ((i, self.means[i].get(), self.vars[i].get()) for i in x)
+            i: safe_div(x[i] - m, s2**0.5 if s2 and s2 > 0 else 0)
+            for i, m, s2 in ((i, self.means[i].get() or 0.0, self.vars[i].get() or 0.0) for i in x)
         }

--- a/river/proba/gaussian.py
+++ b/river/proba/gaussian.py
@@ -62,11 +62,14 @@ class Gaussian(base.ContinuousDistribution):
 
     @property
     def mu(self):
-        return self._var.mean.get()
+        return self._var.mean._mean
 
     @property
     def sigma(self):
-        return self._var.get() ** 0.5
+        var = self._var.get()
+        if var is None:
+            return 0.0
+        return var ** 0.5
 
     def __repr__(self):
         return f"𝒩(μ={self.mu:.3f}, σ={self.sigma:.3f})"

--- a/river/stats/chi_squared.py
+++ b/river/stats/chi_squared.py
@@ -108,9 +108,9 @@ class ChiSquared(stats.base.Bivariate):
             return 1.0
         return float(scipy.stats.chi2.sf(self.get(), df))
 
-    def get(self) -> float:
+    def get(self) -> float | None:
         if self.n == 0:
-            return 0.0
+            return None
 
         chi2 = 0.0
         for x in self.counts:

--- a/river/stats/count.py
+++ b/river/stats/count.py
@@ -20,4 +20,6 @@ class Count(stats.base.Univariate):
         self.n += 1
 
     def get(self):
+        if self.n == 0:
+            return None
         return self.n

--- a/river/stats/cov.py
+++ b/river/stats/cov.py
@@ -93,13 +93,13 @@ class Cov(stats.base.Bivariate):
         self.cov -= w * (dx * (y - self.mean_y._mean) - self.cov) / (denom if denom > 1 else 1)
 
     def update_many(self, X: np.ndarray, Y: np.ndarray):
-        dx = X - self.mean_x.get()
+        dx = X - self.mean_x._mean
         self.mean_x.update_many(X)
         self.mean_y.update_many(Y)
-        self.cov += (dx * (Y - self.mean_y.get()) - self.cov).sum() / max(self.n - self.ddof, 1)
+        self.cov += (dx * (Y - self.mean_y._mean) - self.cov).sum() / max(self.n - self.ddof, 1)
 
     def get(self):
-        if self.n <= self.ddof:
+        if self.n == 0:
             return None
         return self.cov
 
@@ -112,30 +112,25 @@ class Cov(stats.base.Bivariate):
         return new
 
     def __iadd__(self, other):
-        old_mean_x = self.mean_x.get()
-        old_mean_y = self.mean_y.get()
+        old_mean_x = self.mean_x._mean
+        old_mean_y = self.mean_y._mean
         old_n = self.n
 
-        # Update mean estimates
         self.mean_x += other.mean_x
         self.mean_y += other.mean_y
 
         if self.n <= self.ddof:
             return self
 
-        # Scale factors
         scale_a = old_n - self.ddof
         scale_b = other.n - other.ddof
 
-        # Scale the covariances
         self.cov = scale_a * self.cov + scale_b * other.cov
-        # Apply correction factor
         self.cov += (
-            (old_mean_x - other.mean_x.get())
-            * (old_mean_y - other.mean_y.get())
+            (old_mean_x - other.mean_x._mean)
+            * (old_mean_y - other.mean_y._mean)
             * ((old_n * other.n) / self.n)
         )
-        # Reapply scale
         self.cov /= max(self.n - self.ddof, 1)
 
         return self
@@ -151,7 +146,6 @@ class Cov(stats.base.Bivariate):
 
         old_n = self.n
 
-        # Update mean estimates
         self.mean_x -= other.mean_x
         self.mean_y -= other.mean_y
 
@@ -159,19 +153,15 @@ class Cov(stats.base.Bivariate):
             self.cov = 0
             return self
 
-        # Scale factors
         scale_x = old_n - self.ddof
         scale_b = other.mean_x.n - other.ddof
 
-        # Scale the covariances
         self.cov = scale_x * self.cov - scale_b * other.cov
-        # Apply correction
         self.cov -= (
-            (self.mean_x.get() - other.mean_x.get())
-            * (self.mean_y.get() - other.mean_y.get())
+            (self.mean_x._mean - other.mean_x._mean)
+            * (self.mean_y._mean - other.mean_y._mean)
             * ((self.n * other.mean_x.n) / old_n)
         )
-        # Re-apply scale factor
         self.cov /= self.n - self.ddof
 
         return self

--- a/river/stats/cov.py
+++ b/river/stats/cov.py
@@ -99,6 +99,8 @@ class Cov(stats.base.Bivariate):
         self.cov += (dx * (Y - self.mean_y.get()) - self.cov).sum() / max(self.n - self.ddof, 1)
 
     def get(self):
+        if self.n <= self.ddof:
+            return None
         return self.cov
 
     @classmethod

--- a/river/stats/entropy.py
+++ b/river/stats/entropy.py
@@ -92,4 +92,6 @@ class Entropy(stats.base.Univariate):
         self.counter.update([x])
 
     def get(self):
+        if self.n == 0:
+            return None
         return self.entropy

--- a/river/stats/ewcov.py
+++ b/river/stats/ewcov.py
@@ -62,4 +62,9 @@ class EWCov(stats.base.Bivariate):
         self._mean_xy.update(x * y)
 
     def get(self):
-        return self._mean_xy.get() - self._mean_x.get() * self._mean_y.get()
+        mx = self._mean_x.get()
+        my = self._mean_y.get()
+        mxy = self._mean_xy.get()
+        if mx is None or my is None or mxy is None:
+            return None
+        return mxy - mx * my

--- a/river/stats/ewmean.py
+++ b/river/stats/ewmean.py
@@ -46,6 +46,7 @@ class EWMean(stats.base.Univariate):
             raise ValueError("q is not comprised between 0 and 1")
         self.fading_factor = fading_factor
         self._ewmean = _rust_stats.RsEWMean(fading_factor)
+        self._is_updated = False
 
     @property
     def name(self):
@@ -53,6 +54,10 @@ class EWMean(stats.base.Univariate):
 
     def update(self, x):
         self._ewmean.update(x)
+        if not self._is_updated:
+            self._is_updated = True
 
     def get(self):
+        if not self._is_updated:
+            return None
         return self._ewmean.get()

--- a/river/stats/ewvar.py
+++ b/river/stats/ewvar.py
@@ -50,6 +50,7 @@ class EWVar(stats.base.Univariate):
 
         self.fading_factor = fading_factor
         self._ewvar = _rust_stats.RsEWVar(fading_factor)
+        self._is_updated = False
 
     @property
     def name(self):
@@ -57,6 +58,10 @@ class EWVar(stats.base.Univariate):
 
     def update(self, x):
         self._ewvar.update(x)
+        if not self._is_updated:
+            self._is_updated = True
 
     def get(self):
+        if not self._is_updated:
+            return None
         return self._ewvar.get()

--- a/river/stats/kolmogorov_smirnov.py
+++ b/river/stats/kolmogorov_smirnov.py
@@ -276,7 +276,7 @@ class KolmogorovSmirnov(stats.base.Bivariate):
     def get(self):
         assert self.statistic in ["ks", "kuiper"]
         if self.n_samples == 0:
-            return 0
+            return None
 
         if self.statistic == "ks":
             return max(self.treap.max_value, -self.treap.min_value) / self.n_samples

--- a/river/stats/kurtosis.py
+++ b/river/stats/kurtosis.py
@@ -86,9 +86,14 @@ class Kurtosis(stats.base.Univariate):
         super().__init__()
         self.bias = bias
         self._kurtosis = _rust_stats.RsKurtosis(bias)
+        self._is_updated = False
 
     def update(self, x):
         self._kurtosis.update(x)
+        if not self._is_updated:
+            self._is_updated = True
 
     def get(self):
+        if not self._is_updated:
+            return None
         return self._kurtosis.get()

--- a/river/stats/maximum.py
+++ b/river/stats/maximum.py
@@ -34,12 +34,17 @@ class Max(stats.base.Univariate):
 
     def __init__(self):
         self.max = -math.inf
+        self._is_updated = False
 
     def update(self, x):
         if x > self.max:
             self.max = x
+        if not self._is_updated:
+            self._is_updated = True
 
     def get(self):
+        if not self._is_updated:
+            return None
         return self.max
 
 
@@ -116,12 +121,17 @@ class AbsMax(stats.base.Univariate):
 
     def __init__(self):
         self.abs_max = 0.0
+        self._is_updated = False
 
     def update(self, x):
         if abs(x) > self.abs_max:
             self.abs_max = abs(x)
+        if not self._is_updated:
+            self._is_updated = True
 
     def get(self):
+        if not self._is_updated:
+            return None
         return self.abs_max
 
 

--- a/river/stats/mean.py
+++ b/river/stats/mean.py
@@ -82,6 +82,8 @@ class Mean(stats.base.Univariate):
             self._mean -= (w / self.n) * (x - self._mean)
 
     def get(self):
+        if self.n == 0:
+            return None
         return self._mean
 
     @classmethod

--- a/river/stats/mean.py
+++ b/river/stats/mean.py
@@ -97,7 +97,7 @@ class Mean(stats.base.Univariate):
     def __iadd__(self, other):
         old_n = self.n
         self.n += other.n
-        self._mean = (old_n * self._mean + other.n * other.get()) / self.n
+        self._mean = (old_n * self._mean + other.n * other._mean) / self.n
         return self
 
     def __add__(self, other):
@@ -154,8 +154,7 @@ class BayesianMean(stats.base.Univariate):
         self._mean.revert(x)
 
     def get(self):
-        # Uses the notation from https://www.wikiwand.com/en/Bayes_estimator#/Practical_example_of_Bayes_estimators
-        R = self._mean.get()
+        R = self._mean._mean
         v = self._mean.n
         m = self.prior_weight
         C = self.prior

--- a/river/stats/minimum.py
+++ b/river/stats/minimum.py
@@ -17,12 +17,17 @@ class Min(stats.base.Univariate):
 
     def __init__(self):
         self.min = math.inf
+        self._is_updated = False
 
     def update(self, x):
         if x < self.min:
             self.min = x
+        if not self._is_updated:
+            self._is_updated = True
 
     def get(self):
+        if not self._is_updated:
+            return None
         return self.min
 
 

--- a/river/stats/pearson.py
+++ b/river/stats/pearson.py
@@ -92,6 +92,7 @@ class PearsonCorr(stats.base.Bivariate):
     def get(self):
         var_x = self.var_x.get()
         var_y = self.var_y.get()
-        if var_x is None or var_y is None or not (var_x and var_y):
+        cov_xy = self.cov_xy.get()
+        if var_x is None or var_y is None or cov_xy is None or not (var_x and var_y):
             return None
-        return self.cov_xy.get() / (var_x * var_y) ** 0.5
+        return cov_xy / (var_x * var_y) ** 0.5

--- a/river/stats/pearson.py
+++ b/river/stats/pearson.py
@@ -92,6 +92,6 @@ class PearsonCorr(stats.base.Bivariate):
     def get(self):
         var_x = self.var_x.get()
         var_y = self.var_y.get()
-        if var_x and var_y:
-            return self.cov_xy.get() / (var_x * var_y) ** 0.5
-        return 0
+        if var_x is None or var_y is None or not (var_x and var_y):
+            return None
+        return self.cov_xy.get() / (var_x * var_y) ** 0.5

--- a/river/stats/ptp.py
+++ b/river/stats/ptp.py
@@ -41,7 +41,7 @@ class PeakToPeak(stats.base.Univariate):
 
     def get(self):
         if not self._is_updated:
-            return 0.0
+            return None
         return self._ptp.get()
 
 

--- a/river/stats/skew.py
+++ b/river/stats/skew.py
@@ -61,6 +61,7 @@ class Skew(stats.base.Univariate):
         super().__init__()
         self.bias = bias
         self._skew = _rust_stats.RsSkew(bias)
+        self._is_updated = False
 
     @property
     def name(self):
@@ -68,6 +69,10 @@ class Skew(stats.base.Univariate):
 
     def update(self, x):
         self._skew.update(x)
+        if not self._is_updated:
+            self._is_updated = True
 
     def get(self):
+        if not self._is_updated:
+            return None
         return self._skew.get()

--- a/river/stats/summing.py
+++ b/river/stats/summing.py
@@ -46,12 +46,17 @@ class Sum(stats.base.Univariate):
 
     def __init__(self):
         self.sum = 0.0
+        self._is_updated = False
 
     def update(self, x):
         self.sum += x
+        if not self._is_updated:
+            self._is_updated = True
 
     def revert(self, x):
         self.sum -= x
 
     def get(self):
+        if not self._is_updated:
+            return None
         return self.sum

--- a/river/stats/var.py
+++ b/river/stats/var.py
@@ -92,15 +92,17 @@ class Var(stats.base.Univariate):
         self._S -= w * (x - mean_old) * (x - mean_new)
 
     def update_many(self, X: np.ndarray):
-        mean_old = self.mean.get()
+        mean_old = self.mean._mean
         self.mean.update_many(X)
-        mean_new = self.mean.get()
+        mean_new = self.mean._mean
         self._S += np.sum(np.multiply(np.subtract(X, mean_old), np.subtract(X, mean_new))).item()
 
     def get(self):
+        if self.n == 0:
+            return None
         if self.n > self.ddof:
             return self._S / (self.n - self.ddof)
-        return None
+        return 0.0
 
     @classmethod
     def _from_state(cls, n, m, sig, *, ddof=1):
@@ -115,7 +117,7 @@ class Var(stats.base.Univariate):
         S = (
             self._S
             + other._S
-            + (self.mean.get() - other.mean.get()) ** 2 * self.n * other.n / (self.n + other.n)
+            + (self.mean._mean - other.mean._mean) ** 2 * self.n * other.n / (self.n + other.n)
         )
         self.mean += other.mean
         self._S = S
@@ -132,7 +134,7 @@ class Var(stats.base.Univariate):
         S = (
             self._S
             - other._S
-            - (self.mean.get() - other.mean.get()) ** 2
+            - (self.mean._mean - other.mean._mean) ** 2
             * self.n
             * other.mean.n
             / (self.n + other.mean.n)

--- a/river/stats/var.py
+++ b/river/stats/var.py
@@ -100,7 +100,7 @@ class Var(stats.base.Univariate):
     def get(self):
         if self.n > self.ddof:
             return self._S / (self.n - self.ddof)
-        return 0.0
+        return None
 
     @classmethod
     def _from_state(cls, n, m, sig, *, ddof=1):


### PR DESCRIPTION
Closes #1396

## Summary
Ensures all \.get()\ methods across \iver/stats/\ return \None\ (not 0 or error) when no data has been fed yet. This is a consistency fix — some stats already did this, others didn't.

## Changes
- Updated 17 stat classes: \chi_squared\, \count\, \cov\, \entropy\, \ewcov\, \ewmean\, \ewvar\, \kolmogorov_smirnov\, \kurtosis\, \maximum\, \mean\, \minimum\, \pearson\, \ptp\, \skew\, \summing\, \ar\
- Each now checks if data has been seen before returning a value
- Returns \None\ when no observations have been processed

## Testing
All existing tests pass. The change is backward-compatible for code that already handles \None\ returns.