### PR TITLE
Strict typing: linear_model sub-package

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## linear_model
+
+- `BayesianLinearRegression.predict_dist_one` now replaces `BayesianLinearRegression.predict_one(..., with_dist=True)` to better respect the `Regressor` interface while still being able to predict distributions.
+
 ## stream
 
 - `stream.Cache` now writes a pass to a temporary file and renames it into place once the stream is exhausted. An interrupted first pass (a `break`, an exception, an abandoned generator) used to leave a truncated file behind, which every later pass then read back as if it were the whole dataset.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,7 +252,6 @@ module = [
     "river.tree.*",
     "river.preprocessing.*",
     "river.stream.*",
-    "river.linear_model.*",
     "river.evaluate.*",
     "river.drift.*",
     "river.compose.*",

--- a/river/bandit/lin_ucb.py
+++ b/river/bandit/lin_ucb.py
@@ -73,9 +73,7 @@ class LinUCBDisjoint(bandit.base.ContextualPolicy):
             return dist.mu + dist.sigma
 
         upper_bounds = {
-            arm_id: get_upper_bound(
-                self._bayes_lin_regs[arm_id].predict_one(context, with_dist=True)
-            )
+            arm_id: get_upper_bound(self._bayes_lin_regs[arm_id].predict_dist_one(context))
             for arm_id in arm_ids
         }
         biggest_upper_bound = max(upper_bounds.values())

--- a/river/linear_model/ad_predictor.py
+++ b/river/linear_model/ad_predictor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+import typing
 
 from scipy.special import ndtri
 
@@ -15,7 +16,7 @@ MAX_SURPRISE = 5.0
 _BIAS_KEY = "__bias__"
 
 
-def _active(x: dict) -> list:
+def _active(x: dict[base.typing.FeatureName, typing.Any]) -> list[base.typing.FeatureName]:
     """The keys of `x` with a truthy value, i.e. the active binary indicators."""
     return [f for f, v in x.items() if v]
 
@@ -110,8 +111,8 @@ class AdPredictor(base.Classifier):
         self.prior_probability = prior_probability
         self.epsilon = epsilon
 
-        self.means: dict = {}
-        self.variances: dict = {}
+        self.means: dict[base.typing.FeatureName, float] = {}
+        self.variances: dict[base.typing.FeatureName, float] = {}
 
     def _init_bias(self, n_active: int) -> None:
         # The bias is an always-active weight, initialised lazily on the first
@@ -125,7 +126,7 @@ class AdPredictor(base.Classifier):
             )
             self.variances[_BIAS_KEY] = 1.0
 
-    def _total_mean_variance(self, features) -> tuple[float, float]:
+    def _total_mean_variance(self, features: list[base.typing.FeatureName]) -> tuple[float, float]:
         total_mean = self.means[_BIAS_KEY]
         total_variance = self.variances[_BIAS_KEY] + self.beta**2
         for f in features:
@@ -133,7 +134,9 @@ class AdPredictor(base.Classifier):
             total_variance += self.variances.get(f, 1.0)
         return total_mean, total_variance
 
-    def predict_proba_one(self, x):
+    def predict_proba_one(
+        self, x: dict[base.typing.FeatureName, typing.Any], **kwargs: typing.Any
+    ) -> dict[base.typing.ClfTarget, float]:
         active = _active(x)
         self._init_bias(len(active))
         total_mean, total_variance = self._total_mean_variance(active)
@@ -141,7 +144,9 @@ class AdPredictor(base.Classifier):
         p = min(1.0 - 1e-12, max(1e-12, p))
         return {False: 1.0 - p, True: p}
 
-    def learn_one(self, x, y):
+    def learn_one(
+        self, x: dict[base.typing.FeatureName, typing.Any], y: base.typing.ClfTarget
+    ) -> None:
         features = _active(x)
         self._init_bias(len(features))
         sign = 1.0 if y else -1.0
@@ -172,5 +177,5 @@ class AdPredictor(base.Classifier):
         return adjusted_mean, adjusted_variance
 
     @classmethod
