### PR TITLE
Strict typing: optim sub-package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,7 +245,6 @@ ignore_missing_imports = true
 # Disable strict mode for all non fully-typed modules
 module = [
     "river.metrics.*",
-    "river.optim.*",
     "river.datasets.*",
     "river.tree.*",
     "river.preprocessing.*",

--- a/river/optim/ada_bound.py
+++ b/river/optim/ada_bound.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import collections
 import math
 
-from river import optim, utils
+from river import base, optim, utils
 from river.optim.base import DictLike
 
 __all__ = ["AdaBound"]
@@ -54,7 +54,15 @@ class AdaBound(optim.base.Optimizer):
 
     """
 
-    def __init__(self, lr=1e-3, beta_1=0.9, beta_2=0.999, eps=1e-8, gamma=1e-3, final_lr=0.1):
+    def __init__(
+        self,
+        lr: int | float | optim.base.Scheduler = 1e-3,
+        beta_1: float = 0.9,
+        beta_2: float = 0.999,
+        eps: float = 1e-8,
+        gamma: float = 1e-3,
+        final_lr: float = 0.1,
+    ):
         super().__init__(lr)
         # Capture the base learning rate as a float. Reading it back from `lr` directly would
         # break on clone (where `lr` arrives as a `Constant` scheduler rather than a number).
@@ -64,8 +72,8 @@ class AdaBound(optim.base.Optimizer):
         self.beta_2 = beta_2
         self.eps = eps
         self.gamma = gamma
-        self.m = collections.defaultdict(float)
-        self.v = collections.defaultdict(float)
+        self.m: dict[base.typing.FeatureName, float] = collections.defaultdict(float)
+        self.v: dict[base.typing.FeatureName, float] = collections.defaultdict(float)
 
     def _step_with_dict(self, w: DictLike, g: DictLike) -> DictLike:
         bias_1 = 1 - self.beta_1 ** (self.n_iterations + 1)

--- a/river/optim/ada_delta.py
+++ b/river/optim/ada_delta.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import collections
+import typing
 
-from river import optim
+from river import base, optim
 from river.optim.base import DictLike
 
 __all__ = ["AdaDelta"]
@@ -48,16 +49,16 @@ class AdaDelta(optim.base.Optimizer):
 
     """
 
-    def __init__(self, rho=0.95, eps=1e-8):
+    def __init__(self, rho: float = 0.95, eps: float = 1e-8):
         # AdaDelta has no global learning rate (it derives per-coordinate steps from `rho`). We pass
         # an inert 0 so the base keeps a valid `Scheduler`; `learning_rate` is never read here.
         super().__init__(lr=0.0)
         self.rho = rho
         self.eps = eps
-        self.g2 = collections.defaultdict(float)
-        self.s2 = collections.defaultdict(float)
+        self.g2: dict[base.typing.FeatureName, typing.Any] = collections.defaultdict(float)
+        self.s2: dict[base.typing.FeatureName, typing.Any] = collections.defaultdict(float)
 
-    def _rms(self, x):
+    def _rms(self, x: typing.Any) -> typing.Any:
         return (x + self.eps) ** 0.5
 
     def _step_with_dict(self, w: DictLike, g: DictLike) -> DictLike:

--- a/river/optim/ada_grad.py
+++ b/river/optim/ada_grad.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import collections
+import typing
 
-from river import optim
+from river import base, optim
 from river.optim.base import DictLike
 
 __all__ = ["AdaGrad"]
@@ -47,10 +48,10 @@ class AdaGrad(optim.base.Optimizer):
 
     """
 
-    def __init__(self, lr=0.1, eps=1e-8):
+    def __init__(self, lr: int | float | optim.base.Scheduler = 0.1, eps: float = 1e-8):
         super().__init__(lr)
         self.eps = eps
-        self.g2 = collections.defaultdict(float)
+        self.g2: dict[base.typing.FeatureName, typing.Any] = collections.defaultdict(float)
 
     def _step_with_dict(self, w: DictLike, g: DictLike) -> DictLike:
         for i, gi in g.items():

--- a/river/optim/ada_max.py
+++ b/river/optim/ada_max.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import collections
 
-from river import optim
+from river import base, optim
 from river.optim.base import DictLike
 
 __all__ = ["AdaMax"]
@@ -51,13 +51,19 @@ class AdaMax(optim.base.Optimizer):
 
     """
 
-    def __init__(self, lr=0.1, beta_1=0.9, beta_2=0.999, eps=1e-8):
+    def __init__(
+        self,
+        lr: int | float | optim.base.Scheduler = 0.1,
+        beta_1: float = 0.9,
+        beta_2: float = 0.999,
+        eps: float = 1e-8,
+    ):
         super().__init__(lr)
         self.beta_1 = beta_1
         self.beta_2 = beta_2
         self.eps = eps
-        self.m = collections.defaultdict(float)
-        self.u = collections.defaultdict(float)
+        self.m: dict[base.typing.FeatureName, float] = collections.defaultdict(float)
+        self.u: dict[base.typing.FeatureName, float] = collections.defaultdict(float)
 
     def _step_with_dict(self, w: DictLike, g: DictLike) -> DictLike:
         # Correct bias for `m`

--- a/river/optim/adam.py
+++ b/river/optim/adam.py
@@ -6,7 +6,7 @@ import typing
 import numpy as np
 
 from river import optim, utils
-from river.optim.base import DictLike
+from river.optim.base import DictLike, VectorLike
 
 __all__ = ["Adam"]
 
@@ -53,7 +53,13 @@ class Adam(optim.base.Optimizer):
 
     """
 
-    def __init__(self, lr=0.1, beta_1=0.9, beta_2=0.999, eps=1e-8) -> None:
+    def __init__(
+        self,
+        lr: int | float | optim.base.Scheduler = 0.1,
+        beta_1: float = 0.9,
+        beta_2: float = 0.999,
+        eps: float = 1e-8,
+    ) -> None:
         super().__init__(lr)
         self.beta_1 = beta_1
         self.beta_2 = beta_2
@@ -82,7 +88,7 @@ class Adam(optim.base.Optimizer):
 
         return w
 
-    def _step_with_vector(self, w, g):
+    def _step_with_vector(self, w: VectorLike, g: VectorLike) -> VectorLike:
         if self.m is None:
             if isinstance(w, np.ndarray):
                 self.m = np.zeros_like(w)

--- a/river/optim/ams_grad.py
+++ b/river/optim/ams_grad.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import collections
 
-from river import optim
+from river import base, optim
 from river.optim.base import DictLike
 
 __all__ = ["AMSGrad"]
@@ -56,19 +56,19 @@ class AMSGrad(optim.base.Optimizer):
     def __init__(
         self,
         lr: int | float | optim.base.Scheduler = 0.1,
-        beta_1=0.9,
-        beta_2=0.999,
-        eps=1e-8,
-        correct_bias=True,
+        beta_1: float = 0.9,
+        beta_2: float = 0.999,
+        eps: float = 1e-8,
+        correct_bias: bool = True,
     ):
         super().__init__(lr)
         self.beta_1 = beta_1
         self.beta_2 = beta_2
         self.eps = eps
         self.correct_bias = correct_bias
-        self.m: dict[str, float] = collections.defaultdict(float)
-        self.v: dict[str, float] = collections.defaultdict(float)
-        self.v_hat: dict[str, float] = collections.defaultdict(float)
+        self.m: dict[base.typing.FeatureName, float] = collections.defaultdict(float)
+        self.v: dict[base.typing.FeatureName, float] = collections.defaultdict(float)
+        self.v_hat: dict[base.typing.FeatureName, float] = collections.defaultdict(float)
 
     def _step_with_dict(self, w: DictLike, g: DictLike) -> DictLike:
         lr = self.learning_rate

--- a/river/optim/average.py
+++ b/river/optim/average.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import collections
+import typing
 
-from river import optim
-from river.optim.base import DictLike
+from river import base, optim
+from river.optim.base import DictLike, VectorLike
 
 
 class Averager(optim.base.Optimizer):
@@ -54,10 +55,10 @@ class Averager(optim.base.Optimizer):
     def __init__(self, optimizer: optim.base.Optimizer, start: int = 0):
         self.optimizer = optimizer
         self.start = start
-        self.avg_w: dict[str, float] = collections.defaultdict(float)
+        self.avg_w: dict[base.typing.FeatureName, float] = collections.defaultdict(float)
         self.n_iterations = 0
 
-    def look_ahead(self, w):
+    def look_ahead(self, w: DictLike | VectorLike) -> DictLike | VectorLike:
         return self.optimizer.look_ahead(w)
 
     def _step_with_dict(self, w: DictLike, g: DictLike) -> DictLike:
@@ -75,5 +76,5 @@ class Averager(optim.base.Optimizer):
         return self.avg_w
 
     @classmethod
-    def _unit_test_params(cls):
+    def _unit_test_params(cls) -> collections.abc.Iterator[dict[str, typing.Any]]:
         yield {"optimizer": optim.SGD()}

--- a/river/optim/base.py
+++ b/river/optim/base.py
@@ -11,12 +11,20 @@ __all__ = ["Initializer", "Scheduler", "Optimizer", "Loss"]
 
 # Array-like weights/gradients: numpy arrays and `VectorDict`. These support elementwise
 # arithmetic but not necessarily feature-name indexing (a raw `np.ndarray` does not).
-VectorLike = typing.Union[utils.VectorDict, np.ndarray]  # noqa: UP007
+VectorLike = typing.Union[  # noqa: UP007
+    "utils.VectorDict[base.typing.FeatureName, typing.Any]", np.ndarray
+]
 # The "dict" path operates on feature-keyed, dict-like containers: plain dicts and `VectorDict`
 # (which is dict-like). It explicitly excludes `np.ndarray`, which has no `.keys()`/`.items()` and
 # cannot be indexed by feature name. `VectorDict` belongs to both unions because it implements both
 # the mapping and the array protocols.
-DictLike = typing.Union[dict, utils.VectorDict]  # noqa: UP007
+# The values are left dynamic: linear models keep one scalar weight per feature, whereas models
+# with latent factors keep a whole vector per key. Optimizers that only support the scalar case
+# are listed in `tests/optim/test_estimator_compat.py`.
+DictLike = typing.Union[  # noqa: UP007
+    dict[base.typing.FeatureName, typing.Any],
+    "utils.VectorDict[base.typing.FeatureName, typing.Any]",
+]
 
 
 class Initializer(base.Base, abc.ABC):
@@ -53,7 +61,7 @@ class Scheduler(base.Base, abc.ABC):
 
         """
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}({vars(self)})"
 
 
@@ -80,14 +88,14 @@ class Optimizer(base.Base):
         self.n_iterations = 0
 
     @property
