### PR TITLE
feat(cluster): allow manual DBSTREAM cleanup

### DIFF
--- a/river/cluster/dbstream.py
+++ b/river/cluster/dbstream.py
@@ -65,14 +65,17 @@ class DBSTREAM(base.Clusterer):
         Parameter that controls the importance of historical data to current cluster.
         Note that `fading_factor` has to be different from `0`.
     cleanup_interval
-        The time interval between two consecutive time points when the cleanup process is
-         conducted.
+        The time interval between cleanup processes. This interval is also used to
+        determine whether micro-clusters and shared densities are weak.
     minimum_weight
         The minimum weight for a cluster to be not "noisy".
     intersection_factor
         The intersection factor related to the area of the overlap of the micro clusters
         relative to the area cover by micro clusters. This parameter is used to determine
         whether a micro cluster or a shared density is weak.
+    auto_cleanup
+        Whether to automatically run cleanup at each `cleanup_interval`. If `False`, call
+        `cleanup` explicitly instead.
 
     Attributes
     ----------
@@ -138,6 +141,7 @@ class DBSTREAM(base.Clusterer):
         cleanup_interval: float = 2,
         intersection_factor: float = 0.3,
         minimum_weight: float = 1.0,
+        auto_cleanup: bool = True,
     ):
         super().__init__()
         self._time_stamp = 0
@@ -147,6 +151,7 @@ class DBSTREAM(base.Clusterer):
         self.cleanup_interval = cleanup_interval
         self.intersection_factor = intersection_factor
         self.minimum_weight = minimum_weight
+        self.auto_cleanup = auto_cleanup
 
         self._n_clusters: int = 0
         self._clusters: dict[int, DBSTREAMMicroCluster] = {}
@@ -277,6 +282,11 @@ class DBSTREAM(base.Clusterer):
                     s_i[j] = 0
                     s_t_i[j] = 0
 
+    def cleanup(self):
+        """Run the DBSTREAM cleanup process manually."""
+        self._cleanup()
+        self.clustering_is_up_to_date = False
+
     def _generate_weighted_adjacency_matrix(self):
         # Algorithm 3 of Michael Hahsler and Matthew Bolanos: Reclustering using
         # shared density graph
@@ -393,8 +403,8 @@ class DBSTREAM(base.Clusterer):
     def learn_one(self, x, w=None):
         self._update(x)
 
-        if self._time_stamp % self.cleanup_interval == 0:
-            self._cleanup()
+        if self.auto_cleanup and self._time_stamp % self.cleanup_interval == 0:
+            self.cleanup()
 
         self.clustering_is_up_to_date = False
 

--- a/tests/cluster/test_dbstream.py
+++ b/tests/cluster/test_dbstream.py
@@ -73,6 +73,45 @@ def test_cluster_formation_and_cleanup():
     assert dbstream.s == dbstream.s_t == {}
 
 
+def test_automatic_cleanup_can_be_disabled():
+    automatic = DBSTREAM(clustering_threshold=1, fading_factor=0.5, cleanup_interval=2)
+    manual = DBSTREAM(
+        clustering_threshold=1, fading_factor=0.5, cleanup_interval=2, auto_cleanup=False
+    )
+
+    for x in [{0: 0}, {0: 10}, {0: 10}, {0: 10}]:
+        automatic.learn_one(x)
+        manual.learn_one(x)
+
+    assert len(automatic.micro_clusters) == 1
+    assert len(manual.micro_clusters) == 2
+
+
+def test_manual_cleanup_removes_weak_micro_clusters_without_advancing_time():
+    dbstream = DBSTREAM(
+        clustering_threshold=1, fading_factor=0.5, cleanup_interval=2, auto_cleanup=False
+    )
+
+    for x in [{0: 0}, {0: 10}, {0: 10}, {0: 10}]:
+        dbstream.learn_one(x)
+
+    time_stamp = dbstream._time_stamp
+    assert dbstream.n_clusters == 2
+    assert dbstream.clustering_is_up_to_date
+
+    dbstream.cleanup()
+
+    assert dbstream._time_stamp == time_stamp
+    assert len(dbstream.micro_clusters) == 1
+    assert not dbstream.clustering_is_up_to_date
+    assert dbstream.n_clusters == 1
+
+    dbstream.cleanup()
+
+    assert dbstream._time_stamp == time_stamp
+    assert len(dbstream.micro_clusters) == 1
+
+
 def test_with_two_micro_clusters():
     dbstream = build_dbstream()
 


### PR DESCRIPTION
Addresses #1709.

Adds explicit control over DBSTREAM cleanup while preserving the existing cleanup algorithm and default behavior.

Changes:
- adds `auto_cleanup: bool = True`
- exposes a public `cleanup()` method
- allows users to disable automatic cleanup and trigger it manually
- preserves the existing numeric `cleanup_interval` semantics
- adds tests for automatic, disabled, and manual cleanup behavior

This supports workflows where DBSTREAM is persisted between updates or cleanup needs to be coordinated with downstream state.

No existing default behavior is changed.