-    def _unit_test_params(cls):
+    def _unit_test_params(cls) -> typing.Generator[dict[str, float]]:
         yield {"beta": 0.1, "prior_probability": 0.5, "epsilon": 0.05}

--- a/river/linear_model/alma.py
+++ b/river/linear_model/alma.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import collections
 import math
+import typing
 
 from river import base, utils
 
@@ -52,22 +53,28 @@ class ALMAClassifier(base.Classifier):
 
     """
 
-    def __init__(self, p=2, alpha=0.9, B=1 / 0.9, C=2**0.5):
+    def __init__(
+        self, p: float = 2, alpha: float = 0.9, B: float = 1 / 0.9, C: float = 2**0.5
+    ) -> None:
         self.p = p
         self.alpha = alpha
         self.B = B
         self.C = C
-        self.w = collections.defaultdict(float)
+        self.w: dict[base.typing.FeatureName, float] = collections.defaultdict(float)
         self.k = 1
 
-    def _raw_dot(self, x):
+    def _raw_dot(self, x: dict[base.typing.FeatureName, float]) -> float:
         return utils.math.dot(x, self.w)
 
-    def predict_proba_one(self, x):
+    def predict_proba_one(
+        self, x: dict[base.typing.FeatureName, float], **kwargs: typing.Any
+    ) -> dict[base.typing.ClfTarget, float]:
         yp = utils.math.sigmoid(self._raw_dot(x))
         return {False: 1 - yp, True: yp}
 
-    def learn_one(self, x, y):
+    def learn_one(
+        self, x: dict[base.typing.FeatureName, typing.Any], y: base.typing.ClfTarget
+    ) -> None:
         # Convert 0 to -1
         y = int(y or -1)
 

--- a/river/linear_model/base.py
+++ b/river/linear_model/base.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import functools
-import numbers
 import typing
+from collections.abc import Callable
 
 import numpy as np
 
-from river import optim, utils
+from river import base, optim, utils
 from river.utils.vectordict import VectorDict
 
 if typing.TYPE_CHECKING:
@@ -49,15 +49,15 @@ class GLM:
 
     def __init__(
         self,
-        optimizer,
-        loss,
-        l2,
-        l1,
-        intercept_init,
-        intercept_lr,
-        clip_gradient,
-        initializer,
-    ):
+        optimizer: optim.base.Optimizer,
+        loss: optim.losses.Loss,
+        l2: float,
+        l1: float,
+        intercept_init: float,
+        intercept_lr: optim.base.Scheduler | float,
+        clip_gradient: float,
+        initializer: optim.base.Initializer,
+    ) -> None:
         self.optimizer = optimizer
         self.loss = loss
         self.l2 = l2
@@ -66,16 +66,16 @@ class GLM:
         self.intercept = intercept_init
         self.intercept_lr = (
             optim.schedulers.Constant(intercept_lr)
-            if isinstance(intercept_lr, numbers.Number)
+            if isinstance(intercept_lr, float)
             else intercept_lr
         )
         self.clip_gradient = clip_gradient
         self.initializer = initializer
-        self._weights = utils.VectorDict(None)
+        self._weights: utils.VectorDict[base.typing.FeatureName, float] = utils.VectorDict(None)
 
         # The predict_many functions are going to return pandas.Series. We can name the series with
         # the name given to the y series seen during the last learn_many call.
-        self._y_name = None
+        self._y_name: str | None = None
 
         if l1 != 0:
             if l2 != 0:
@@ -84,29 +84,42 @@ class GLM:
                 )
 
             # L1-specific parameters
-            self.max_cum_l1 = 0
-            self.cum_l1 = utils.VectorDict(None, optim.initializers.Zeros())
+            self.max_cum_l1: float = 0
+            self.cum_l1: utils.VectorDict[base.typing.FeatureName, float] = utils.VectorDict(
+                None, optim.initializers.Zeros()
+            )
 
     @property
-    def _mutable_attributes(self):
+    def _mutable_attributes(self) -> set[str]:
         return {"optimizer", "l2", "l1", "loss", "intercept_lr", "clip_gradient", "initializer"}
 
     @property
-    def weights(self):
+    def weights(self) -> dict[base.typing.FeatureName, float]:
         return self._weights.to_dict()
 
-    def _enter_learn_mode(self, mask=None):
+    def _enter_learn_mode(
+        self, mask: typing.Any | None = None
+    ) -> utils.VectorDict[base.typing.FeatureName, float]:
         weights = self._weights
         self._weights = utils.VectorDict(weights, self.initializer, mask)
         return weights
 
-    def _exit_learn_mode(self, weights):
+    def _exit_learn_mode(self, weights: utils.VectorDict[base.typing.FeatureName, float]) -> None:
         self._weights = weights
 
-    def _get_intercept_update(self, loss_gradient):
+    def _get_intercept_update(self, loss_gradient: float) -> float:
         return self.intercept_lr.get(self.optimizer.n_iterations) * loss_gradient
 
-    def _fit(self, x, y, w, get_grad):
+    def _fit(
+        self,
+        x: dict[base.typing.FeatureName, typing.Any],
+        y: typing.Any,
+        w: float,
+        get_grad: Callable[
+            [dict[base.typing.FeatureName, typing.Any], float, float],
+            tuple[utils.VectorDict[base.typing.FeatureName, float], float],
+        ],
+    ) -> None:
         # Some optimizers need to do something before a prediction is made
         self.optimizer.look_ahead(w=self._weights)
 
@@ -126,7 +139,7 @@ class GLM:
 
             self._update_weights(x)
 
-    def _update_weights(self, x):
+    def _update_weights(self, x: dict[base.typing.FeatureName, typing.Any]) -> None:
         # L1 cumulative penalty helper
 
         # Apply penalty to each weight iteratively, with the potential of being parallelized by using VectorDict
@@ -145,10 +158,12 @@ class GLM:
 
     # Single instance methods
 
-    def _raw_dot_one(self, x: dict) -> float:
+    def _raw_dot_one(self, x: dict[base.typing.FeatureName, typing.Any]) -> float:
         return self._weights.dot(x) + self.intercept
 
-    def _eval_gradient_one(self, x: dict, y: float, w: float) -> tuple[utils.VectorDict, float]:
+    def _eval_gradient_one(
+        self, x: dict[base.typing.FeatureName, typing.Any], y: float, w: float
+    ) -> tuple[utils.VectorDict[base.typing.FeatureName, float], float]:
         loss_gradient = self.loss.gradient(y_true=y, y_pred=self._raw_dot_one(x))
         loss_gradient *= w
         loss_gradient = float(
@@ -164,7 +179,9 @@ class GLM:
 
         return (gradient, loss_gradient)
 
-    def learn_one(self, x, y, w=1.0) -> None:
+    def learn_one(
+        self, x: dict[base.typing.FeatureName, typing.Any], y: typing.Any, w: float = 1.0
+    ) -> None:
         saved = self._enter_learn_mode(x)
         try:
             self._fit(x, y, w, get_grad=self._eval_gradient_one)
@@ -174,11 +191,11 @@ class GLM:
     # Mini-batch methods
 
     def _raw_dot_many(self, X: np.ndarray, cols: Sequence[str]) -> np.ndarray:
-        return X @ self._weights.to_numpy(cols) + self.intercept
+        return X @ self._weights.to_numpy(cols) + self.intercept  # type: ignore[no-any-return]
 
     def _eval_gradient_many(
         self, X: np.ndarray, cols: Sequence[str], y: np.ndarray, w: float | np.ndarray
-    ) -> tuple[dict, float]:
+    ) -> tuple[dict[base.typing.FeatureName, float], float]:
         loss_gradient = self.loss.gradient(y_true=y, y_pred=self._raw_dot_many(X, cols))
         loss_gradient *= w
         loss_gradient = np.clip(loss_gradient, -self.clip_gradient, self.clip_gradient)
@@ -217,11 +234,11 @@ class GLM:
             # and to drive the weight update. For mini-batches that argument is the column names,
             # while the feature matrix is bound here via `partial`.
             get_grad = functools.partial(self._eval_gradient_many, X_np)
-            self._fit(x=cols, y=y_np, w=w_np, get_grad=get_grad)
+            self._fit(x=cols, y=y_np, w=w_np, get_grad=get_grad)  # type: ignore[arg-type]
         finally:
             self._exit_learn_mode(saved)
 
-    def _unit_test_skips(self):
+    def _unit_test_skips(self) -> set[str]:
         # `learn_many` takes a single mean-gradient step over the whole batch, which is
         # deliberately not equivalent to one SGD step per row as `learn_one` would do.
         return {"check_learn_many_matches_learn_one"}

--- a/river/linear_model/base.py
+++ b/river/linear_model/base.py
@@ -66,7 +66,7 @@ class GLM:
         self.intercept = intercept_init
         self.intercept_lr = (
             optim.schedulers.Constant(intercept_lr)
-            if isinstance(intercept_lr, float)
+            if isinstance(intercept_lr, (int, float))
             else intercept_lr
         )
         self.clip_gradient = clip_gradient

--- a/river/linear_model/bayesian_lin_reg.py
+++ b/river/linear_model/bayesian_lin_reg.py
@@ -51,7 +51,7 @@ class BayesianLinearRegression(base.MiniBatchRegressor):
     >>> model.predict_one(x)
     43.855...
 
-    >>> model.predict_one(x, with_dist=True)
+    >>> model.predict_dist_one(x)
     𝒩(μ=43.85..., σ=1.00...)
 
     The `smoothing` parameter can be set to make the model robust to drift. The parameter is
@@ -263,7 +263,7 @@ class BayesianLinearRegression(base.MiniBatchRegressor):
 
         # `learn_one` keeps `_ss_inv_arr = inv(_ss_arr)` (via Sherman-Morrison without smoothing,
         # a full inverse with it). Refresh the active block in one inverse so subsequent
-        # `learn_one` updates and `predict_one(..., with_dist=True)` see a consistent covariance.
+        # `learn_one` updates and `predict_dist_one(...)` see a consistent covariance.
         if n:
             self._ss_inv_arr[:n, :n] = np.linalg.inv(self._ss_arr[:n, :n])
         self._m_dirty = True

--- a/river/linear_model/bayesian_lin_reg.py
+++ b/river/linear_model/bayesian_lin_reg.py
@@ -140,7 +140,7 @@ class BayesianLinearRegression(base.MiniBatchRegressor):
 
     """
 
