### PR TITLE
refactor(tree): share LAST split criterion

### DIFF
--- a/river/tree/last_classifier.py
+++ b/river/tree/last_classifier.py
@@ -146,6 +146,7 @@ class LASTClassifier(HoeffdingTreeClassifier, base.Classifier):
         )
         self.change_detector = change_detector if change_detector is not None else drift.ADWIN()
         self.track_error = track_error
+        self._change_detector_split_criterion = None
 
         # To keep track of the observed classes
         self.classes: set = set()
@@ -155,6 +156,9 @@ class LASTClassifier(HoeffdingTreeClassifier, base.Classifier):
         return {}
 
     def _new_leaf(self, initial_stats=None, parent=None):
+        if not self.track_error and self._change_detector_split_criterion is None:
+            self._change_detector_split_criterion = self._new_split_criterion()
+
         if initial_stats is None:
             initial_stats = {}
         if parent is None:
@@ -168,7 +172,6 @@ class LASTClassifier(HoeffdingTreeClassifier, base.Classifier):
                 depth,
                 self.splitter,
                 self.change_detector.clone(),
-                split_criterion=self._new_split_criterion() if not self.track_error else None,
             )
         elif self._leaf_prediction == self._NAIVE_BAYES:
             return LeafNaiveBayesWithDetector(
@@ -176,7 +179,6 @@ class LASTClassifier(HoeffdingTreeClassifier, base.Classifier):
                 depth,
                 self.splitter,
                 self.change_detector.clone(),
-                split_criterion=self._new_split_criterion() if not self.track_error else None,
             )
         else:  # Naives Bayes Adaptive (default)
             return LeafNaiveBayesAdaptiveWithDetector(
@@ -184,7 +186,6 @@ class LASTClassifier(HoeffdingTreeClassifier, base.Classifier):
                 depth,
                 self.splitter,
                 self.change_detector.clone(),
-                split_criterion=self._new_split_criterion() if not self.track_error else None,
             )
 
     def _new_split_criterion(self):
@@ -203,6 +204,9 @@ class LASTClassifier(HoeffdingTreeClassifier, base.Classifier):
             split_criterion = InfoGainSplitCriterion(self.min_branch_fraction)
 
         return split_criterion
+
+    def _change_detector_merit(self, stats):
+        return self._change_detector_split_criterion.current_merit(stats)
 
     def _attempt_to_split(self, leaf: HTLeaf, parent: DTBranch, parent_branch: int, **kwargs):
         """Attempt to split a leaf.

--- a/river/tree/nodes/last_nodes.py
+++ b/river/tree/nodes/last_nodes.py
@@ -19,30 +19,23 @@ class LeafMajorityClassWithDetector(LeafMajorityClass):
     change_detector
         Change detector that monitors the leaf error rate or class distribution and
         determines when the leaf will split.
-    split_criterion
-        Split criterion used in the tree for updating the change detector if it
-        monitors the class distribution.
     kwargs
         Other parameters passed to the learning node.
     """
 
-    def __init__(self, stats, depth, splitter, change_detector, split_criterion=None, **kwargs):
+    def __init__(self, stats, depth, splitter, change_detector, **kwargs):
         super().__init__(stats, depth, splitter, **kwargs)
         self.change_detector = change_detector
-        # change this in future PR's by accessing the tree parameter in the leaf
-        self.split_criterion = (
-            split_criterion  # if None, the change detector will have binary inputs
-        )
 
     def learn_one(self, x, y, *, w=1, tree=None):
         self.update_stats(y, w)
         if self.is_active():
-            if self.split_criterion is None:
+            if tree.track_error:
                 mc_pred = self.prediction(x)
                 detector_input = max(mc_pred, key=mc_pred.get) != y
                 self.change_detector.update(detector_input)
             else:
