### PR TITLE
feat(typing): strict typing stream file readers (`iter_csv`, `iter_arff` and `iter_libsvm`)

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -160,3 +160,6 @@
 
 - Added `stream.iter_frame`, a dataframe-agnostic row iterator powered by [Narwhals](https://narwhals-dev.github.io/narwhals/) that works with any eager dataframe (pandas, polars, PyArrow, Modin, cuDF, ...).
 - Deprecated `stream.iter_pandas` and `stream.iter_polars` in favour of `stream.iter_frame`. They now emit a `DeprecationWarning` and will be removed in a future release.
+- Fixed `stream.iter_libsvm` leaking the file it opens: the file is now closed once the stream is exhausted, as `stream.iter_csv` and `stream.iter_arff` already did. A buffer passed in by the caller is still left open, since the caller owns it.
+- Enabled strict typing for `stream.iter_arff`, `stream.iter_csv`, `stream.iter_libsvm`, and the `open_filepath` helper they share. The `compression` argument is now a literal (`"infer"`, `"gzip"`, `"zip"`, or `None`) instead of an untyped string, and paths are annotated as `str | os.PathLike[str]`, so `pathlib.Path` inputs type-check. The shared aliases live in the new `river.stream.typing` module. Typing-only, apart from the fix above.
+- Added dedicated tests for the three file readers and for `open_filepath`, covering compression inference, an explicit `compression` overriding a misleading extension, and which files each reader closes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -287,30 +287,3 @@ allow_untyped_calls = true
 allow_incomplete_defs = true
 allow_untyped_defs = true
 warn_return_any = false
-
-[[tool.mypy.overrides]]
-# Opt fully-typed modules back into strict mode, one by one, as part of the incremental typing
-# effort tracked in https://github.com/online-ml/river/issues/1944. mypy applies the most
-# specific pattern, so these bare module names win over the package wildcards above. Keep the
-# list alphabetical, and only add a module once `uv run mypy river` is clean with it listed.
-module = [
-    "river.compact.sklearn_to_river",
-    "river.stream.iter_arff",
-    "river.stream.iter_csv",
-    "river.stream.iter_libsvm",
-    "river.stream.typing",
-    "river.stream.utils",
-    "tests.stream.conftest",
-    "tests.stream.test_iter_arff",
-    "tests.stream.test_iter_csv",
-    "tests.stream.test_iter_libsvm",
-    "tests.stream.test_utils",
-]
-warn_unused_ignores = true
-check_untyped_defs = true
-disallow_subclassing_any = true
-disallow_any_generics = true
-disallow_untyped_calls = true
-disallow_incomplete_defs = true
-disallow_untyped_defs = true
-warn_return_any = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -287,3 +287,30 @@ allow_untyped_calls = true
 allow_incomplete_defs = true
 allow_untyped_defs = true
 warn_return_any = false
+
+[[tool.mypy.overrides]]
+# Opt fully-typed modules back into strict mode, one by one, as part of the incremental typing
+# effort tracked in https://github.com/online-ml/river/issues/1944. mypy applies the most
+# specific pattern, so these bare module names win over the package wildcards above. Keep the
+# list alphabetical, and only add a module once `uv run mypy river` is clean with it listed.
+module = [
+    "river.compact.sklearn_to_river",
+    "river.stream.iter_arff",
+    "river.stream.iter_csv",
+    "river.stream.iter_libsvm",
+    "river.stream.typing",
+    "river.stream.utils",
+    "tests.stream.conftest",
+    "tests.stream.test_iter_arff",
+    "tests.stream.test_iter_csv",
+    "tests.stream.test_iter_libsvm",
+    "tests.stream.test_utils",
+]
+warn_unused_ignores = true
+check_untyped_defs = true
+disallow_subclassing_any = true
+disallow_any_generics = true
+disallow_untyped_calls = true
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+warn_return_any = true

--- a/river/stream/iter_arff.py
+++ b/river/stream/iter_arff.py
@@ -1,15 +1,24 @@
 from __future__ import annotations
 
+import os
+import typing
+
 import scipy.io.arff
 from scipy.io.arff._arffread import read_header
 
 from river import base
+from river.stream import utils
 
-from . import utils
+if typing.TYPE_CHECKING:
+    from river.base.typing import FeatureName
+    from river.stream.typing import Compression, FilePath
 
 
 def iter_arff(
-    filepath_or_buffer, target: str | list[str] | None = None, compression="infer", sparse=False
+    filepath_or_buffer: FilePath | typing.TextIO,
+    target: str | list[str] | None = None,
+    compression: Compression | None = "infer",
+    sparse: bool = False,
 ) -> base.typing.Stream:
     """Iterates over rows from an ARFF file.
 
@@ -148,12 +157,15 @@ def iter_arff(
     """
 
     # If a file is not opened, then we open it
-    buffer = filepath_or_buffer
-    if not hasattr(buffer, "read"):
-        buffer = utils.open_filepath(buffer, compression)
+    if isinstance(filepath_or_buffer, (str, os.PathLike)):
+        buffer = utils.open_filepath(filepath_or_buffer, compression)
+        should_close = True
+    else:
+        buffer = filepath_or_buffer
+        should_close = False
 
     try:
-        rel, attrs = read_header(buffer)
+        _rel, attrs = read_header(buffer)
     except ValueError as e:
         msg = f"Error while parsing header, error was: {e}"
         raise scipy.io.arff.ParseArffError(msg)
@@ -165,6 +177,9 @@ def iter_arff(
     for r in buffer:
         if len(r) == 0:
             continue
+
+        x: dict[FeatureName, typing.Any]
+        y: typing.Any | dict[FeatureName, typing.Any] | None
 
         # Read row
         if sparse:
@@ -180,18 +195,18 @@ def iter_arff(
             }
 
         # Handle target
-        y = None
-        if target is not None:
-            if isinstance(target, list):
-                y = {name: x.pop(name, 0) for name in target}
-            else:
-                try:
-                    y = x.pop(target) if target else None
-                except KeyError:
-                    y = None
+        if target is None:
+            y = None
+        elif isinstance(target, str):
+            try:
+                y = x.pop(target) if target else None
+            except KeyError:
+                y = None
+        else:
+            y = {name: x.pop(name, 0) for name in target}
 
         yield x, y
 
     # Close the file if we opened it
-    if buffer is not filepath_or_buffer:
+    if should_close:
         buffer.close()

--- a/river/stream/iter_csv.py
+++ b/river/stream/iter_csv.py
@@ -2,47 +2,57 @@ from __future__ import annotations
 
 import csv
 import datetime as dt
+import os
 import random
+import typing
 
-from .. import base
-from . import utils
+from river import base
+from river.stream import utils
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    from river.base.typing import FeatureName
+    from river.stream.typing import Compression, FilePath
 
 __all__ = ["iter_csv"]
 
 
-class DictReader(csv.DictReader):
+class DictReader(csv.DictReader["FeatureName"]):
     """Overlay on top of `csv.DictReader` which allows sampling."""
 
-    def __init__(self, fraction, rng, *args, **kwargs):
+    def __init__(
+        self, fraction: float, rng: random.Random, *args: typing.Any, **kwargs: typing.Any
+    ) -> None:
         super().__init__(*args, **kwargs)
         self.fraction = fraction
         self.rng = rng
+        # NOTE: `fieldnames` reads the header row, and is `None` for an empty file,
+        # in which case the first `next(self.reader)` below stops the iteration anyway.
+        self.names: Sequence[FeatureName] = self.fieldnames or ()
 
-    def __next__(self):
-        if self.line_num == 0:
-            self.fieldnames
-
+    def __next__(self) -> dict[FeatureName, typing.Any]:
         row = next(self.reader)
 
         if self.fraction < 1:
             while self.rng.random() > self.fraction:
                 row = next(self.reader)
 
-        return dict(zip(self.fieldnames, row))
+        return dict(zip(self.names, row))
 
 
 def iter_csv(
-    filepath_or_buffer,
+    filepath_or_buffer: FilePath | typing.TextIO,
     target: str | list[str] | None = None,
-    converters: dict | None = None,
-    parse_dates: dict | None = None,
+    converters: dict[FeatureName, Callable[[typing.Any], typing.Any]] | None = None,
+    parse_dates: dict[FeatureName, str] | None = None,
     drop: list[str] | None = None,
-    drop_nones=False,
-    fraction=1.0,
-    compression="infer",
+    drop_nones: bool = False,
+    fraction: float = 1.0,
+    compression: Compression | None = "infer",
     seed: int | None = None,
     field_size_limit: int | None = None,
-    **kwargs,
+    **kwargs: typing.Any,
 ) -> base.typing.Stream:
     """Iterates over rows from a CSV file.
 
@@ -147,30 +157,33 @@ def iter_csv(
         csv.field_size_limit(field_size_limit)
 
     # If a file is not opened, then we open it
-    buffer = filepath_or_buffer
-    if not hasattr(buffer, "read"):
-        buffer = utils.open_filepath(buffer, compression)
+    if isinstance(filepath_or_buffer, (str, os.PathLike)):
+        buffer = utils.open_filepath(filepath_or_buffer, compression)
+        should_close = True
+    else:
+        buffer = filepath_or_buffer
+        should_close = False
 
     for x in DictReader(fraction=fraction, rng=random.Random(seed), f=buffer, **kwargs):
         if drop:
-            for i in drop:
-                del x[i]
+            for dropped in drop:
+                del x[dropped]
 
         # Cast the values to the given types
         if converters is not None:
-            for i, t in converters.items():
-                x[i] = t(x[i])
+            for name, convert in converters.items():
+                x[name] = convert(x[name])
 
         # Drop Nones
         if drop_nones:
-            for i in list(x):
-                if x[i] is None:
-                    del x[i]
+            for name in list(x):
+                if x[name] is None:
+                    del x[name]
 
         # Parse the dates
         if parse_dates is not None:
-            for i, fmt in parse_dates.items():
-                x[i] = dt.datetime.strptime(x[i], fmt)
+            for name, fmt in parse_dates.items():
+                x[name] = dt.datetime.strptime(x[name], fmt)
 
         # Separate the target from the features
         y = None
@@ -182,7 +195,7 @@ def iter_csv(
         yield x, y
 
     # Close the file if we opened it
-    if buffer is not filepath_or_buffer:
+    if should_close:
         buffer.close()
 
     # Reset the file size limit to it's original value

--- a/river/stream/iter_libsvm.py
+++ b/river/stream/iter_libsvm.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
-from river import base
+import os
+import typing
 
-from . import utils
+from river import base
+from river.stream import utils
+
+if typing.TYPE_CHECKING:
+    from river.base.typing import FeatureName
+    from river.stream.typing import Compression, FilePath
 
 
 def iter_libsvm(
-    filepath_or_buffer: str, target_type=float, compression="infer"
+    filepath_or_buffer: FilePath | typing.TextIO,
+    target_type: type[typing.Any] = float,
+    compression: Compression | None = "infer",
 ) -> base.typing.Stream:
     """Iterates over a dataset in LIBSVM format.
 
@@ -49,16 +57,12 @@ def iter_libsvm(
     """
 
     # If a file is not opened, then we open it
-    buffer = filepath_or_buffer
-    should_close = False
-    if not hasattr(buffer, "read"):
+    if isinstance(filepath_or_buffer, (str, os.PathLike)):
+        buffer = utils.open_filepath(filepath_or_buffer, compression)
+        should_close = True
+    else:
+        buffer = filepath_or_buffer
         should_close = False
-        buffer = utils.open_filepath(buffer, compression)
-
-    def split_pair(pair):
-        name, value = pair.split(":")
-        value = float(value)
-        return name, value
 
     for line in buffer:
         # Remove carriage return and whitespace
@@ -73,4 +77,10 @@ def iter_libsvm(
 
     # Close the file if we opened it
     if should_close:
-        buffer.close()  # type: ignore
+        buffer.close()
+
+
+def split_pair(pair: str) -> tuple[FeatureName, float]:
+    name, value = pair.split(":")
+    value = float(value)
+    return name, value

--- a/river/stream/iter_libsvm.py
+++ b/river/stream/iter_libsvm.py
@@ -72,7 +72,7 @@ def iter_libsvm(
 
         y, x_str = line.split(" ", maxsplit=1)
         y = target_type(y)
-        x = dict([split_pair(pair) for pair in x_str.split(" ")])
+        x = dict([_split_pair(pair) for pair in x_str.split(" ")])
         yield x, y
 
     # Close the file if we opened it
@@ -80,7 +80,6 @@ def iter_libsvm(
         buffer.close()
 
 
-def split_pair(pair: str) -> tuple[FeatureName, float]:
+def _split_pair(pair: str) -> tuple[FeatureName, float]:
     name, value = pair.split(":")
-    value = float(value)
-    return name, value
+    return name, float(value)

--- a/river/stream/typing.py
+++ b/river/stream/typing.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import os
+import typing
+
+if typing.TYPE_CHECKING:
+    FilePath = str | os.PathLike[str]
+    Compression = typing.Literal["infer", "gzip", "zip"]
+    ResolvedCompression = typing.Literal["gzip", "zip"]

--- a/river/stream/typing.py
+++ b/river/stream/typing.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import os
 import typing
 
-if typing.TYPE_CHECKING:
-    FilePath = str | os.PathLike[str]
-    Compression = typing.Literal["infer", "gzip", "zip"]
-    ResolvedCompression = typing.Literal["gzip", "zip"]
+FilePath = str | os.PathLike[str]
+"""Anything the built-in open() accepts as a file location."""
+ResolvedCompression = typing.Literal["gzip", "zip"]
+"""A decompression method that maps to a concrete reader."""
+Compression = ResolvedCompression | typing.Literal["infer"]
+"""A caller-facing decompression method, "infer" being resolved from the file extension."""

--- a/river/stream/utils.py
+++ b/river/stream/utils.py
@@ -9,9 +9,7 @@ import zipfile
 if typing.TYPE_CHECKING:
     from collections.abc import Mapping
 
-    FilePath = str | os.PathLike[str]
-    Compression = typing.Literal["infer", "gzip", "zip"]
-    ResolvedCompression = typing.Literal["gzip", "zip"]
+    from river.stream.typing import Compression, FilePath, ResolvedCompression
 
 EXT_TO_COMPRESSION: typing.Final[Mapping[str, ResolvedCompression]] = {
     ".gz": "gzip",

--- a/river/stream/utils.py
+++ b/river/stream/utils.py
@@ -1,30 +1,59 @@
 from __future__ import annotations
 
-import functools
 import gzip
 import io
 import os
+import typing
 import zipfile
 
+if typing.TYPE_CHECKING:
+    from collections.abc import Mapping
 
-def open_filepath(filepath_or_buffer, compression):
-    # Determine the compression from the file extension if "infer" has been specified
-    if compression == "infer":
-        _, ext = os.path.splitext(filepath_or_buffer)
-        compression = {".gz": "gzip", ".zip": "zip"}.get(ext)
+    FilePath = str | os.PathLike[str]
+    Compression = typing.Literal["infer", "gzip", "zip"]
+    ResolvedCompression = typing.Literal["gzip", "zip"]
 
-    def open_zipfile(path):
-        with zipfile.ZipFile(path, "r") as zf:
-            f = zf.open(zf.namelist()[0], "r")
-            f = io.TextIOWrapper(f)
-            return f
+EXT_TO_COMPRESSION: typing.Final[Mapping[str, ResolvedCompression]] = {
+    ".gz": "gzip",
+    ".zip": "zip",
+}
 
-    # Determine the file opening method from the compression
-    open_func = {
-        None: open,
-        "gzip": functools.partial(gzip.open, mode="rt"),
-        "zip": open_zipfile,
-    }[compression]
 
-    # Open the file using the opening method
-    return open_func(filepath_or_buffer)
+def open_filepath(filepath: FilePath, compression: Compression | None) -> typing.TextIO:
+    """Open a possibly compressed file in text mode.
+
+    Parameters
+    ----------
+    filepath
+        Location of the file to open.
+    compression
+        Decompression method to use. `None` opens the file as-is, whereas "infer" picks the method
+        from the file extension, and opens the file as-is for unknown extensions.
+
+    Returns
+    -------
+    A text-mode file object, which the caller is responsible for closing.
+
+    """
+    resolved: ResolvedCompression | None = (
+        EXT_TO_COMPRESSION.get(os.path.splitext(filepath)[1])
+        if compression == "infer"
+        else compression
+    )
+
+    match resolved:
+        case None:
+            return open(filepath)
+        case "gzip":
+            return gzip.open(filepath, mode="rt")
+        case "zip":
+            return _open_zipfile(filepath)
+        case _:
+            typing.assert_never(resolved)
+
+
+def _open_zipfile(path: FilePath) -> typing.TextIO:
+    with zipfile.ZipFile(path, "r") as zf:
+        # Closing the archive does not close the member handles it handed out, so the wrapper
+        # stays readable after this block.
+        return io.TextIOWrapper(zf.open(zf.namelist()[0], "r"))

--- a/river/stream/utils.py
+++ b/river/stream/utils.py
@@ -7,14 +7,10 @@ import typing
 import zipfile
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Mapping
-
     from river.stream.typing import Compression, FilePath, ResolvedCompression
 
-EXT_TO_COMPRESSION: typing.Final[Mapping[str, ResolvedCompression]] = {
-    ".gz": "gzip",
-    ".zip": "zip",
-}
+_EXT_TO_COMPRESSION: dict[str, ResolvedCompression] = {".gz": "gzip", ".zip": "zip"}
+"""File extensions that "infer" knows how to turn into a decompression method."""
 
 
 def open_filepath(filepath: FilePath, compression: Compression | None) -> typing.TextIO:
@@ -33,8 +29,8 @@ def open_filepath(filepath: FilePath, compression: Compression | None) -> typing
     A text-mode file object, which the caller is responsible for closing.
 
     """
-    resolved: ResolvedCompression | None = (
-        EXT_TO_COMPRESSION.get(os.path.splitext(filepath)[1])
+    resolved = (
+        _EXT_TO_COMPRESSION.get(os.path.splitext(filepath)[1])
         if compression == "infer"
         else compression
     )

--- a/tests/stream/conftest.py
+++ b/tests/stream/conftest.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import gzip
+import typing
+import zipfile
+
+import pytest
+
+from river.stream import utils
+
+if typing.TYPE_CHECKING:
+    import pathlib
+
+    from river.stream.typing import Compression, FilePath
+
+    class WriteFile(typing.Protocol):
+        """Writes `content` to `path`, compressed as `compression` ("infer" uses the extension)."""
+
+        def __call__(
+            self, path: pathlib.Path, content: str, compression: Compression | None = "infer"
+        ) -> pathlib.Path: ...
+
+
+EXT_TO_FORMAT = {".gz": "gzip", ".zip": "zip"}
+
+
+class CompressionCase(typing.NamedTuple):
+    """An extension to write a file under, the format to write it in, and how to read it back."""
+
+    suffix: str
+    written_as: Compression | None
+    read_as: Compression | None
+
+
+# The last two cases give the file an extension that contradicts its content, so that they only
+# pass if the explicit `compression` argument wins over the inference.
+COMPRESSION_CASES = {
+    "plain": CompressionCase("", "infer", "infer"),
+    "gzip-inferred": CompressionCase(".gz", "infer", "infer"),
+    "zip-inferred": CompressionCase(".zip", "infer", "infer"),
+    "gzip-explicit": CompressionCase("", "gzip", "gzip"),
+    "none-explicit": CompressionCase(".gz", None, None),
+}
+
+
+@pytest.fixture(params=COMPRESSION_CASES.values(), ids=list(COMPRESSION_CASES))
+def compression_case(request: pytest.FixtureRequest) -> CompressionCase:
+    return typing.cast("CompressionCase", request.param)
+
+
+@pytest.fixture
+def write_file() -> WriteFile:
+    def write(
+        path: pathlib.Path, content: str, compression: Compression | None = "infer"
+    ) -> pathlib.Path:
+        match EXT_TO_FORMAT.get(path.suffix) if compression == "infer" else compression:
+            case "gzip":
+                with gzip.open(path, mode="wt") as f:
+                    _ = f.write(content)
+            case "zip":
+                with zipfile.ZipFile(path, mode="w") as archive:
+                    archive.writestr(path.stem, content)
+            case _:
+                _ = path.write_text(content)
+        return path
+
+    return write
+
+
+@pytest.fixture
+def opened_files(monkeypatch: pytest.MonkeyPatch) -> list[typing.TextIO]:
+    """Records the files the readers open themselves, so tests can check they close them."""
+    handles: list[typing.TextIO] = []
+    open_filepath = utils.open_filepath
+
+    def spy(filepath: FilePath, compression: Compression | None) -> typing.TextIO:
+        handle = open_filepath(filepath, compression)
+        handles.append(handle)
+        return handle
+
+    monkeypatch.setattr(utils, "open_filepath", spy)
+    return handles

--- a/tests/stream/test_iter_arff.py
+++ b/tests/stream/test_iter_arff.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import io
+import typing
+
+import pytest
+import scipy.io.arff
+
+from river import stream
+
+if typing.TYPE_CHECKING:
+    import pathlib
+
+    from river.base.typing import FeatureName
+    from tests.stream.conftest import CompressionCase, WriteFile
+
+    Row = tuple[dict[FeatureName, typing.Any], typing.Any]
+
+DENSE = """@relation test
+@attribute a numeric
+@attribute b numeric
+@attribute c {x,y}
+@data
+1,2,x
+3,?,y
+"""
+
+SPARSE = """@relation test
+@attribute y0 {0,1}
+@attribute y1 {0,1}
+@attribute X0 numeric
+@attribute X1 numeric
+@data
+{ 1 1,2 0.5 }
+{ 0 1,3 0.25 }
+"""
+
+# The second row holds a `?`, so `b` is expected to be missing from its features.
+UNTOUCHED: list[Row] = [({"a": 1.0, "b": 2.0, "c": "x"}, None), ({"a": 3.0, "c": "y"}, None)]
+DENSE_CASES: dict[str, tuple[str | list[str] | None, list[Row]]] = {
+    "target": ("c", [({"a": 1.0, "b": 2.0}, "x"), ({"a": 3.0}, "y")]),
+    "no-target": (None, UNTOUCHED),
+    "absent-target": ("nope", UNTOUCHED),
+    "targets": (
+        ["b", "c"],
+        [({"a": 1.0}, {"b": 2.0, "c": "x"}), ({"a": 3.0}, {"b": 0, "c": "y"})],
+    ),
+}
+
+
+@pytest.mark.parametrize(("target", "expected"), DENSE_CASES.values(), ids=DENSE_CASES)
+def test_numeric_attributes_are_cast_and_the_target_is_split_off(
+    target: str | list[str] | None, expected: list[Row]
+) -> None:
+    assert list(stream.iter_arff(io.StringIO(DENSE), target=target)) == expected
+
+
+def test_sparse_rows_only_carry_the_features_they_list() -> None:
+    dataset = stream.iter_arff(io.StringIO(SPARSE), target=["y0", "y1"], sparse=True)
+
+    assert list(dataset) == [
+        ({"X0": "0.5"}, {"y0": 0, "y1": "1"}),
+        ({"X1": "0.25"}, {"y0": "1", "y1": 0}),
+    ]
+
+
+def test_a_dataset_is_read_from_a_path(
+    tmp_path: pathlib.Path, write_file: WriteFile, compression_case: CompressionCase
+) -> None:
+    path = write_file(
+        tmp_path / f"data.arff{compression_case.suffix}", DENSE, compression_case.written_as
+    )
+
+    dataset = stream.iter_arff(path, target="c", compression=compression_case.read_as)
+    assert list(dataset) == DENSE_CASES["target"][1]
+
+
+def test_a_file_the_reader_opened_is_closed(
+    tmp_path: pathlib.Path,
+    write_file: WriteFile,
+    compression_case: CompressionCase,
+    opened_files: list[typing.TextIO],
+) -> None:
+    path = write_file(
+        tmp_path / f"data.arff{compression_case.suffix}", DENSE, compression_case.written_as
+    )
+
+    _ = list(stream.iter_arff(path, target="c", compression=compression_case.read_as))
+
+    assert len(opened_files) == 1
+    assert opened_files[0].closed
+
+
+def test_a_buffer_passed_in_by_the_caller_is_left_open() -> None:
+    buffer = io.StringIO(DENSE)
+
+    _ = list(stream.iter_arff(buffer, target="c"))
+
+    assert not buffer.closed
+
+
+def test_an_unparsable_header_is_reported_as_a_parse_error() -> None:
+    dataset = stream.iter_arff(io.StringIO("@relation test\n@attribute a bogus\n@data\n1\n"))
+
+    with pytest.raises(scipy.io.arff.ParseArffError):
+        next(dataset)

--- a/tests/stream/test_iter_csv.py
+++ b/tests/stream/test_iter_csv.py
@@ -1,44 +1,148 @@
 from __future__ import annotations
 
+import csv
 import io
+import typing
+from datetime import datetime
+from functools import partial
+
+import pytest
 
 from river import stream
 
+if typing.TYPE_CHECKING:
+    import pathlib
+    from collections.abc import Callable
 
-def test_iter_csv_custom_converter():
-    example = io.StringIO("col1,col2,col3\n,1,2\n5,,4\n3,1,")
+    from river import base
+    from river.base.typing import FeatureName
+    from tests.stream.conftest import CompressionCase, WriteFile
 
-    def int_or_none(s):
-        try:
-            return int(s)
-        except ValueError:
-            return None
+    Row = tuple[dict[FeatureName, typing.Any], typing.Any]
+    MakeStream = Callable[[typing.TextIO], base.typing.Stream]
+    Converters = dict[FeatureName, Callable[[typing.Any], typing.Any]]
 
-    params = {"converters": {"col1": int_or_none, "col2": int_or_none, "col3": int_or_none}}
-    dataset = stream.iter_csv(example, **params)
-    assert list(dataset) == [
-        ({"col1": None, "col2": 1, "col3": 2}, None),
-        ({"col1": 5, "col2": None, "col3": 4}, None),
-        ({"col1": 3, "col2": 1, "col3": None}, None),
+CONTENT = "name,year,rating\na,2016,9.5\nb,2006,9.4\nc,2001,9.4\nd,2008,9.1\ne,2019,9.0\n"
+HOLES = "col1,col2,col3\n,1,2\n5,,4\n3,1,"
+
+
+def int_or_none(s: str) -> int | None:
+    try:
+        return int(s)
+    except ValueError:
+        return None
+
+
+FIRST_ROW_CASES: dict[str, tuple[MakeStream, Row]] = {
+    "defaults": (
+        stream.iter_csv,
+        ({"name": "a", "year": "2016", "rating": "9.5"}, None),
+    ),
+    "target": (
+        partial(stream.iter_csv, target="rating"),
+        ({"name": "a", "year": "2016"}, "9.5"),
+    ),
+    "targets": (
+        partial(stream.iter_csv, target=["year", "rating"]),
+        ({"name": "a"}, {"year": "2016", "rating": "9.5"}),
+    ),
+    "drop": (partial(stream.iter_csv, drop=["year"]), ({"name": "a", "rating": "9.5"}, None)),
+    "parse_dates": (
+        partial(stream.iter_csv, parse_dates={"year": "%Y"}),
+        ({"name": "a", "year": datetime(2016, 1, 1), "rating": "9.5"}, None),
+    ),
+    # Given field names, the header is data like any other row.
+    "fieldnames": (
+        partial(stream.iter_csv, fieldnames=["A", "B", "C"]),
+        ({"A": "name", "B": "year", "C": "rating"}, None),
+    ),
+}
+
+CONVERTER_CASES: dict[str, tuple[bool, list[Row]]] = {
+    "keep-nones": (
+        False,
+        [
+            ({"col1": None, "col2": 1, "col3": 2}, None),
+            ({"col1": 5, "col2": None, "col3": 4}, None),
+            ({"col1": 3, "col2": 1, "col3": None}, None),
+        ],
+    ),
+    "drop-nones": (
+        True,
+        [
+            ({"col2": 1, "col3": 2}, None),
+            ({"col1": 5, "col3": 4}, None),
+            ({"col1": 3, "col2": 1}, None),
+        ],
+    ),
+}
+
+
+@pytest.mark.parametrize(("make", "expected"), FIRST_ROW_CASES.values(), ids=FIRST_ROW_CASES)
+def test_the_options_shape_the_rows(make: MakeStream, expected: Row) -> None:
+    assert next(make(io.StringIO(CONTENT))) == expected
+
+
+@pytest.mark.parametrize(("drop_nones", "expected"), CONVERTER_CASES.values(), ids=CONVERTER_CASES)
+def test_values_are_cast_by_the_converters(drop_nones: bool, expected: list[Row]) -> None:
+    converters: Converters = {"col1": int_or_none, "col2": int_or_none, "col3": int_or_none}
+
+    dataset = stream.iter_csv(io.StringIO(HOLES), converters=converters, drop_nones=drop_nones)
+    assert list(dataset) == expected
+
+
+@pytest.mark.parametrize("content", ["", "name,year,rating\n"], ids=["empty", "header-only"])
+def test_a_file_without_rows_yields_nothing(content: str) -> None:
+    assert list(stream.iter_csv(io.StringIO(content))) == []
+
+
+def test_sampling_is_deterministic_for_a_given_seed() -> None:
+    sampled = [x["name"] for x, _ in stream.iter_csv(io.StringIO(CONTENT), fraction=0.5, seed=42)]
+
+    assert sampled == [
+        x["name"] for x, _ in stream.iter_csv(io.StringIO(CONTENT), fraction=0.5, seed=42)
     ]
+    assert set(sampled) <= {"a", "b", "c", "d", "e"}
 
 
-def test_iter_csv_drop_nones():
-    example = io.StringIO("col1,col2,col3\n,1,2\n5,,4\n3,1,")
+def test_the_field_size_limit_is_restored(tmp_path: pathlib.Path, write_file: WriteFile) -> None:
+    limit = csv.field_size_limit()
 
-    def int_or_none(s):
-        try:
-            return int(s)
-        except ValueError:
-            return None
+    _ = list(stream.iter_csv(write_file(tmp_path / "data.csv", CONTENT), field_size_limit=10**6))
 
-    params = {
-        "converters": {"col1": int_or_none, "col2": int_or_none, "col3": int_or_none},
-        "drop_nones": True,
-    }
-    dataset = stream.iter_csv(example, **params)
-    assert list(dataset) == [
-        ({"col2": 1, "col3": 2}, None),
-        ({"col1": 5, "col3": 4}, None),
-        ({"col1": 3, "col2": 1}, None),
-    ]
+    assert csv.field_size_limit() == limit
+
+
+def test_a_dataset_is_read_from_a_path(
+    tmp_path: pathlib.Path, write_file: WriteFile, compression_case: CompressionCase
+) -> None:
+    path = write_file(
+        tmp_path / f"data.csv{compression_case.suffix}", CONTENT, compression_case.written_as
+    )
+
+    dataset = stream.iter_csv(path, target="rating", compression=compression_case.read_as)
+    assert next(dataset) == ({"name": "a", "year": "2016"}, "9.5")
+
+
+def test_a_file_the_reader_opened_is_closed(
+    tmp_path: pathlib.Path,
+    write_file: WriteFile,
+    compression_case: CompressionCase,
+    opened_files: list[typing.TextIO],
+) -> None:
+    path = write_file(
+        tmp_path / f"data.csv{compression_case.suffix}", CONTENT, compression_case.written_as
+    )
+
+    _ = list(stream.iter_csv(path, compression=compression_case.read_as))
+
+    assert len(opened_files) == 1
+    assert opened_files[0].closed
+
+
+def test_a_buffer_passed_in_by_the_caller_is_left_open() -> None:
+    buffer = io.StringIO(CONTENT)
+
+    _ = list(stream.iter_csv(buffer))
+
+    assert not buffer.closed

--- a/tests/stream/test_iter_libsvm.py
+++ b/tests/stream/test_iter_libsvm.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import io
+import typing
+
+import pytest
+
+from river import stream
+
+if typing.TYPE_CHECKING:
+    import pathlib
+
+    from river.base.typing import FeatureName
+    from tests.stream.conftest import CompressionCase, WriteFile
+
+CONTENT = "+1 x:-134.26 y:0.2563\n1 x:-12 z:0.3\n-1 y:.25\n"
+FEATURES: list[dict[FeatureName, float]] = [
+    {"x": -134.26, "y": 0.2563},
+    {"x": -12.0, "z": 0.3},
+    {"y": 0.25},
+]
+
+# `1.0 == 1`, so the labels are compared by type as well as by value.
+TARGET_TYPE_CASES: dict[str, tuple[type[typing.Any], list[typing.Any]]] = {
+    "float": (float, [1.0, 1.0, -1.0]),
+    "int": (int, [1, 1, -1]),
+    "str": (str, ["+1", "1", "-1"]),
+}
+
+
+@pytest.mark.parametrize(
+    ("target_type", "targets"), TARGET_TYPE_CASES.values(), ids=TARGET_TYPE_CASES
+)
+def test_the_label_is_cast_to_the_target_type(
+    target_type: type[typing.Any], targets: list[typing.Any]
+) -> None:
+    rows = list(stream.iter_libsvm(io.StringIO(CONTENT), target_type=target_type))
+
+    assert rows == list(zip(FEATURES, targets))
+    assert [type(y) for _, y in rows] == [target_type] * len(targets)
+
+
+def test_the_label_is_a_float_by_default() -> None:
+    rows = list(stream.iter_libsvm(io.StringIO(CONTENT)))
+
+    assert rows == list(zip(FEATURES, [1.0, 1.0, -1.0]))
+    assert [type(y) for _, y in rows] == [float, float, float]
+
+
+def test_trailing_comments_are_ignored() -> None:
+    dataset = stream.iter_libsvm(io.StringIO("+1 x:1#a comment\n"), target_type=int)
+
+    assert list(dataset) == [({"x": 1.0}, 1)]
+
+
+def test_a_dataset_is_read_from_a_path(
+    tmp_path: pathlib.Path, write_file: WriteFile, compression_case: CompressionCase
+) -> None:
+    path = write_file(
+        tmp_path / f"data.svm{compression_case.suffix}", CONTENT, compression_case.written_as
+    )
+
+    dataset = stream.iter_libsvm(path, target_type=int, compression=compression_case.read_as)
+    assert list(dataset) == list(zip(FEATURES, [1, 1, -1]))
+
+
+def test_a_file_the_reader_opened_is_closed(
+    tmp_path: pathlib.Path,
+    write_file: WriteFile,
+    compression_case: CompressionCase,
+    opened_files: list[typing.TextIO],
+) -> None:
+    path = write_file(
+        tmp_path / f"data.svm{compression_case.suffix}", CONTENT, compression_case.written_as
+    )
+
+    _ = list(stream.iter_libsvm(path, compression=compression_case.read_as))
+
+    assert len(opened_files) == 1
+    assert opened_files[0].closed
+
+
+def test_a_buffer_passed_in_by_the_caller_is_left_open() -> None:
+    buffer = io.StringIO(CONTENT)
+
+    _ = list(stream.iter_libsvm(buffer))
+
+    assert not buffer.closed

--- a/tests/stream/test_utils.py
+++ b/tests/stream/test_utils.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import typing
+
+import pytest
+
+from river.stream import utils
+
+if typing.TYPE_CHECKING:
+    import pathlib
+    from collections.abc import Callable
+
+    from river.stream.typing import Compression
+    from tests.stream.conftest import CompressionCase, WriteFile
+
+    ReadBack = Callable[[typing.TextIO], typing.Any]
+
+CONTENT = "name,rating\na,9.5\nb,9.4\n"
+LINES = ["name,rating\n", "a,9.5\n", "b,9.4\n"]
+
+READ_BACK_CASES: dict[str, tuple[ReadBack, typing.Any]] = {
+    "whole": (lambda f: f.read(), CONTENT),
+    "line-by-line": (lambda f: list(f), LINES),
+}
+
+
+@pytest.mark.parametrize(("read_back", "expected"), READ_BACK_CASES.values(), ids=READ_BACK_CASES)
+@pytest.mark.parametrize("as_str", [False, True], ids=["pathlike", "str"])
+def test_the_content_is_read_back_as_text(
+    tmp_path: pathlib.Path,
+    write_file: WriteFile,
+    compression_case: CompressionCase,
+    as_str: bool,
+    read_back: ReadBack,
+    expected: typing.Any,
+) -> None:
+    path = write_file(
+        tmp_path / f"data.csv{compression_case.suffix}", CONTENT, compression_case.written_as
+    )
+
+    with utils.open_filepath(str(path) if as_str else path, compression_case.read_as) as f:
+        assert read_back(f) == expected
+
+
+def test_an_unknown_extension_is_read_as_is(tmp_path: pathlib.Path, write_file: WriteFile) -> None:
+    with utils.open_filepath(write_file(tmp_path / "data.unknown", CONTENT), "infer") as f:
+        assert f.read() == CONTENT
+
+
+@pytest.mark.parametrize("compression", ["infer", "gzip", "zip", None])
+def test_a_missing_file_raises(tmp_path: pathlib.Path, compression: Compression | None) -> None:
+    with pytest.raises(FileNotFoundError):
+        utils.open_filepath(tmp_path / "nope.csv", compression)
+
+
+def test_a_zip_member_outlives_the_archive_object(
+    tmp_path: pathlib.Path, write_file: WriteFile
+) -> None:
+    """`open_filepath` returns a member of a `ZipFile` it has already closed."""
+    handle = utils.open_filepath(write_file(tmp_path / "data.csv.zip", CONTENT), "infer")
+    try:
+        assert handle.read() == CONTENT
+    finally:
+        handle.close()
+    assert handle.closed


### PR DESCRIPTION
# Description

Makes the three file-based stream readers and their shared `open_filepath` helper type-complete, and opts them into strict mypy, with aliases factored out into a new `river.stream.typing` module.

Along the way it fixes a file-handle leak in `iter_libsvm`, which never closed the file it opened because `should_close` was assigned `False` twice.

Adds parametrized tests for all three readers plus `open_filepath`, sharing one 5-case compression matrix (plain / gzip / zip, inferred and explicit) and asserting each reader closes what it opens while leaving caller-supplied buffers alone. **Note**: tests were scaffolded/initially generated by Claude Opus 5.

Finally, added a `[[tool.mypy.overrides]]` entry in pyproject.toml to track files that are type complete. I am sure there are others to add - I simply added what I worked on here and past PRs related to strict typing.

---

Related #1944 

---

Unwanted opinion for reviewing:

* I think the split view is a bit more digestible for a review in this case 😇
* 65%+ of the changes are either tests or non codebase related