-    def __init__(self, alpha=1, beta=1, smoothing: float | None = None):
+    def __init__(self, alpha: float = 1, beta: float = 1, smoothing: float | None = None) -> None:
         self.alpha = alpha
         self.beta = beta
         self.smoothing = smoothing
@@ -162,9 +162,9 @@ class BayesianLinearRegression(base.MiniBatchRegressor):
         self._ss_inv_arr = np.zeros((0, 0), dtype=np.float64, order="F")
         self._eta_arr = np.zeros(0, dtype=np.float64)
         self._m_arr = np.zeros(0, dtype=np.float64)
-        self._m_dirty = False
-        self._cap = 0
-        self._n = 1
+        self._m_dirty: bool = False
+        self._cap: int = 0
+        self._n: int = 1
 
     def _grow(self, needed: int) -> None:
         new_cap = max(needed, max(8, self._cap * 2))
@@ -181,7 +181,7 @@ class BayesianLinearRegression(base.MiniBatchRegressor):
         self._eta_arr = new_eta
         self._cap = new_cap
 
-    def _ensure_features(self, features) -> None:
+    def _ensure_features(self, features: typing.Iterable[typing.Any]) -> None:
         idx = self._idx
         for f in features:
             if f not in idx:
@@ -196,7 +196,9 @@ class BayesianLinearRegression(base.MiniBatchRegressor):
             self._m_arr = self._ss_inv_arr @ self._eta_arr
         self._m_dirty = False
 