-    def _mutable_attributes(self):
+    def _mutable_attributes(self) -> set[str]:
         return {"lr"}
 
     @property
     def learning_rate(self) -> float:
         return self.lr.get(self.n_iterations)
 
-    def look_ahead(self, w: dict) -> dict:
+    def look_ahead(self, w: DictLike | VectorLike) -> DictLike | VectorLike:
         """Updates a weight vector before a prediction is made.
 
         Parameters:
@@ -105,7 +113,7 @@ class Optimizer(base.Base):
     def _step_with_vector(self, w: VectorLike, g: VectorLike) -> VectorLike:
         raise NotImplementedError
 
-    def step(self, w: dict | VectorLike, g: dict | VectorLike) -> dict | VectorLike:
+    def step(self, w: DictLike | VectorLike, g: DictLike | VectorLike) -> DictLike | VectorLike:
         """Updates a weight vector given a gradient.
 
         Parameters
@@ -134,18 +142,18 @@ class Optimizer(base.Base):
         self.n_iterations += 1
         return w
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}({vars(self)})"
 
 
 class Loss(base.Base, abc.ABC):
     """Base class for all loss functions."""
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}({vars(self)})"
 
     @abc.abstractmethod
-    def __call__(self, y_true, y_pred) -> typing.Any:
+    def __call__(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any:
         """Returns the loss.
 
         Parameters
@@ -162,7 +170,7 @@ class Loss(base.Base, abc.ABC):
         """
 
     @abc.abstractmethod
-    def gradient(self, y_true, y_pred) -> typing.Any:
+    def gradient(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any:
         """Return the gradient with respect to y_pred.
 
         Parameters
@@ -179,7 +187,7 @@ class Loss(base.Base, abc.ABC):
         """
 
     @abc.abstractmethod
-    def mean_func(self, y_pred) -> typing.Any:
+    def mean_func(self, y_pred: typing.Any) -> typing.Any:
         """Mean function.
 
         This is the inverse of the link function. Typically, a loss function takes as input the raw

--- a/river/optim/ftrl.py
+++ b/river/optim/ftrl.py
@@ -4,7 +4,7 @@ import collections
 
 import numpy as np
 
-from river import optim
+from river import base, optim
 from river.optim.base import DictLike
 
 __all__ = ["FTRLProximal"]
@@ -53,13 +53,13 @@ class FTRLProximal(optim.base.Optimizer):
 
     """
 
-    def __init__(self, alpha=0.05, beta=1.0, l1=0.0, l2=1.0):
+    def __init__(self, alpha: float = 0.05, beta: float = 1.0, l1: float = 0.0, l2: float = 1.0):
         self.alpha = alpha
         self.beta = beta
         self.l1 = l1
         self.l2 = l2
-        self.z = collections.defaultdict(float)
-        self.n = collections.defaultdict(float)
+        self.z: dict[base.typing.FeatureName, float] = collections.defaultdict(float)
+        self.n: dict[base.typing.FeatureName, float] = collections.defaultdict(float)
         self.n_iterations = 0
 
     def _step_with_dict(self, w: DictLike, g: DictLike) -> DictLike:

--- a/river/optim/initializers.py
+++ b/river/optim/initializers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import typing
+
 import numpy as np
 
 from river.optim.base import Initializer as Initializer
@@ -34,7 +36,7 @@ class Constant(Initializer):
     def __init__(self, value: float):
         self.value = value
 
-    def __call__(self, shape=1):
+    def __call__(self, shape: int = 1) -> typing.Any:
         return np.full(shape, self.value, dtype=float) if shape != 1 else self.value
 
 
@@ -56,7 +58,7 @@ class Zeros(Constant):
 
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(value=0.0)
 
 
@@ -87,13 +89,13 @@ class Normal(Initializer):
 
     """
 
-    def __init__(self, mu=0.0, sigma=1.0, seed: int | None = None):
+    def __init__(self, mu: float = 0.0, sigma: float = 1.0, seed: int | None = None):
         self.mu = mu
         self.sigma = sigma
         self.seed = seed
         self._rng = np.random.RandomState(seed)
 
-    def __call__(self, shape=1):
+    def __call__(self, shape: int = 1) -> typing.Any:
         weights = self._rng.normal(loc=self.mu, scale=self.sigma, size=shape)
         if shape == 1:
             return weights[0]

--- a/river/optim/losses.py
+++ b/river/optim/losses.py
@@ -13,10 +13,12 @@ vectorised branches of a loss **must** resolve such a boundary point identically
 
 from __future__ import annotations
 
+import abc
 import math
+import typing
 
 import numpy as np
-from scipy import special  # type: ignore
+from scipy import special
 
 from river import base, utils
 from river.optim.base import Loss as Loss
@@ -46,7 +48,31 @@ def clamp_proba(x: float) -> float:
 class BinaryLoss(Loss):
     """A loss appropriate for binary classification tasks."""
 
-    def mean_func(self, y_pred):
+    @typing.overload
+    def __call__(self, y_true: bool, y_pred: float) -> float: ...
+
+    @typing.overload
+    def __call__(self, y_true: np.ndarray, y_pred: np.ndarray) -> np.ndarray: ...
+
+    @abc.abstractmethod
+    def __call__(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any: ...
+
+    @typing.overload
+    def gradient(self, y_true: bool, y_pred: float) -> float: ...
+
+    @typing.overload
+    def gradient(self, y_true: np.ndarray, y_pred: np.ndarray) -> np.ndarray: ...
+
+    @abc.abstractmethod
+    def gradient(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any: ...
+
+    @typing.overload
+    def mean_func(self, y_pred: float) -> float: ...
+
+    @typing.overload
+    def mean_func(self, y_pred: np.ndarray) -> np.ndarray: ...
+
+    def mean_func(self, y_pred: typing.Any) -> typing.Any:
         if isinstance(y_pred, np.ndarray):
             return 1.0 / (1.0 + np.exp(-y_pred))
         return utils.math.sigmoid(y_pred)
@@ -55,7 +81,25 @@ class BinaryLoss(Loss):
 class MultiClassLoss(Loss):
     """A loss appropriate for multi-class classification tasks."""
 
-    def mean_func(self, y_pred):
+    @abc.abstractmethod
+    def __call__(
+        self, y_true: base.typing.ClfTarget, y_pred: dict[base.typing.ClfTarget, float]
+    ) -> float: ...
+
+    @abc.abstractmethod
+    def gradient(
+        self, y_true: base.typing.ClfTarget, y_pred: dict[base.typing.ClfTarget, float]
+    ) -> dict[base.typing.ClfTarget, float]: ...
+
+    @typing.overload
+    def mean_func(
+        self, y_pred: dict[base.typing.ClfTarget, float]
+    ) -> dict[base.typing.ClfTarget, float]: ...
+
+    @typing.overload
+    def mean_func(self, y_pred: np.ndarray) -> np.ndarray: ...
+
+    def mean_func(self, y_pred: typing.Any) -> typing.Any:
         if isinstance(y_pred, np.ndarray):
             return special.softmax(y_pred)
         return utils.math.softmax(y_pred)
@@ -64,7 +108,31 @@ class MultiClassLoss(Loss):
 class RegressionLoss(Loss):
     """A loss appropriate for regression tasks."""
 
-    def mean_func(self, y_pred):
+    @typing.overload
+    def __call__(self, y_true: float, y_pred: float) -> float: ...
+
+    @typing.overload
+    def __call__(self, y_true: np.ndarray, y_pred: np.ndarray) -> np.ndarray: ...
+
+    @abc.abstractmethod
+    def __call__(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any: ...
+
+    @typing.overload
+    def gradient(self, y_true: float, y_pred: float) -> float: ...
+
+    @typing.overload
+    def gradient(self, y_true: np.ndarray, y_pred: np.ndarray) -> np.ndarray: ...
+
+    @abc.abstractmethod
+    def gradient(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any: ...
+
+    @typing.overload
+    def mean_func(self, y_pred: float) -> float: ...
+
+    @typing.overload
+    def mean_func(self, y_pred: np.ndarray) -> np.ndarray: ...
+
+    def mean_func(self, y_pred: typing.Any) -> typing.Any:
         return y_pred
 
 
@@ -94,12 +162,12 @@ class Absolute(RegressionLoss):
 
     """
 
-    def __call__(self, y_true, y_pred):
+    def __call__(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any:
         if isinstance(y_true, np.ndarray):
             return np.abs(y_pred - y_true)
         return abs(y_pred - y_true)
 
-    def gradient(self, y_true, y_pred):
+    def gradient(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any:
         if isinstance(y_true, np.ndarray):
             return np.where(y_pred > y_true, 1, -1)
 
@@ -122,15 +190,15 @@ class Cauchy(RegressionLoss):
 
     """
 
-    def __init__(self, C=80):
+    def __init__(self, C: float = 80):
         self.C = C
 
-    def __call__(self, y_true, y_pred):
+    def __call__(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any:
         if isinstance(y_true, np.ndarray):
             return np.abs(y_pred - y_true)
         return abs(y_pred - y_true)
 
-    def gradient(self, y_true, y_pred):
+    def gradient(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any:
         diff = y_pred - y_true
         return diff / ((diff / self.C) ** 2 + 1)
 
@@ -185,8 +253,8 @@ class CrossEntropy(MultiClassLoss):
             class_weight = {}
         self.class_weight = class_weight
 
-    def __call__(self, y_true, y_pred):
-        total = 0
+    def __call__(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any:
+        total = 0.0
 
         for label, proba in y_pred.items():
             if y_true == label:
@@ -194,7 +262,7 @@ class CrossEntropy(MultiClassLoss):
 
         return -total
 
-    def gradient(self, y_true, y_pred):
+    def gradient(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any:
         return {
             label: (
                 self.class_weight.get(label, 1.0)
@@ -242,10 +310,10 @@ class Hinge(BinaryLoss):
 
     """
 
-    def __init__(self, threshold=1.0):
+    def __init__(self, threshold: float = 1.0):
         self.threshold = threshold
 
-    def __call__(self, y_true, y_pred):
+    def __call__(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any:
         y_true = y_true * 2 - 1  # [0, 1] -> [-1, 1]
 
         if isinstance(y_true, np.ndarray):
@@ -253,7 +321,7 @@ class Hinge(BinaryLoss):
 
         return max(self.threshold - y_true * y_pred, 0)
 
-    def gradient(self, y_true, y_pred):
+    def gradient(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any:
         y_true = y_true * 2 - 1  # [0, 1] -> [-1, 1]
 
         # Boundary convention (see module docstring): a point sitting exactly on the margin
@@ -277,10 +345,10 @@ class EpsilonInsensitiveHinge(RegressionLoss):
 
     """
 
-    def __init__(self, eps=0.1):
+    def __init__(self, eps: float = 0.1):
         self.eps = eps
 
-    def __call__(self, y_true, y_pred):
+    def __call__(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any:
         y_true = y_true * 2 - 1  # [0, 1] -> [-1, 1]
 
         if isinstance(y_true, np.ndarray):
@@ -288,7 +356,7 @@ class EpsilonInsensitiveHinge(RegressionLoss):
 
         return max(math.fabs(y_pred - y_true) - self.eps, 0)
 
-    def gradient(self, y_true, y_pred):
+    def gradient(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any:
         y_true = y_true * 2 - 1  # [0, 1] -> [-1, 1]
 
         if isinstance(y_true, np.ndarray):
@@ -321,11 +389,11 @@ class Log(BinaryLoss):
 
     """
 
-    def __init__(self, weight_pos=1.0, weight_neg=1.0):
+    def __init__(self, weight_pos: float = 1.0, weight_neg: float = 1.0):
         self.weight_pos = weight_pos
         self.weight_neg = weight_neg
 
-    def __call__(self, y_true, y_pred):
+    def __call__(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any:
         if isinstance(y_true, np.ndarray):
             weights = np.where(y_true == 0, self.weight_neg, self.weight_pos)
             y_true = 2 * y_true - 1  # map {0, 1} to {-1, 1}
@@ -346,7 +414,7 @@ class Log(BinaryLoss):
             return weight * -z
         return weight * math.log(1.0 + math.exp(-z))
 
-    def gradient(self, y_true, y_pred):
+    def gradient(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any:
         if isinstance(y_true, np.ndarray):
             weights = np.where(y_true == 0, self.weight_neg, self.weight_pos)
             y_true = 2 * y_true - 1  # map {0, 1} to {-1, 1}
@@ -398,14 +466,14 @@ class Quantile(RegressionLoss):
 
     """
 
-    def __init__(self, alpha=0.5):
+    def __init__(self, alpha: float = 0.5):
         self.alpha = alpha
 
-    def __call__(self, y_true, y_pred):
+    def __call__(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any:
         diff = y_pred - y_true
         return (self.alpha - (diff < 0)) * diff
 
-    def gradient(self, y_true, y_pred):
+    def gradient(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any:
         return (y_true < y_pred) - self.alpha
 
 
@@ -439,10 +507,10 @@ class Squared(RegressionLoss):
 
     """
 
-    def __call__(self, y_true, y_pred):
+    def __call__(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any:
         return (y_pred - y_true) * (y_pred - y_true)
 
-    def gradient(self, y_true, y_pred):
+    def gradient(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any:
         return 2 * (y_pred - y_true)
 
 
@@ -461,10 +529,10 @@ class Huber(RegressionLoss):
 
     """
 
-    def __init__(self, epsilon=0.1):
+    def __init__(self, epsilon: float = 0.1):
         self.epsilon = epsilon
 
-    def __call__(self, y_true, y_pred):
+    def __call__(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any:
         r = y_pred - y_true
 
         if isinstance(y_true, np.ndarray):
@@ -480,7 +548,7 @@ class Huber(RegressionLoss):
             return 0.5 * r * r
         return self.epsilon * abs_r - (0.5 * self.epsilon * self.epsilon)
 
-    def gradient(self, y_true, y_pred):
+    def gradient(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any:
         r = y_pred - y_true
 
         if isinstance(y_true, np.ndarray):
@@ -513,11 +581,11 @@ class BinaryFocalLoss(BinaryLoss):
 
     """
 
-    def __init__(self, gamma=2, beta=1):
+    def __init__(self, gamma: float = 2, beta: float = 1):
         self.gamma = gamma
         self.beta = beta
 
-    def __call__(self, y_true, y_pred):
+    def __call__(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any:
         y_true = y_true * 2 - 1  # [0, 1] -> [-1, 1]
 
         xt = y_true * y_pred
@@ -529,7 +597,7 @@ class BinaryFocalLoss(BinaryLoss):
         pt = utils.math.sigmoid(self.gamma * xt + self.beta)
         return -math.log(pt) / self.gamma
 
-    def gradient(self, y_true, y_pred):
+    def gradient(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any:
         y_true = y_true * 2 - 1  # [0, 1] -> [-1, 1]
 
         xt = y_true * y_pred
@@ -557,17 +625,17 @@ class Poisson(RegressionLoss):
 
     """
 
-    def __call__(self, y_true, y_pred):
+    def __call__(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any:
         if isinstance(y_pred, np.ndarray):
             return np.exp(y_pred) - y_true * y_pred
         return math.exp(y_pred) - y_true * y_pred
 
-    def gradient(self, y_true, y_pred):
+    def gradient(self, y_true: typing.Any, y_pred: typing.Any) -> typing.Any:
         if isinstance(y_pred, np.ndarray):
             return np.exp(y_pred) - y_true
         return math.exp(y_pred) - y_true
 
-    def mean_func(self, y_pred):
+    def mean_func(self, y_pred: typing.Any) -> typing.Any:
         if isinstance(y_pred, np.ndarray):
             return np.exp(y_pred)
         return math.exp(y_pred)

--- a/river/optim/momentum.py
+++ b/river/optim/momentum.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import collections
+import typing
 
-from river import optim
+from river import base, optim
 from river.optim.base import DictLike
 
 __all__ = ["Momentum"]
@@ -39,10 +40,10 @@ class Momentum(optim.base.Optimizer):
 
     """
 
-    def __init__(self, lr=0.1, rho=0.9):
+    def __init__(self, lr: int | float | optim.base.Scheduler = 0.1, rho: float = 0.9):
         super().__init__(lr)
         self.rho = rho
-        self.s = collections.defaultdict(float)
+        self.s: dict[base.typing.FeatureName, typing.Any] = collections.defaultdict(float)
 
     def _step_with_dict(self, w: DictLike, g: DictLike) -> DictLike:
         for i, gi in g.items():

--- a/river/optim/nadam.py
+++ b/river/optim/nadam.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import collections
 import math
+import typing
 
-from river import optim
+from river import base, optim
 from river.optim.base import DictLike
 
 __all__ = ["Nadam"]
@@ -46,13 +47,19 @@ class Nadam(optim.base.Optimizer):
 
     """
 
-    def __init__(self, lr=0.1, beta_1=0.9, beta_2=0.999, eps=1e-8):
+    def __init__(
+        self,
+        lr: int | float | optim.base.Scheduler = 0.1,
+        beta_1: float = 0.9,
+        beta_2: float = 0.999,
+        eps: float = 1e-8,
+    ):
         super().__init__(lr)
         self.beta_1 = beta_1
         self.beta_2 = beta_2
         self.eps = eps
-        self.m = collections.defaultdict(float)
-        self.v = collections.defaultdict(float)
+        self.m: dict[base.typing.FeatureName, typing.Any] = collections.defaultdict(float)
+        self.v: dict[base.typing.FeatureName, typing.Any] = collections.defaultdict(float)
 
     def _step_with_dict(self, w: DictLike, g: DictLike) -> DictLike:
         for i, gi in g.items():

--- a/river/optim/nesterov.py
+++ b/river/optim/nesterov.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import collections
+import typing
 
 import numpy as np
 
-from river import optim
-from river.optim.base import DictLike
+from river import base, optim
+from river.optim.base import DictLike, VectorLike
 
 __all__ = ["NesterovMomentum"]
 
@@ -41,14 +42,15 @@ class NesterovMomentum(optim.base.Optimizer):
 
     """
 
-    def __init__(self, lr=0.1, rho=0.9):
+    def __init__(self, lr: int | float | optim.base.Scheduler = 0.1, rho: float = 0.9):
         super().__init__(lr)
         self.rho = rho
-        self.s = collections.defaultdict(float)
+        self.s: dict[base.typing.FeatureName, typing.Any] = collections.defaultdict(float)
 
-    def look_ahead(self, w):
+    def look_ahead(self, w: DictLike | VectorLike) -> DictLike | VectorLike:
         # `w` may be a dict-like (iterating yields keys) or a NumPy array (iterate its indices).
-        for i in range(len(w)) if isinstance(w, np.ndarray) else w:
+        indices: typing.Iterable[typing.Any] = range(len(w)) if isinstance(w, np.ndarray) else w
+        for i in indices:
             w[i] -= self.rho * self.s[i]
 
         return w

--- a/river/optim/newton.py
+++ b/river/optim/newton.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import typing
+
 import numpy as np
 
 from river import base, optim, utils
@@ -64,7 +66,7 @@ class Newton(optim.base.Optimizer):
 
     """
 
-    def __init__(self, lr=0.1, eps=1e-5):
+    def __init__(self, lr: int | float | optim.base.Scheduler = 0.1, eps: float = 1e-5):
         super().__init__(lr)
         self.eps = eps
         self._idx: dict[base.typing.FeatureName, int] = {}
@@ -82,7 +84,7 @@ class Newton(optim.base.Optimizer):
         self._H_inv = new_H_inv
         self._cap = new_cap
 
-    def _ensure_features(self, features) -> None:
+    def _ensure_features(self, features: typing.Iterable[base.typing.FeatureName]) -> None:
         idx = self._idx
         for f in features:
             if f not in idx:

--- a/river/optim/rms_prop.py
+++ b/river/optim/rms_prop.py
@@ -6,7 +6,7 @@ import typing
 import numpy as np
 
 from river import optim, utils
-from river.optim.base import DictLike
+from river.optim.base import DictLike, VectorLike
 
 __all__ = ["RMSProp"]
 
@@ -47,7 +47,9 @@ class RMSProp(optim.base.Optimizer):
 
     """
 
-    def __init__(self, lr=0.1, rho=0.9, eps=1e-8):
+    def __init__(
+        self, lr: int | float | optim.base.Scheduler = 0.1, rho: float = 0.9, eps: float = 1e-8
+    ):
         super().__init__(lr)
         self.rho = rho
         self.eps = eps
@@ -66,7 +68,7 @@ class RMSProp(optim.base.Optimizer):
 
         return w
 
-    def _step_with_vector(self, w, g):
+    def _step_with_vector(self, w: VectorLike, g: VectorLike) -> VectorLike:
         if self.g2 is None:
             if isinstance(w, np.ndarray):
                 self.g2 = np.zeros_like(w)

--- a/river/optim/schedulers.py
+++ b/river/optim/schedulers.py
@@ -22,10 +22,10 @@ class Constant(optim.base.Scheduler):
         self.learning_rate = learning_rate
 
     @property
-    def _mutable_attributes(self):
+    def _mutable_attributes(self) -> set[str]:
         return {"learning_rate"}
 
-    def get(self, t):
+    def get(self, t: int) -> float:
         return self.learning_rate
 
 
@@ -45,12 +45,12 @@ class InverseScaling(optim.base.Scheduler):
 
     """
 
-    def __init__(self, learning_rate: float, power=0.5):
+    def __init__(self, learning_rate: float, power: float = 0.5):
         self.learning_rate = learning_rate
         self.power = power
 
-    def get(self, t):
-        return self.learning_rate / pow(t + 1, self.power)
+    def get(self, t: int) -> float:
+        return self.learning_rate / math.pow(t + 1, self.power)
 
 
 class Optimal(optim.base.Scheduler):
@@ -67,13 +67,13 @@ class Optimal(optim.base.Scheduler):
 
     """
 
-    def __init__(self, loss: optim.losses.Loss, alpha=1e-4):
+    def __init__(self, loss: optim.losses.Loss, alpha: float = 1e-4):
         self.loss = loss
         self.alpha = alpha
 
         typw = math.sqrt(1.0 / math.sqrt(self.alpha))
-        initial_eta0 = typw / max(1.0, self.loss.gradient(True, -typw))
+        initial_eta0 = typw / max(1.0, float(self.loss.gradient(True, -typw)))
         self.t0 = 1.0 / (initial_eta0 * self.alpha)
 
-    def get(self, t):
+    def get(self, t: int) -> float:
         return 1.0 / (self.alpha * (self.t0 + t))

--- a/river/optim/sgd.py
+++ b/river/optim/sgd.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 
 from river import optim
-from river.optim.base import DictLike
+from river.optim.base import DictLike, VectorLike
 
 __all__ = ["SGD"]
 
@@ -42,7 +42,7 @@ class SGD(optim.base.Optimizer):
 
     """
 
-    def __init__(self, lr=0.01) -> None:
+    def __init__(self, lr: int | float | optim.base.Scheduler = 0.01) -> None:
         super().__init__(lr)
 
     def _step_with_dict(self, w: DictLike, g: DictLike) -> DictLike:
@@ -50,7 +50,7 @@ class SGD(optim.base.Optimizer):
             w[i] -= self.learning_rate * gi
         return w
 
-    def _step_with_vector(self, w, g):
+    def _step_with_vector(self, w: VectorLike, g: VectorLike) -> VectorLike:
         if isinstance(w, np.ndarray):
             w -= self.learning_rate * g
         else:


### PR DESCRIPTION
## Description

Related to https://github.com/online-ml/river/issues/1944

Implement strict typing for the `river.optim` package as it only depends on already strictly typed packages.

Some methods (see `losses.py`) accept `Any` as input but internally check for various specific types at runtime using `isinstance` and then routes differently depending in the detected type: this works fine but doesn't provide much typing info to the user, so we added `@typing.overload`s. Note that this does not alter runtime behaviour.

> [!NOTE]
> *AI disclaimer*: most of the changes in this PR have been written with an LLM-based coding agent.
> I have personally reviewed / corrected these changes before submitting this PR.