-                detector_input = self.split_criterion.current_merit(self.stats)
+                detector_input = tree._change_detector_merit(self.stats)
                 self.change_detector.update(detector_input)
             self.update_splitters(x, y, w, tree.nominal_attributes)
 
@@ -62,25 +55,22 @@ class LeafNaiveBayesWithDetector(LeafMajorityClassWithDetector):
     change_detector
         Change detector that monitors the leaf error rate or class distribution and
         determines when the leaf will split.
-    split_criterion
-        Split criterion used in the tree for updating the change detector if it
-        monitors the class distribution.
     kwargs
         Other parameters passed to the learning node.
     """
 
-    def __init__(self, stats, depth, splitter, change_detector, split_criterion=None, **kwargs):
-        super().__init__(stats, depth, splitter, change_detector, split_criterion, **kwargs)
+    def __init__(self, stats, depth, splitter, change_detector, **kwargs):
+        super().__init__(stats, depth, splitter, change_detector, **kwargs)
 
     def learn_one(self, x, y, *, w=1, tree=None):
         self.update_stats(y, w)
         if self.is_active():
-            if self.split_criterion is None:
+            if tree.track_error:
                 nb_pred = self.prediction(x)
                 detector_input = max(nb_pred, key=nb_pred.get) == y
                 self.change_detector.update(detector_input)
             else:
-                detector_input = self.split_criterion.current_merit(self.stats)
+                detector_input = tree._change_detector_merit(self.stats)
                 self.change_detector.update(detector_input)
             self.update_splitters(x, y, w, tree.nominal_attributes)
 
@@ -119,15 +109,12 @@ class LeafNaiveBayesAdaptiveWithDetector(LeafMajorityClassWithDetector):
     change_detector
         Change detector that monitors the leaf error rate or class distribution and
         determines when the leaf will split.
-    split_criterion
-        Split criterion used in the tree for updating the change detector if it
-        monitors the class distribution.
     kwargs
         Other parameters passed to the learning node.
     """
 
-    def __init__(self, stats, depth, splitter, change_detector, split_criterion=None, **kwargs):
-        super().__init__(stats, depth, splitter, change_detector, split_criterion, **kwargs)
+    def __init__(self, stats, depth, splitter, change_detector, **kwargs):
+        super().__init__(stats, depth, splitter, change_detector, **kwargs)
         self._mc_correct_weight = 0.0
         self._nb_correct_weight = 0.0
 
@@ -162,13 +149,13 @@ class LeafNaiveBayesAdaptiveWithDetector(LeafMajorityClassWithDetector):
 
         self.update_stats(y, w)
         if self.is_active():
-            if self.split_criterion is None:
+            if tree.track_error:
                 if self._nb_correct_weight >= self._mc_correct_weight:
                     self.change_detector.update(detector_input_nb)
                 else:
                     self.change_detector.update(detector_input_mc)
             else:
-                detector_input = self.split_criterion.current_merit(self.stats)
+                detector_input = tree._change_detector_merit(self.stats)
                 self.change_detector.update(detector_input)
             self.update_splitters(x, y, w, tree.nominal_attributes)
 