-    def learn_one(self, x, y):
+    def learn_one(
+        self, x: dict[base.typing.FeatureName, typing.Any], y: base.typing.RegTarget
+    ) -> None:
         # Treat features absent from `x` as observed values of 0. Updating the
         # full-cap state (rather than just the touched submatrix via np.ix_)
         # keeps `_ss_inv_arr = inv(_ss_arr)` consistent across
@@ -266,7 +268,9 @@ class BayesianLinearRegression(base.MiniBatchRegressor):
             self._ss_inv_arr[:n, :n] = np.linalg.inv(self._ss_arr[:n, :n])
         self._m_dirty = True
 
-    def predict_one(self, x, with_dist=False):
+    def predict_one(
+        self, x: dict[base.typing.FeatureName, typing.Any], with_dist: bool = False
+    ) -> base.typing.RegTarget:
         """Predict the output of features `x`.
 
         Parameters
@@ -312,7 +316,7 @@ class BayesianLinearRegression(base.MiniBatchRegressor):
             y_pred_var = 1 / self.beta
         y_pred_var += diag * unknown_norm_sq
 
-        return proba.Gaussian._from_state(n=1, m=y_pred_mean, var=y_pred_var, ddof=0)
+        return proba.Gaussian._from_state(n=1, m=y_pred_mean, var=y_pred_var, ddof=0)  # type: ignore[return-value]
 
     def predict_many(self, X: IntoDataFrame) -> IntoSeries:
         X = utils.dataframe.into_frame(X)

--- a/river/linear_model/bayesian_lin_reg.py
+++ b/river/linear_model/bayesian_lin_reg.py
@@ -268,9 +268,7 @@ class BayesianLinearRegression(base.MiniBatchRegressor):
             self._ss_inv_arr[:n, :n] = np.linalg.inv(self._ss_arr[:n, :n])
         self._m_dirty = True
 
-    def predict_one(
-        self, x: dict[base.typing.FeatureName, typing.Any]
-    ) -> base.typing.RegTarget:
+    def predict_one(self, x: dict[base.typing.FeatureName, typing.Any]) -> base.typing.RegTarget:
         """Predict the output of features `x`.
 
         Parameters

