### PR TITLE
fix: handle zero vectors in Normalizer 

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -7,3 +7,7 @@
 - `stream.iter_csv` now closes the file it opened and restores `csv.field_size_limit` even when the stream is not exhausted, e.g. when the caller breaks out of the loop. Only the file `iter_csv` opened itself is closed; a buffer passed in by the caller is still left open.
 - `stream.iter_sql` now closes the result it iterates, so the underlying cursor is released once the stream is exhausted or abandoned.
 - `stream.cache`, `stream.iter_csv`, and `stream.iter_sql` are now clean under strict mypy. `sqlalchemy` is type-checked rather than ignored, so the `query` and `conn` arguments of `stream.iter_sql` are checked against the SQLAlchemy 2.0 types.
+
+## preprocessing
+
+- `preprocessing.Normalizer` now handles zero vectors without raising a `ZeroDivisionError`. A zero vector is returned unchanged instead.

--- a/river/preprocessing/scale.py
+++ b/river/preprocessing/scale.py
@@ -771,7 +771,7 @@ class Normalizer(base.Transformer):
 
     def transform_one(self, x):
         norm = utils.math.norm(x, order=self.order)
-        return {i: xi / norm for i, xi in x.items()}
+        return {i: safe_div(xi, norm) for i, xi in x.items()}
 
 
 class AdaptiveStandardScaler(base.Transformer):


### PR DESCRIPTION
Fixes #1997 

Fixed the issue related to Normalizer.transform_one

Previously it was giving ZeroDivisionError. This change handles zero vectors safely instead.

File Changed - river/preprocessing/scale.py