--- a/tests/tree/test_last_classifier.py
+++ b/tests/tree/test_last_classifier.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import pytest
+
+from river import base, datasets, drift, tree
+
+
+class RecordingDetector(base.DriftDetector):
+    def __init__(self):
+        super().__init__()
+        self.values = []
+
+    def update(self, x):
+        self.values.append(x)
+
+
+def test_error_tracking_detector_input():
+    model = tree.LASTClassifier(
+        change_detector=RecordingDetector(), leaf_prediction="mc", track_error=True
+    )
+
+    model.learn_one({0: 0}, False)
+    model.learn_one({0: 1}, True)
+
+    assert model._root.change_detector.values == [False, True]
+
+
+@pytest.mark.parametrize(
+    "split_criterion, expected", [("gini", [0.0, 0.5]), ("info_gain", [0.0, 1.0])]
+)
+def test_distribution_tracking_detector_input(split_criterion, expected):
+    model = tree.LASTClassifier(
+        change_detector=RecordingDetector(),
+        leaf_prediction="mc",
+        split_criterion=split_criterion,
+        track_error=False,
+    )
+
+    model.learn_one({0: 0}, False)
+    model.learn_one({0: 1}, True)
+
+    assert model._root.change_detector.values == expected
+
+
+@pytest.mark.parametrize("split_criterion", ["gini", "info_gain"])
+def test_distribution_tracking_uses_tree_split_criterion(split_criterion):
+    model = tree.LASTClassifier(
+        change_detector=drift.NoDrift(),
+        leaf_prediction="mc",
+        split_criterion=split_criterion,
+        track_error=False,
+    )
+
+    first_leaf = model._new_leaf()
+    split_criterion = model._change_detector_split_criterion
+    second_leaf = model._new_leaf()
+
+    assert split_criterion is model._change_detector_split_criterion
+    assert not hasattr(first_leaf, "split_criterion")
+    assert not hasattr(second_leaf, "split_criterion")
+    assert model._change_detector_merit({False: 1, True: 1}) == split_criterion.current_merit(
+        {False: 1, True: 1}
+    )
+
+    first_leaf.learn_one({0: 0}, False, tree=model)
+    second_leaf.learn_one({0: 1}, True, tree=model)
+
+
+@pytest.mark.parametrize("track_error", [True, False])
+def test_deterministic_stream_predictions(track_error):
+    model = tree.LASTClassifier(
+        change_detector=drift.DummyDriftDetector(t_0=10),
+        leaf_prediction="mc",
+        split_criterion="info_gain",
+        track_error=track_error,
+    )
+    predictions = []
+
+    for x, y in datasets.synth.SEA(seed=42).take(100):
+        predictions.append(model.predict_one(x))
+        model.learn_one(x, y)
+
+    assert predictions[-20:] == [
+        True,
+        True,
+        False,
+        True,
+        False,
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        False,
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        False,
+    ]
+    assert model.height == 4
+    assert model.n_nodes == 11
+    assert model.n_leaves == 6
+    assert model.predict_proba_one({0: 1, 1: 2, 2: 3}) == {False: 1.0, True: 0.0}
+
+
+def test_hellinger_distribution_tracking_is_rejected():
+    model = tree.LASTClassifier(split_criterion="hellinger", track_error=False)
+
+    with pytest.raises(ValueError, match="cannot estimate the purity"):
+        model.learn_one({0: 0}, False)
+
+
+def test_hellinger_error_tracking_works():
+    model = tree.LASTClassifier(
+        change_detector=drift.NoDrift(),
+        split_criterion="hellinger",
+        track_error=True,
+    )
+
+    model.learn_one({0: 0}, False)
+
+    assert not hasattr(model._root, "split_criterion")
+    assert model._change_detector_split_criterion is None


### PR DESCRIPTION
Addresses #1612.

This refactors `LASTClassifier` so distribution-tracking leaves no longer retain a separate split-criterion instance.

Before this change, when `track_error=False`, each LAST leaf stored its own persistent Gini or Information Gain criterion. A tree with N leaves therefore retained N monitoring criteria.

This PR moves that monitoring criterion to the tree level:

- one lazily initialized criterion is retained per LAST tree
- leaves access the tree-owned criterion through `_change_detector_merit`
- `track_error=True` behavior is unchanged
- `track_error=False` behavior is unchanged
- split evaluation still creates its own temporary criterion, preserving the existing split-attempt lifecycle
- Hellinger restrictions remain unchanged

Tests cover:
- error-tracking detector inputs
- Gini and Information Gain distribution tracking
- reuse of the single tree-owned criterion
- absence of per-leaf `split_criterion`
- deterministic predictions and tree structure
- Hellinger behavior

No public API changes are introduced.