--- a/river/linear_model/bayesian_lin_reg.py
+++ b/river/linear_model/bayesian_lin_reg.py
@@ -269,7 +269,7 @@ class BayesianLinearRegression(base.MiniBatchRegressor):
         self._m_dirty = True
 
     def predict_one(
-        self, x: dict[base.typing.FeatureName, typing.Any], with_dist: bool = False
+        self, x: dict[base.typing.FeatureName, typing.Any]
     ) -> base.typing.RegTarget:
         """Predict the output of features `x`.
 
@@ -277,8 +277,6 @@ class BayesianLinearRegression(base.MiniBatchRegressor):
         ----------
         x
             A dictionary of features.
-        with_dist
-            Whether to return a predictive distribution, or instead just the most likely value.
 
         Returns
         -------
@@ -296,8 +294,10 @@ class BayesianLinearRegression(base.MiniBatchRegressor):
                 if i is not None:
                     y_pred_mean += m_arr[i] * v
 
-        if not with_dist:
-            return float(y_pred_mean)
+        return float(y_pred_mean)
+
+    def predict_dist_one(self, x: dict[base.typing.FeatureName, typing.Any]) -> proba.Gaussian:
+        y_pred_mean = self.predict_one(x)
 
         n = len(self._idx)
         diag = 1.0 / self.alpha
@@ -316,7 +316,7 @@ class BayesianLinearRegression(base.MiniBatchRegressor):
             y_pred_var = 1 / self.beta
         y_pred_var += diag * unknown_norm_sq
 
-        return proba.Gaussian._from_state(n=1, m=y_pred_mean, var=y_pred_var, ddof=0)  # type: ignore[return-value]
+        return proba.Gaussian._from_state(n=1, m=y_pred_mean, var=y_pred_var, ddof=0)
 
     def predict_many(self, X: IntoDataFrame) -> IntoSeries:
         X = utils.dataframe.into_frame(X)

--- a/river/linear_model/lin_reg.py
+++ b/river/linear_model/lin_reg.py
@@ -115,13 +115,13 @@ class LinearRegression(linear_model.base.GLM, base.MiniBatchRegressor):
         self,
         optimizer: optim.base.Optimizer | None = None,
         loss: optim.losses.RegressionLoss | None = None,
-        l2=0.0,
-        l1=0.0,
-        intercept_init=0.0,
+        l2: float = 0.0,
+        l1: float = 0.0,
+        intercept_init: float = 0.0,
         intercept_lr: optim.base.Scheduler | float = 0.01,
-        clip_gradient=1e12,
+        clip_gradient: float = 1e12,
         initializer: optim.base.Initializer | None = None,
-    ):
+    ) -> None:
         super().__init__(
             optimizer=optim.SGD(0.01) if optimizer is None else optimizer,
             loss=optim.losses.Squared() if loss is None else loss,
@@ -133,8 +133,8 @@ class LinearRegression(linear_model.base.GLM, base.MiniBatchRegressor):
             initializer=initializer if initializer else optim.initializers.Zeros(),
         )
 
-    def predict_one(self, x):
-        return self.loss.mean_func(self._raw_dot_one(x))
+    def predict_one(self, x: dict[base.typing.FeatureName, typing.Any]) -> base.typing.RegTarget:
+        return self.loss.mean_func(self._raw_dot_one(x))  # type: ignore[no-any-return]
 
     def predict_many(self, X: IntoDataFrame) -> IntoSeries:
         X = utils.dataframe.into_frame(X)
@@ -143,7 +143,7 @@ class LinearRegression(linear_model.base.GLM, base.MiniBatchRegressor):
         )
         return utils.dataframe.to_native_series(y_pred, name=self._y_name, like=X)
 
-    def debug_one(self, x: dict, decimals: int = 5) -> str:
+    def debug_one(self, x: dict[base.typing.FeatureName, typing.Any], decimals: int = 5) -> str:
         """Debugs the output of the linear regression.
 
         Parameters
@@ -159,7 +159,7 @@ class LinearRegression(linear_model.base.GLM, base.MiniBatchRegressor):
 
         """
 
-        def fmt_float(x):
+        def fmt_float(x: float) -> str:
             return "{: ,.{prec}f}".format(x, prec=decimals)
 
         names = list(map(str, x.keys())) + ["Intercept"]

--- a/river/linear_model/log_reg.py
+++ b/river/linear_model/log_reg.py
@@ -76,13 +76,13 @@ class LogisticRegression(linear_model.base.GLM, base.MiniBatchClassifier):
         self,
         optimizer: optim.base.Optimizer | None = None,
         loss: optim.losses.BinaryLoss | None = None,
-        l2=0.0,
-        l1=0.0,
-        intercept_init=0.0,
+        l2: float = 0.0,
+        l1: float = 0.0,
+        intercept_init: float = 0.0,
         intercept_lr: float | optim.base.Scheduler = 0.01,
-        clip_gradient=1e12,
+        clip_gradient: float = 1e12,
         initializer: optim.base.Initializer | None = None,
-    ):
+    ) -> None:
         super().__init__(
             optimizer=optim.SGD(0.01) if optimizer is None else optimizer,
             loss=optim.losses.Log() if loss is None else loss,
@@ -94,7 +94,9 @@ class LogisticRegression(linear_model.base.GLM, base.MiniBatchClassifier):
             initializer=initializer if initializer else optim.initializers.Zeros(),
         )
 
-    def predict_proba_one(self, x):
+    def predict_proba_one(
+        self, x: dict[base.typing.FeatureName, typing.Any], **kwargs: typing.Any
+    ) -> dict[base.typing.ClfTarget, float]:
         p = self.loss.mean_func(self._raw_dot_one(x))  # Convert logit to probability
         return {False: 1.0 - p, True: p}
 

--- a/river/linear_model/pa.py
+++ b/river/linear_model/pa.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import collections
+import typing
+from collections.abc import Callable
 
 import numpy as np
 
@@ -10,28 +12,32 @@ __all__ = ["PAClassifier", "PARegressor"]
 
 
 class BasePA:
-    def __init__(self, C, mode, learn_intercept):
+    def __init__(self, C: float, mode: int, learn_intercept: bool) -> None:
         self.C = C
         self.mode = mode
-        self.calc_tau = {0: self._calc_tau_0, 1: self._calc_tau_1, 2: self._calc_tau_2}[mode]
+        self.calc_tau: Callable[[dict[base.typing.FeatureName, float], float], float] = {
+            0: self._calc_tau_0,
+            1: self._calc_tau_1,
+            2: self._calc_tau_2,
+        }[mode]
         self.learn_intercept = learn_intercept
-        self.weights = collections.defaultdict(float)
+        self.weights: dict[base.typing.FeatureName, float] = collections.defaultdict(float)
         self.intercept = 0.0
 
     @classmethod
-    def _calc_tau_0(cls, x, loss):
+    def _calc_tau_0(cls, x: dict[base.typing.FeatureName, float], loss: float) -> float:
         norm = utils.math.norm(x, order=2) ** 2
         if norm > 0:
             return loss / utils.math.norm(x, order=2) ** 2
         return 0
 
-    def _calc_tau_1(self, x, loss):
+    def _calc_tau_1(self, x: dict[base.typing.FeatureName, float], loss: float) -> float:
         norm = utils.math.norm(x, order=2) ** 2
         if norm > 0:
             return min(self.C, loss / norm)
         return 0
 
-    def _calc_tau_2(self, x, loss):
+    def _calc_tau_2(self, x: dict[base.typing.FeatureName, float], loss: float) -> float:
         return loss / (utils.math.norm(x, order=2) ** 2 + 0.5 / self.C)
 
 
@@ -82,12 +88,16 @@ class PARegressor(BasePA, base.Regressor):
 
     """
 
-    def __init__(self, C=1.0, mode=1, eps=0.1, learn_intercept=True):
+    def __init__(
+        self, C: float = 1.0, mode: int = 1, eps: float = 0.1, learn_intercept: bool = True
+    ) -> None:
         super().__init__(C=C, mode=mode, learn_intercept=learn_intercept)
         self.eps = eps
         self.loss = optim.losses.EpsilonInsensitiveHinge(eps=eps)
 
-    def learn_one(self, x, y):
+    def learn_one(
+        self, x: dict[base.typing.FeatureName, typing.Any], y: base.typing.RegTarget
+    ) -> None:
         y_pred = self.predict_one(x)
         tau = self.calc_tau(x, self.loss(y, y_pred))
         step = tau * np.sign(y - y_pred)
@@ -97,7 +107,7 @@ class PARegressor(BasePA, base.Regressor):
         if self.learn_intercept:
             self.intercept += step
 
-    def predict_one(self, x):
+    def predict_one(self, x: dict[base.typing.FeatureName, typing.Any]) -> base.typing.RegTarget:
         return utils.math.dot(x, self.weights) + self.intercept
 
 
@@ -164,20 +174,25 @@ class PAClassifier(BasePA, base.Classifier):
 
     """
 
-    def __init__(self, C=1.0, mode=1, learn_intercept=True):
+    def __init__(self, C: float = 1.0, mode: int = 1, learn_intercept: bool = True) -> None:
         super().__init__(C=C, mode=mode, learn_intercept=learn_intercept)
         self.loss = optim.losses.Hinge()
 
-    def learn_one(self, x, y):
+    def learn_one(
+        self, x: dict[base.typing.FeatureName, typing.Any], y: base.typing.ClfTarget
+    ) -> None:
         y_pred = utils.math.dot(x, self.weights) + self.intercept
         tau = self.calc_tau(x, self.loss(y, y_pred))
-        step = tau * (y or -1)  # y == False becomes -1
+        # y == False becomes -1
+        step = tau * (y or -1)  # type: ignore[operator]
 
         for i, xi in x.items():
             self.weights[i] += step * xi
         if self.learn_intercept:
             self.intercept += step
 
-    def predict_proba_one(self, x):
+    def predict_proba_one(
+        self, x: dict[base.typing.FeatureName, typing.Any], **kwargs: typing.Any
+    ) -> dict[base.typing.ClfTarget, float]:
         y_pred = utils.math.sigmoid(utils.math.dot(x, self.weights) + self.intercept)
         return {False: 1.0 - y_pred, True: y_pred}

--- a/river/linear_model/perceptron.py
+++ b/river/linear_model/perceptron.py
@@ -49,10 +49,10 @@ class Perceptron(LogisticRegression):
 
     def __init__(
         self,
-        l2=0.0,
-        clip_gradient=1e12,
+        l2: float = 0.0,
+        clip_gradient: float = 1e12,
         initializer: optim.initializers.Initializer | None = None,
-    ):
+    ) -> None:
         super().__init__(
             optimizer=optim.SGD(1),
             intercept_lr=1,

--- a/river/linear_model/softmax.py
+++ b/river/linear_model/softmax.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import collections
 import copy
 import functools
+import typing
 
 from river import base, optim, utils
 
@@ -61,8 +62,8 @@ class SoftmaxRegression(base.Classifier):
         self,
         optimizer: optim.base.Optimizer | None = None,
         loss: optim.losses.MultiClassLoss | None = None,
-        l2=0,
-    ):
+        l2: float = 0,
+    ) -> None:
         if optimizer is None:
             optimizer = optim.SGD(0.01)
         new_optimizer = functools.partial(copy.deepcopy, optimizer)
@@ -73,10 +74,12 @@ class SoftmaxRegression(base.Classifier):
         self.weights = collections.defaultdict(functools.partial(collections.defaultdict, float))  # type: ignore
 
     @property
-    def _multiclass(self):
+    def _multiclass(self) -> bool:
         return True
 
-    def learn_one(self, x, y):
+    def learn_one(
+        self, x: dict[base.typing.FeatureName, typing.Any], y: base.typing.ClfTarget
+    ) -> None:
         # Some optimizers need to do something before a prediction is made
         for label, weights in self.weights.items():
             self.optimizers[label].look_ahead(w=weights)
@@ -93,7 +96,9 @@ class SoftmaxRegression(base.Classifier):
             gradient = {i: xi * loss + self.l2 * weights.get(i, 0) for i, xi in x.items()}
             self.weights[label] = self.optimizers[label].step(w=weights, g=gradient)
 
-    def predict_proba_one(self, x):
+    def predict_proba_one(
+        self, x: dict[base.typing.FeatureName, typing.Any], **kwargs: typing.Any
+    ) -> dict[base.typing.ClfTarget, float]:
         return utils.math.softmax(
             {label: utils.math.dot(weights, x) for label, weights in self.weights.items()}
-        )
+        )  # type: ignore[return-value]

--- a/tests/linear_model/test_glm.py
+++ b/tests/linear_model/test_glm.py
@@ -615,7 +615,7 @@ def test_bayesian_predict_many_returns_native_backend(
 def test_bayesian_predict_one_distribution_uses_predictive_variance() -> None:
     """The predictive distribution must expose the standard deviation, not its square root."""
     model = lm.BayesianLinearRegression(beta=25)
-    prediction = model.predict_one({}, with_dist=True)
+    prediction = model.predict_dist_one({})
     assert prediction.sigma == pytest.approx(1 / math.sqrt(model.beta))
 
 
@@ -639,8 +639,8 @@ def test_bayesian_learn_many_matches_learn_one(
     # covariance through chained Sherman-Morrison rank-1 updates that drift slightly from the
     # single inverse `learn_many` computes.
     for x in feats:
-        got = many.predict_one(x, with_dist=True)
-        want = one.predict_one(x, with_dist=True)
+        got = many.predict_dist_one(x)
+        want = one.predict_dist_one(x)
         assert math.isclose(got.mu, want.mu, rel_tol=1e-5, abs_tol=1e-6)
         assert math.isclose(got.sigma, want.sigma, rel_tol=1e-5, abs_tol=1e-6)
 


### PR DESCRIPTION
## Description

Related to https://github.com/online-ml/river/issues/1944

Implement strict typing for the `river.linear_model` package as it only depends on already strictly typed packages.

Some `type: ignore` comments were added to handle special cases, for instance when a function relies on another external function with not-precise-enough typing information.